### PR TITLE
AvoidUninitialized rule must recognize built-in $ExecutionContext variable

### DIFF
--- a/Engine/SpecialVars.cs
+++ b/Engine/SpecialVars.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
         internal const string MyInvocation = "MyInvocation";
         internal const string PSScriptRoot = "PSScriptRoot";
         internal const string PSCommandPath = "PSCommandPath";
+        internal const string ExecutionContext = "ExecutionContext";
+
 
         internal static readonly string[] InitializedVariables;
 
@@ -67,6 +69,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                                                                    MyInvocation,  
                                                                    PSScriptRoot,  
                                                                    PSCommandPath,  
+                                                                   ExecutionContext
                                                                };
         internal static readonly Type[] AutomaticVariableTypes = new Type[]  
                                                                  {  
@@ -79,6 +82,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                                                                    /* MyInvocation */      typeof(InvocationInfo),  
                                                                    /* PSScriptRoot */      typeof(string),  
                                                                    /* PSCommandPath */     typeof(string),  
+                                                                   /* ExecutionContext */  typeof(EngineIntrinsics),  
                                                                  };
 
 


### PR DESCRIPTION
...nagement.Automation.EngineIntrinsics variable