### PR TITLE
Fix AvoidReservedParams does not work if function does not have cmdletbi...

### DIFF
--- a/Rules/AvoidReservedParams.cs
+++ b/Rules/AvoidReservedParams.cs
@@ -30,43 +30,38 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName) {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
-            IEnumerable<Ast> paramAsts = ast.FindAll(testAst => testAst is ParameterAst, true);
-            Ast parentAst;
+            IEnumerable<Ast> funcAsts = ast.FindAll(item => item is FunctionDefinitionAst, true);
 
             string paramName;
 
-            PropertyInfo[] commonParams = typeof(CommonParameters).GetProperties();
-            List<string> commonParamNames = new List<string>();
+            List<string> commonParamNames = typeof(CommonParameters).GetProperties().Select(param => param.Name).ToList();
 
-            if (commonParams != null) {
-                foreach (PropertyInfo commonParam in commonParams) {
-                    commonParamNames.Add("$" + commonParam.Name);
+            foreach (FunctionDefinitionAst funcAst in funcAsts)
+            {
+                IEnumerable<ParameterAst> parameters = null;
+                if (funcAst.Parameters != null)
+                {
+                    parameters = funcAst.Parameters;
                 }
-            }
+                // Check param block
+                else
+                {
+                    if (funcAst.Body != null && funcAst.Body.ParamBlock != null && funcAst.Body.ParamBlock.Parameters != null)
+                    {
+                        parameters = funcAst.Body.ParamBlock.Parameters;
+                    }
+                }
 
-            if (paramAsts != null) {
-                foreach (ParameterAst paramAst in paramAsts) {
-                    paramName = paramAst.Name.ToString();
+                if (parameters != null)
+                {
+                    foreach (ParameterAst paramAst in parameters)
+                    {
+                        paramName = paramAst.Name.VariablePath.UserPath;
 
-                    if (commonParamNames.Contains(paramName, StringComparer.OrdinalIgnoreCase)) {
-                        parentAst = paramAst.Parent;
-                        while (parentAst != null && !(parentAst is FunctionDefinitionAst)) {
-                            parentAst = parentAst.Parent;
-                        }
-
-                        if (parentAst is FunctionDefinitionAst) 
+                        if (commonParamNames.Contains(paramName, StringComparer.OrdinalIgnoreCase))
                         {
-                            IEnumerable<Ast> attrs = parentAst.FindAll(testAttr => testAttr is AttributeAst, true);
-                            foreach (AttributeAst attr in attrs)
-                            {
-                                if (string.Equals(attr.Extent.Text, "[CmdletBinding()]",
-                                    StringComparison.OrdinalIgnoreCase))
-                                {
-                                    string funcName = string.Format(CultureInfo.CurrentCulture,Strings.ReservedParamsCmdletPrefix, (parentAst as FunctionDefinitionAst).Name);
-                                    yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.ReservedParamsError, funcName,paramName), paramAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
-                                   
-                                }
-                            }
+                            yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.ReservedParamsError, funcAst.Name, paramName),
+                                paramAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
                         }
                     }
                 }

--- a/Tests/Rules/AvoidReservedParams.tests.ps1
+++ b/Tests/Rules/AvoidReservedParams.tests.ps1
@@ -1,5 +1,5 @@
 ﻿Import-Module ScriptAnalyzer
-$violationMessage = [regex]::Escape('The cmdlet Verb-Files defines the reserved common parameter $Verbose.')
+$violationMessage = [regex]::Escape("Verb-Files' defines the reserved common parameter 'Verbose'.")
 $violationName = "PSReservedParams"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\BadCmdlet.ps1 | Where-Object {$_.RuleName -eq $violationName}


### PR DESCRIPTION
AvoidReservedParams does not work if function does not have cmdlet binding attribute. Also the current implementation looks at the parameter first before the outer function (should be the other way round).