### PR TITLE
Add rule severity support for Get-ScriptAnalyzerRule

### DIFF
--- a/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
+++ b/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
@@ -10,17 +10,14 @@
 // THE SOFTWARE.
 //
 
+using Microsoft.PowerShell.Commands;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Composition;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
-using System.Resources;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
 {
@@ -56,6 +53,21 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             set { name = value; }
         }
         private string[] name;
+
+        /// <summary>
+        /// Severity: Array of the severity types to be enabled.
+        /// </summary>
+        /// </summary>
+        [ValidateSet("Warning", "Error", "Information", IgnoreCase = true)]
+        [Parameter(Mandatory = false)]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        public string[] Severity
+        {
+            get { return severity; }
+            set { severity = value; }
+        }
+        private string[] severity;
+
         #endregion Parameters
 
         #region Private Members
@@ -128,9 +140,16 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             }
             else
             {
+                if (severity != null)
+                {
+                    var ruleSeverity = severity.Select(item => Enum.Parse(typeof (RuleSeverity), item));
+                    rules = rules.Where(item => ruleSeverity.Contains(item.GetSeverity())).ToList();
+                }
+
                 foreach (IRule rule in rules)
                 {
-                    WriteObject(new RuleInfo(rule.GetName(), rule.GetCommonName(), rule.GetDescription(), rule.GetSourceType(), rule.GetSourceName()));
+                    WriteObject(new RuleInfo(rule.GetName(), rule.GetCommonName(), rule.GetDescription(),
+                        rule.GetSourceType(), rule.GetSourceName(), rule.GetSeverity()));
                 }
             }
         }

--- a/Engine/Generic/AvoidCmdletGeneric.cs
+++ b/Engine/Generic/AvoidCmdletGeneric.cs
@@ -93,5 +93,11 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
         /// </summary>
         /// <returns>The source type of the rule.</returns>
         public abstract  SourceType GetSourceType();
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public abstract RuleSeverity GetSeverity();
     }
 }

--- a/Engine/Generic/AvoidParameterGeneric.cs
+++ b/Engine/Generic/AvoidParameterGeneric.cs
@@ -104,5 +104,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
         /// </summary>
         /// <returns>The source type of the rule.</returns>
         public abstract  SourceType GetSourceType();
+
+        public abstract RuleSeverity GetSeverity();
     }
 }

--- a/Engine/Generic/ExternalRule.cs
+++ b/Engine/Generic/ExternalRule.cs
@@ -55,6 +55,12 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
             return SourceType.Module;
         }
 
+        //Set the community rule level as warning as the current implementation does not require user to specify rule severity when defining their functions in PS scripts
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
+
         public string GetSourceName()
         {
             return this.srcName;

--- a/Engine/Generic/IRule.cs
+++ b/Engine/Generic/IRule.cs
@@ -10,12 +10,6 @@
 // THE SOFTWARE.
 //
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
 {
     /// <summary>
@@ -52,5 +46,12 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
         /// </summary>
         /// <returns>The source type of the rule.</returns>
         SourceType GetSourceType();
+
+        /// <summary>
+        /// GetSeverity: Retrieves severity of the rule.
+        /// </summary>
+        /// <returns></returns>
+        RuleSeverity GetSeverity();
+
     }
 }

--- a/Engine/Generic/RuleInfo.cs
+++ b/Engine/Generic/RuleInfo.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
         private string description;
         private SourceType sourceType;
         private string sourceName;
+        private RuleSeverity ruleSeverity;
 
         /// <summary>
         /// Name: The name of the rule.
@@ -82,6 +83,16 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
         }
 
         /// <summary>
+        /// Severity : The severity of the rule violation.
+        /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        public RuleSeverity Severity
+        {
+            get { return ruleSeverity; }
+            private set { ruleSeverity = value; }
+        }
+
+        /// <summary>
         /// Constructor for a RuleInfo.
         /// </summary>
         /// <param name="name">Name of the rule.</param>
@@ -89,13 +100,14 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
         /// <param name="description">Description of the rule.</param>
         /// <param name="sourceType">Source type of the rule.</param>
         /// <param name="sourceName">Source name of the rule.</param>
-        public RuleInfo(string name, string commonName, string description, SourceType sourceType, string sourceName)
+        public RuleInfo(string name, string commonName, string description, SourceType sourceType, string sourceName, RuleSeverity severity)
         {
             Name        = name;
             CommonName  = commonName;
             Description = description;
             SourceType  = sourceType;
             SourceName  = sourceName;
+            Severity = severity;
         }
     }
 }

--- a/Engine/Generic/RuleSeverity.cs
+++ b/Engine/Generic/RuleSeverity.cs
@@ -1,0 +1,35 @@
+﻿//
+// Copyright (c) Microsoft Corporation.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
+{
+    /// <summary>
+    /// Represents the severity of a PSScriptAnalyzer rule
+    /// </summary>
+    public enum RuleSeverity : uint
+    {
+        /// <summary>
+        /// Information: This warning is trivial, but may be useful. They are recommended by PowerShell best practice.
+        /// </summary>
+        Information = 0,
+
+        /// <summary>
+        /// WARNING: This warning may cause a problem or does not follow PowerShell's recommended guidelines.
+        /// </summary>
+        Warning = 1,
+
+        /// <summary>
+        /// ERROR: This warning is likely to cause a problem or does not follow PowerShell's required guidelines.
+        /// </summary>
+        Error = 2,
+    };
+}

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
         #region Private memebers
 
         private CompositionContainer container;
-        private const string baseName = "Microsoft.Windows.Powershell.ScriptAnalyzer.Properties.Strings";
 
         #endregion
 
@@ -91,7 +90,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
         public void Initialize()
         {
             // Clear external rules for each invoke.
-            this.ExternalRules = new List<ExternalRule>();
+            ExternalRules = new List<ExternalRule>();
 
             // Initialize helper
             Helper.Instance.Initialize();
@@ -129,7 +128,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
             List<string> paths = new List<string>();
 
             // Clear external rules for each invoke.
-            this.ExternalRules = new List<ExternalRule>();
+            ExternalRules = new List<ExternalRule>();
 
             // Initialize helper
             Helper.Instance.Initialize();

--- a/Engine/ScriptAnalyzer.format.ps1xml
+++ b/Engine/ScriptAnalyzer.format.ps1xml
@@ -62,19 +62,19 @@
     <TableControl>
       <TableHeaders>
         <TableColumnHeader>
-          <Width>30</Width>
-          <Label>Name</Label>
+          <Width>35</Width>
+          <Label>Rule Name</Label>
         </TableColumnHeader>
         <TableColumnHeader>
-          <Width>33</Width>
-          <Label>CommonName</Label>
+          <Width>15</Width>
+          <Label>Severity</Label>
         </TableColumnHeader>
         <TableColumnHeader>
-          <Width>45</Width>
+          <Width>60</Width>
           <Label>Description</Label>
         </TableColumnHeader>
         <TableColumnHeader>
-          <Width>8</Width>
+          <Width>10</Width>
           <Label>Source</Label>
         </TableColumnHeader>
       </TableHeaders>
@@ -86,7 +86,7 @@
               <PropertyName>Name</PropertyName>
             </TableColumnItem>
             <TableColumnItem>
-              <PropertyName>CommonName</PropertyName>
+              <PropertyName>Severity</PropertyName>
             </TableColumnItem>
             <TableColumnItem>
               <PropertyName>Description</PropertyName>

--- a/Engine/ScriptAnalyzer.format.ps1xml
+++ b/Engine/ScriptAnalyzer.format.ps1xml
@@ -13,7 +13,7 @@
           <Label>Rule Name</Label>
         </TableColumnHeader>
         <TableColumnHeader>
-          <Width>10</Width>
+          <Width>12</Width>
           <Label>Severity</Label>
         </TableColumnHeader>
         <TableColumnHeader>

--- a/Engine/ScriptAnalyzer.types.ps1xml
+++ b/Engine/ScriptAnalyzer.types.ps1xml
@@ -42,7 +42,7 @@
             <Name>DefaultDisplayPropertySet</Name>
             <ReferencedProperties>
               <Name>Name</Name>
-              <Name>CommonName</Name>
+              <Name>Severity</Name>
               <Name>Description</Name>
               <Name>SourceName</Name>
             </ReferencedProperties>

--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -11,19 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -95,6 +87,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidDefaultTrueValueSwitchParameter.cs
+++ b/Rules/AvoidDefaultTrueValueSwitchParameter.cs
@@ -11,19 +11,12 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -89,6 +82,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidEmptyCatchBlock.cs
+++ b/Rules/AvoidEmptyCatchBlock.cs
@@ -11,19 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -89,6 +81,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidGlobalVars.cs
+++ b/Rules/AvoidGlobalVars.cs
@@ -12,16 +12,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -91,6 +85,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidInvokingEmptyMembers.cs
+++ b/Rules/AvoidInvokingEmptyMembers.cs
@@ -11,19 +11,12 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -103,6 +96,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidPositionalParameters.cs
+++ b/Rules/AvoidPositionalParameters.cs
@@ -11,20 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
-using Microsoft.Windows.Powershell.ScriptAnalyzer;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -95,6 +86,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidReservedCharInCmdlet.cs
+++ b/Rules/AvoidReservedCharInCmdlet.cs
@@ -11,19 +11,13 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -83,6 +77,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidReservedParams.cs
+++ b/Rules/AvoidReservedParams.cs
@@ -13,15 +13,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
 
@@ -104,6 +99,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidShouldContinueWithoutForce.cs
+++ b/Rules/AvoidShouldContinueWithoutForce.cs
@@ -11,19 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -117,6 +109,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidTrapStatement.cs
+++ b/Rules/AvoidTrapStatement.cs
@@ -11,19 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -87,6 +79,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidUnitializedVariable.cs
+++ b/Rules/AvoidUnitializedVariable.cs
@@ -11,20 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
-using Microsoft.Windows.Powershell.ScriptAnalyzer;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -110,6 +101,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidUserNameAndPasswordParams.cs
+++ b/Rules/AvoidUserNameAndPasswordParams.cs
@@ -11,18 +11,12 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
 using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
@@ -127,6 +121,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Error;
         }
 
         /// <summary>

--- a/Rules/AvoidUsingComputerNameHardcoded.cs
+++ b/Rules/AvoidUsingComputerNameHardcoded.cs
@@ -11,19 +11,10 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -129,6 +120,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public override SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public override RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Error;
         }
 
         /// <summary>

--- a/Rules/AvoidUsingConvertToSecureStringWithPlainText.cs
+++ b/Rules/AvoidUsingConvertToSecureStringWithPlainText.cs
@@ -11,19 +11,12 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -44,7 +37,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         {
             if (CTSTCmdlet == null)
             {
-                CTSTCmdlet = Microsoft.Windows.Powershell.ScriptAnalyzer.Helper.Instance.CmdletNameAndAliases("convertto-securestring");
+                CTSTCmdlet = Helper.Instance.CmdletNameAndAliases("convertto-securestring");
             }
 
             return CmdAst != null && CmdAst.GetCommandName() != null && CTSTCmdlet.Contains(CmdAst.GetCommandName(), StringComparer.OrdinalIgnoreCase);
@@ -105,6 +98,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public override SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public override RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Error;
         }
 
         /// <summary>

--- a/Rules/AvoidUsingInternalURLs.cs
+++ b/Rules/AvoidUsingInternalURLs.cs
@@ -171,6 +171,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         }
 
         /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
+
+        /// <summary>
         /// Method: Retrieves the module/assembly name the rule is from.
         /// </summary>
         public string GetSourceName()

--- a/Rules/AvoidUsingInvokeExpression.cs
+++ b/Rules/AvoidUsingInvokeExpression.cs
@@ -11,17 +11,9 @@
 //
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -82,6 +74,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public override SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity:Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public override RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidUsingPlainTextForPassword.cs
+++ b/Rules/AvoidUsingPlainTextForPassword.cs
@@ -11,18 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
 using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
@@ -105,6 +98,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/AvoidUsingWMIObjectCmdlet.cs
+++ b/Rules/AvoidUsingWMIObjectCmdlet.cs
@@ -116,6 +116,17 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
             return SourceType.Builtin;
         }
 
+
+        /// <summary>
+        /// GetSeverity:Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
+
+
         /// <summary>
         /// GetSourceName: Retrieves the module/assembly name the rule is from.
         /// </summary>

--- a/Rules/AvoidUsingWriteHost.cs
+++ b/Rules/AvoidUsingWriteHost.cs
@@ -11,19 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -103,6 +95,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/MissingModuleManifestField.cs
+++ b/Rules/MissingModuleManifestField.cs
@@ -12,18 +12,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation.Language;
 using System.Management.Automation;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
-using System.IO;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -108,6 +101,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/PossibleIncorrectComparisonWithNull.cs
+++ b/Rules/PossibleIncorrectComparisonWithNull.cs
@@ -11,19 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -85,6 +77,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/ProvideCommentHelp.cs
+++ b/Rules/ProvideCommentHelp.cs
@@ -13,15 +13,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 using System.Management.Automation;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
@@ -233,6 +228,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Information;
         }
 
         /// <summary>

--- a/Rules/ProvideVerboseMessage.cs
+++ b/Rules/ProvideVerboseMessage.cs
@@ -12,16 +12,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -115,6 +109,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Information;
         }
 
         /// <summary>

--- a/Rules/ReturnCorrectTypesForDSCFunctions.cs
+++ b/Rules/ReturnCorrectTypesForDSCFunctions.cs
@@ -11,20 +11,12 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
-using Microsoft.Windows.Powershell.ScriptAnalyzer;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -215,6 +207,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Information;
         }
 
         /// <summary>

--- a/Rules/UseApprovedVerbs.cs
+++ b/Rules/UseApprovedVerbs.cs
@@ -11,18 +11,13 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
 using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
@@ -100,6 +95,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/UseCmdletCorrectly.cs
+++ b/Rules/UseCmdletCorrectly.cs
@@ -11,21 +11,13 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation.Runspaces;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using Microsoft.Windows.Powershell.ScriptAnalyzer;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -195,6 +187,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -11,19 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -95,7 +87,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
                                 assignments.Remove(varKey);
                             }
                             //Check if variable belongs to PowerShell builtin variables
-                            if (Microsoft.Windows.Powershell.ScriptAnalyzer.Helper.Instance.HasSpecialVars(varKey))
+                            if (Helper.Instance.HasSpecialVars(varKey))
                             {
                                 assignments.Remove(varKey);
                             }
@@ -142,6 +134,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/UseIdenticalMandatoryParametersDSC.cs
+++ b/Rules/UseIdenticalMandatoryParametersDSC.cs
@@ -154,6 +154,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         }
 
         /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Information;
+        }
+
+        /// <summary>
         /// GetSourceName: Retrieves the module/assembly name the rule is from.
         /// </summary>
         public string GetSourceName()

--- a/Rules/UseIdenticalParametersDSC.cs
+++ b/Rules/UseIdenticalParametersDSC.cs
@@ -11,19 +11,12 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -165,6 +158,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/UsePSCredentialType.cs
+++ b/Rules/UsePSCredentialType.cs
@@ -11,19 +11,12 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -124,6 +117,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/UseShouldProcessCorrectly.cs
+++ b/Rules/UseShouldProcessCorrectly.cs
@@ -11,19 +11,11 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -112,6 +104,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/UseShouldProcessForStateChangingFunctions.cs
+++ b/Rules/UseShouldProcessForStateChangingFunctions.cs
@@ -119,6 +119,16 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         }
 
         /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
+
+
+        /// <summary>
         /// GetSourceName: Retrieves the module/assembly name the rule is from.
         /// </summary>
         public string GetSourceName()

--- a/Rules/UseSingularNouns.cs
+++ b/Rules/UseSingularNouns.cs
@@ -11,19 +11,13 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -89,6 +83,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/UseStandardDSCFunctionsInResource.cs
+++ b/Rules/UseStandardDSCFunctionsInResource.cs
@@ -11,19 +11,12 @@
 //
 
 using System;
-using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
-using System.Resources;
 using System.Globalization;
-using System.Threading;
-using System.Reflection;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -131,6 +124,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public SourceType GetSourceType()
         {
             return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Error;
         }
 
         /// <summary>

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -109,3 +109,15 @@ Describe "Test RuleExtension" {
 
     }
 }
+
+Describe "TestSeverity" {
+    It "filters rules based on the specified rule severity" {
+        $rules = Get-ScriptAnalyzerRule -Severity Error
+        $rules.Count | Should be 4
+    }
+
+    It "filters rules based on multiple severity inputs"{
+        $rules = Get-ScriptAnalyzerRule -Severity Error,Information
+        $rules.Count | Should be 8
+    }
+}


### PR DESCRIPTION
Added -Severity parameter in Get-ScriptAnalyzerRule cmdlet. Will filter the rules base on the rule severity specified.

Also updated the output format of Get-ScriptAnalyzerRule and Invoke-ScriptAnalyzer to make them look more aligned. 