### PR TITLE
Add wildcard support when include/exclude rules

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -10,6 +10,7 @@
 // THE SOFTWARE.
 //
 
+using System.Text.RegularExpressions;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System;
 using System.Collections.Generic;
@@ -272,7 +273,28 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             IEnumerable<Ast> funcDefAsts;
 
             // Use a List of KVP rather than dictionary, since for a script containing inline functions with same signature, keys clash
-            List<KeyValuePair<CommandInfo, IScriptExtent>> cmdInfoTable = new List<KeyValuePair<CommandInfo, IScriptExtent>>();            
+            List<KeyValuePair<CommandInfo, IScriptExtent>> cmdInfoTable = new List<KeyValuePair<CommandInfo, IScriptExtent>>();
+
+            //Check wild card input for the Include/ExcludRules and create regex match patterns
+            List<Regex> includeRegexList = new List<Regex>();
+            List<Regex> excludeRegexList = new List<Regex>();
+            if (includeRule != null)
+            {
+                foreach (string rule in includeRule)
+                {
+                    Regex includeRegex = new Regex(rule.Replace("*", ".*?"), RegexOptions.IgnoreCase);
+                    includeRegexList.Add(includeRegex);
+                }
+            }
+            if (excludeRule != null)
+            {
+                foreach (string rule in excludeRule)
+                {
+                    Regex excludeRegex = new Regex(rule.Replace("*", ".*?"), RegexOptions.IgnoreCase);
+                    excludeRegexList.Add(excludeRegex);
+                }
+            }
+
 
             //Parse the file
             if (File.Exists(filePath))
@@ -316,12 +338,30 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             #region Run ScriptRules
             //Trim down to the leaf element of the filePath and pass it to Diagnostic Record
             string fileName = System.IO.Path.GetFileName(filePath);
+           
             if (ScriptAnalyzer.Instance.ScriptRules != null)
             {
                 foreach (IScriptRule scriptRule in ScriptAnalyzer.Instance.ScriptRules)
                 {
-                    if ((includeRule == null || includeRule.Contains(scriptRule.GetName(), StringComparer.OrdinalIgnoreCase)) && 
-                        (excludeRule == null || !excludeRule.Contains(scriptRule.GetName(), StringComparer.OrdinalIgnoreCase)))
+                    bool includeRegexMatch = false;
+                    bool excludeRegexMatch = false;
+                    foreach (Regex include in includeRegexList)
+                    {
+                        if (include.IsMatch(scriptRule.GetName()))
+                        {
+                            includeRegexMatch = true;
+                            break;
+                        }
+                    }
+                    foreach (Regex exclude in excludeRegexList)
+                    {
+                        if (exclude.IsMatch(scriptRule.GetName()))
+                        {
+                            excludeRegexMatch = true;
+                        }
+                    }
+                    if ((includeRule == null || includeRule.Contains(scriptRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) && 
+                        (excludeRule == null || !excludeRule.Contains(scriptRule.GetName(), StringComparer.OrdinalIgnoreCase) || !excludeRegexMatch))
                     {
                         WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, scriptRule.GetName()));
 
@@ -334,7 +374,6 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                         catch (Exception scriptRuleException)
                         {
                             WriteError(new ErrorRecord(scriptRuleException, Strings.RuleError, ErrorCategory.InvalidOperation, filePath));
-                            continue;
                         }
                     }
                 }
@@ -379,8 +418,25 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             {
                 foreach (ICommandRule commandRule in ScriptAnalyzer.Instance.CommandRules)
                 {
-                    if ((includeRule == null || includeRule.Contains(commandRule.GetName(), StringComparer.OrdinalIgnoreCase)) &&
-                        (excludeRule == null || !excludeRule.Contains(commandRule.GetName(), StringComparer.OrdinalIgnoreCase)))
+                    bool includeRegexMatch = false;
+                    bool excludeRegexMatch = false;
+                    foreach (Regex include in includeRegexList)
+                    {
+                        if (include.IsMatch(commandRule.GetName()))
+                        {
+                            includeRegexMatch = true;
+                            break;
+                        }
+                    }
+                    foreach (Regex exclude in excludeRegexList)
+                    {
+                        if (exclude.IsMatch(commandRule.GetName()))
+                        {
+                            excludeRegexMatch = true;
+                        }
+                    }
+                    if ((includeRule == null || includeRule.Contains(commandRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) &&
+                        (excludeRule == null || !excludeRule.Contains(commandRule.GetName(), StringComparer.OrdinalIgnoreCase) || !excludeRegexMatch))
                     {
                         foreach (KeyValuePair<CommandInfo, IScriptExtent> commandInfo in cmdInfoTable)
                         {
@@ -395,7 +451,6 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                             catch (Exception commandRuleException)
                             {
                                 WriteError(new ErrorRecord(commandRuleException, Strings.RuleError, ErrorCategory.InvalidOperation, fileName));
-                                continue;
                             }  
                         }
                     }
@@ -410,8 +465,25 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             {
                 foreach (ITokenRule tokenRule in ScriptAnalyzer.Instance.TokenRules)
                 {
-                    if ((includeRule == null || includeRule.Contains(tokenRule.GetName(), StringComparer.OrdinalIgnoreCase)) && 
-                        (excludeRule == null || !excludeRule.Contains(tokenRule.GetName(), StringComparer.OrdinalIgnoreCase)))
+                    bool includeRegexMatch = false;
+                    bool excludeRegexMatch = false;
+                    foreach (Regex include in includeRegexList)
+                    {
+                        if (include.IsMatch(tokenRule.GetName()))
+                        {
+                            includeRegexMatch = true;
+                            break;
+                        }
+                    }
+                    foreach (Regex exclude in excludeRegexList)
+                    {
+                        if (exclude.IsMatch(tokenRule.GetName()))
+                        {
+                            excludeRegexMatch = true;
+                        }
+                    }
+                    if ((includeRule == null || includeRule.Contains(tokenRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) && 
+                        (excludeRule == null || !excludeRule.Contains(tokenRule.GetName(), StringComparer.OrdinalIgnoreCase)) || !excludeRegexMatch)
                     {
                         WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, tokenRule.GetName()));
 
@@ -424,7 +496,6 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                         catch (Exception tokenRuleException)
                         {
                             WriteError(new ErrorRecord(tokenRuleException, Strings.RuleError, ErrorCategory.InvalidOperation, fileName));
-                            continue;
                         } 
                     }
                 }
@@ -438,8 +509,25 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                 // Run DSC Class rule
                 foreach (IDSCResourceRule dscResourceRule in ScriptAnalyzer.Instance.DSCResourceRules)
                 {
-                    if ((includeRule == null || includeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase)) &&
-                        (excludeRule == null || !excludeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase)))
+                    bool includeRegexMatch = false;
+                    bool excludeRegexMatch = false;
+                    foreach (Regex include in includeRegexList)
+                    {
+                        if (include.IsMatch(dscResourceRule.GetName()))
+                        {
+                            includeRegexMatch = true;
+                            break;
+                        }
+                    }
+                    foreach (Regex exclude in excludeRegexList)
+                    {
+                        if (exclude.IsMatch(dscResourceRule.GetName()))
+                        {
+                            excludeRegexMatch = true;
+                        }
+                    }
+                    if ((includeRule == null || includeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) &&
+                        (excludeRule == null || !excludeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase) || excludeRegexMatch))
                     {
                         WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, dscResourceRule.GetName()));
 
@@ -452,7 +540,6 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                         catch (Exception dscResourceRuleException)
                         {
                             WriteError(new ErrorRecord(dscResourceRuleException, Strings.RuleError, ErrorCategory.InvalidOperation, filePath));
-                            continue;
                         }    
                     }
                 }
@@ -480,8 +567,25 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                                     // Run all DSC Rules
                                     foreach (IDSCResourceRule dscResourceRule in ScriptAnalyzer.Instance.DSCResourceRules)
                                     {
-                                        if ((includeRule == null || includeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase)) &&
-                                            (excludeRule == null || !excludeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase)))
+                                        bool includeRegexMatch = false;
+                                        bool excludeRegexMatch = false;
+                                        foreach (Regex include in includeRegexList)
+                                        {
+                                            if (include.IsMatch(dscResourceRule.GetName()))
+                                            {
+                                                includeRegexMatch = true;
+                                                break;
+                                            }
+                                        }
+                                        foreach (Regex exclude in excludeRegexList)
+                                        {
+                                            if (exclude.IsMatch(dscResourceRule.GetName()))
+                                            {
+                                                excludeRegexMatch = true;
+                                            }
+                                        }
+                                        if ((includeRule == null || includeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) &&
+                                            (excludeRule == null || !excludeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase) || !excludeRegexMatch))
                                         {
                                             WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, dscResourceRule.GetName()));
 
@@ -494,7 +598,6 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                                             catch (Exception dscResourceRuleException)
                                             {
                                                 WriteError(new ErrorRecord(dscResourceRuleException, Strings.RuleError, ErrorCategory.InvalidOperation, filePath));
-                                                continue;
                                             }  
                                         }
                                     }

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             {
                 foreach (string rule in includeRule)
                 {
-                    Regex includeRegex = new Regex(rule.Replace("*", ".*?"), RegexOptions.IgnoreCase);
+                    Regex includeRegex = new Regex(String.Format("^{0}$", Regex.Escape(rule).Replace(@"\*", ".*")), RegexOptions.IgnoreCase);
                     includeRegexList.Add(includeRegex);
                 }
             }
@@ -290,7 +290,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             {
                 foreach (string rule in excludeRule)
                 {
-                    Regex excludeRegex = new Regex(rule.Replace("*", ".*?"), RegexOptions.IgnoreCase);
+                    Regex excludeRegex = new Regex(String.Format("^{0}$", Regex.Escape(rule).Replace(@"\*", ".*")), RegexOptions.IgnoreCase);
                     excludeRegexList.Add(excludeRegex);
                 }
             }
@@ -361,8 +361,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                             break;
                         }
                     }
-                    if ((includeRule == null || includeRule.Contains(scriptRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) && 
-                        (excludeRule == null || !excludeRule.Contains(scriptRule.GetName(), StringComparer.OrdinalIgnoreCase) || !excludeRegexMatch))
+                    if ((includeRule == null || includeRegexMatch) &&                         (excludeRule == null || !excludeRegexMatch))
                     {
                         WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, scriptRule.GetName()));
 
@@ -435,10 +434,9 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                         {
                             excludeRegexMatch = true;
                             break;
-                        }
+                         }
                     }
-                    if ((includeRule == null || includeRule.Contains(commandRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) &&
-                        (excludeRule == null || !excludeRule.Contains(commandRule.GetName(), StringComparer.OrdinalIgnoreCase) || !excludeRegexMatch))
+                    if ((includeRule == null || includeRegexMatch) && (excludeRule == null || !excludeRegexMatch))
                     {
                         foreach (KeyValuePair<CommandInfo, IScriptExtent> commandInfo in cmdInfoTable)
                         {
@@ -485,8 +483,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                             break;
                         }
                     }
-                    if ((includeRule == null || includeRule.Contains(tokenRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) && 
-                        (excludeRule == null || !excludeRule.Contains(tokenRule.GetName(), StringComparer.OrdinalIgnoreCase)) || !excludeRegexMatch)
+                    if ((includeRule == null || includeRegexMatch) && (excludeRule == null  || !excludeRegexMatch))
                     {
                         WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, tokenRule.GetName()));
 
@@ -530,8 +527,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                             break;
                         }
                     }
-                    if ((includeRule == null || includeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) &&
-                        (excludeRule == null || !excludeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase) || excludeRegexMatch))
+                    if ((includeRule == null || includeRegexMatch) && (excludeRule == null || excludeRegexMatch))
                     {
                         WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, dscResourceRule.GetName()));
 
@@ -588,8 +584,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                                                 excludeRegexMatch = true;
                                             }
                                         }
-                                        if ((includeRule == null || includeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) &&
-                                            (excludeRule == null || !excludeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase) || !excludeRegexMatch))
+                                        if ((includeRule == null || includeRegexMatch) && (excludeRule == null || !excludeRegexMatch))
                                         {
                                             WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, dscResourceRule.GetName()));
 

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -275,7 +275,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             // Use a List of KVP rather than dictionary, since for a script containing inline functions with same signature, keys clash
             List<KeyValuePair<CommandInfo, IScriptExtent>> cmdInfoTable = new List<KeyValuePair<CommandInfo, IScriptExtent>>();
 
-            //Check wild card input for the Include/ExcludRules and create regex match patterns
+            //Check wild card input for the Include/ExcludeRules and create regex match patterns
             List<Regex> includeRegexList = new List<Regex>();
             List<Regex> excludeRegexList = new List<Regex>();
             if (includeRule != null)
@@ -358,6 +358,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                         if (exclude.IsMatch(scriptRule.GetName()))
                         {
                             excludeRegexMatch = true;
+                            break;
                         }
                     }
                     if ((includeRule == null || includeRule.Contains(scriptRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) && 
@@ -433,6 +434,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                         if (exclude.IsMatch(commandRule.GetName()))
                         {
                             excludeRegexMatch = true;
+                            break;
                         }
                     }
                     if ((includeRule == null || includeRule.Contains(commandRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) &&
@@ -480,6 +482,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                         if (exclude.IsMatch(tokenRule.GetName()))
                         {
                             excludeRegexMatch = true;
+                            break;
                         }
                     }
                     if ((includeRule == null || includeRule.Contains(tokenRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) && 
@@ -524,6 +527,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                         if (exclude.IsMatch(dscResourceRule.GetName()))
                         {
                             excludeRegexMatch = true;
+                            break;
                         }
                     }
                     if ((includeRule == null || includeRule.Contains(dscResourceRule.GetName(), StringComparer.OrdinalIgnoreCase) || includeRegexMatch) &&

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -3,6 +3,8 @@ $sa = Get-Command Invoke-ScriptAnalyzer
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $singularNouns = "PSUseSingularNouns"
 $rules = $singularNouns, "PSUseApprovedVerbs"
+$avoidRules = "PSAvoid*"
+$useRules = "PSUse*"
 
 Describe "Test available parameters" {
     $params = $sa.Parameters
@@ -103,6 +105,12 @@ Describe "Test ExcludeRule" {
         }
     }
 
+    Context "Support wild card" {
+        It "supports wild card exclusions of input rules"{
+            $excludeWildCard = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -ExcludeRule $avoidRules | Where-Object {$_.RuleName -match $avoidRules}
+        }
+    }
+
 }
 
 Describe "Test IncludeRule" {
@@ -122,6 +130,18 @@ Describe "Test IncludeRule" {
         It "does not include any rules" {
             $wrongInclude = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -IncludeRule "This is a wrong rule"
             $wrongInclude.Count | Should Be 0
+        }
+    }
+
+    Context "IncludeRule supports wild card" {
+        It "includes 1 wildcard rule"{
+            $includeWildcard = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -IncludeRule $avoidRules
+            $includeWildcard.Count | Should be 5
+        }
+
+        it "includes 2 wildcardrules" {
+            $includeWildcard = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -IncludeRule $avoidRules, $useRules 
+            $includeWildcard.Count | Should be 7
         }
     }
 }


### PR DESCRIPTION
With this change, users can do something like Invoke-ScriptAnalyzer -IncludeRule PSAvoid*, PSUse*

This feature does not apply to customized rules.