### PR TITLE
Fix bugs in importing external rule

### DIFF
--- a/Engine/Generic/ExternalRule.cs
+++ b/Engine/Generic/ExternalRule.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
         string param   = string.Empty;
         string srcName = string.Empty;
         string modPath = string.Empty;
-        
+        string paramType = string.Empty;
 
         public string GetName()
         {
@@ -53,6 +53,11 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
         public SourceType GetSourceType()
         {
             return SourceType.Module;
+        }
+
+        public string GetParameterType()
+        {
+            return this.paramType;
         }
 
         //Set the community rule level as warning as the current implementation does not require user to specify rule severity when defining their functions in PS scripts
@@ -80,7 +85,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
 
         }
 
-        public ExternalRule(string name, string commonName, string desc, string param, string srcName, string modPath)
+        public ExternalRule(string name, string commonName, string desc, string param, string paramType, string srcName, string modPath)
         {
             this.name    = name;
             this.commonName = commonName;
@@ -88,6 +93,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Generic
             this.param   = param;
             this.srcName = srcName;
             this.modPath = modPath;
+            this.paramType = paramType;
         }
 
         #endregion

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                 paths = result.ContainsKey("ValidDllPaths") ? result["ValidDllPaths"] : result["ValidPaths"];
                 foreach (string path in paths)
                 {
-                    if (Path.GetExtension(path).ToLower(CultureInfo.CurrentCulture) == ".dll")
+                    if (String.Equals(Path.GetExtension(path),".dll",StringComparison.OrdinalIgnoreCase))
                     {
                         catalog.Catalogs.Add(new AssemblyCatalog(path));
                     }
@@ -241,8 +241,8 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
 
                         FunctionInfo funcInfo = (FunctionInfo)psobject.ImmediateBaseObject;
                         ParameterMetadata param = funcInfo.Parameters.Values
-                            .First<ParameterMetadata>(item => item.Name.ToLower(CultureInfo.CurrentCulture).EndsWith("ast", StringComparison.CurrentCulture) ||
-                                                              item.Name.ToLower(CultureInfo.CurrentCulture).EndsWith("token", StringComparison.CurrentCulture));
+                            .First<ParameterMetadata>(item => item.Name.EndsWith("ast", StringComparison.OrdinalIgnoreCase) ||
+                                item.Name.EndsWith("token", StringComparison.CurrentCulture));
                         
                         //Only add functions that are defined as rules.
                         if (param != null)
@@ -251,7 +251,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                             string desc =posh.AddScript(script).Invoke()[0].ImmediateBaseObject.ToString()
                                     .Replace("\r\n", " ").Trim();
 
-                            rules.Add(new ExternalRule(funcInfo.Name, funcInfo.Name, desc, param.Name,
+                            rules.Add(new ExternalRule(funcInfo.Name, funcInfo.Name, desc, param.ParameterType.Name,
                                 funcInfo.ModuleName, funcInfo.Module.Path));
                         }
                     }
@@ -381,30 +381,33 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                         string message = string.Empty;
                         string ruleName = string.Empty;
 
-                        // Because error stream is merged to output stream,
-                        // we need to handle the error records.
-                        if (psobject.ImmediateBaseObject is ErrorRecord)
+                        if (psobject != null && psobject.ImmediateBaseObject != null)
                         {
-                            ErrorRecord record = (ErrorRecord)psobject.ImmediateBaseObject;
-                            command.WriteError(record);
-                            continue;
-                        }
+                            // Because error stream is merged to output stream,
+                            // we need to handle the error records.
+                            if (psobject.ImmediateBaseObject is ErrorRecord)
+                            {
+                                ErrorRecord record = (ErrorRecord)psobject.ImmediateBaseObject;
+                                command.WriteError(record);
+                                continue;
+                            }
 
-                        // DiagnosticRecord may not be correctly returned from external rule.
-                        try
-                        {
-                            Enum.TryParse<DiagnosticSeverity>(psobject.Properties["Severity"].Value.ToString().ToUpper(), out severity);
-                            message = psobject.Properties["Message"].Value.ToString();
-                            extent = (IScriptExtent)psobject.Properties["Extent"].Value;
-                            ruleName = psobject.Properties["RuleName"].Value.ToString();
-                        }
-                        catch (Exception ex)
-                        {
-                            command.WriteError(new ErrorRecord(ex, ex.HResult.ToString("X"), ErrorCategory.NotSpecified, this));
-                            continue;
-                        }
+                            // DiagnosticRecord may not be correctly returned from external rule.
+                            try
+                            {
+                                Enum.TryParse<DiagnosticSeverity>(psobject.Properties["Severity"].Value.ToString().ToUpper(), out severity);
+                                message = psobject.Properties["Message"].Value.ToString();
+                                extent = (IScriptExtent)psobject.Properties["Extent"].Value;
+                                ruleName = psobject.Properties["RuleName"].Value.ToString();
+                            }
+                            catch (Exception ex)
+                            {
+                                command.WriteError(new ErrorRecord(ex, ex.HResult.ToString("X"), ErrorCategory.NotSpecified, this));
+                                continue;
+                            }
 
-                        if (!string.IsNullOrEmpty(message)) yield return new DiagnosticRecord(message, extent, ruleName, severity, null);
+                            if (!string.IsNullOrEmpty(message)) yield return new DiagnosticRecord(message, extent, ruleName, severity, null);
+                        }
                     }
                 }
 
@@ -478,7 +481,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
 
                     cmdlet.WriteDebug(string.Format(CultureInfo.CurrentCulture, Strings.CheckAssemblyFile, resolvedPath));
 
-                    if (Path.GetExtension(resolvedPath).ToLower(CultureInfo.CurrentCulture) == ".dll")
+                    if (String.Equals(Path.GetExtension(resolvedPath),".dll"))
                     {
                         if (!File.Exists(resolvedPath))
                         {

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -242,7 +242,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                         FunctionInfo funcInfo = (FunctionInfo)psobject.ImmediateBaseObject;
                         ParameterMetadata param = funcInfo.Parameters.Values
                             .First<ParameterMetadata>(item => item.Name.EndsWith("ast", StringComparison.OrdinalIgnoreCase) ||
-                                item.Name.EndsWith("token", StringComparison.CurrentCulture));
+                                item.Name.EndsWith("token", StringComparison.OrdinalIgnoreCase));
                         
                         //Only add functions that are defined as rules.
                         if (param != null)

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                             string desc =posh.AddScript(script).Invoke()[0].ImmediateBaseObject.ToString()
                                     .Replace("\r\n", " ").Trim();
 
-                            rules.Add(new ExternalRule(funcInfo.Name, funcInfo.Name, desc, param.ParameterType.Name,
+                            rules.Add(new ExternalRule(funcInfo.Name, funcInfo.Name, desc, param.Name,param.ParameterType.FullName,
                                 funcInfo.ModuleName, funcInfo.Module.Path));
                         }
                     }
@@ -290,12 +290,12 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
             // Groups rules by AstType and Tokens.
             Dictionary<string, List<ExternalRule>> astRuleGroups = rules
                 .Where<ExternalRule>(item => item.GetParameter().EndsWith("ast", StringComparison.OrdinalIgnoreCase))
-                .GroupBy<ExternalRule, string>(item => item.GetParameter())
+                .GroupBy<ExternalRule, string>(item => item.GetParameterType())
                 .ToDictionary(item => item.Key, item => item.ToList());
 
             Dictionary<string, List<ExternalRule>> tokenRuleGroups = rules
                 .Where<ExternalRule>(item => item.GetParameter().EndsWith("token", StringComparison.OrdinalIgnoreCase))
-                .GroupBy<ExternalRule, string>(item => item.GetParameter())
+                .GroupBy<ExternalRule, string>(item => item.GetParameterType())
                 .ToDictionary(item => item.Key, item => item.ToList());
 
             using (rsp)
@@ -337,7 +337,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                 {
                     // Find all AstTypes that appeared in rule groups.
                     IEnumerable<Ast> childAsts = ast.FindAll(new Func<Ast, bool>((testAst) =>
-                        (String.Equals(testAst.GetType().Name, astRuleGroup.Key, StringComparison.OrdinalIgnoreCase))), false);
+                        (astRuleGroup.Key.IndexOf(testAst.GetType().FullName,StringComparison.OrdinalIgnoreCase) != -1)), false);
 
                     foreach (Ast childAst in childAsts)
                     {

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                             string desc =posh.AddScript(script).Invoke()[0].ImmediateBaseObject.ToString()
                                     .Replace("\r\n", " ").Trim();
 
-                            rules.Add(new ExternalRule(funcInfo.Name, funcInfo.Name, desc, param.ParameterType.Name,
+                            rules.Add(new ExternalRule(funcInfo.Name, funcInfo.Name, desc, param.ParameterType.FullName,
                                 funcInfo.ModuleName, funcInfo.Module.Path));
                         }
                     }
@@ -481,7 +481,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
 
                     cmdlet.WriteDebug(string.Format(CultureInfo.CurrentCulture, Strings.CheckAssemblyFile, resolvedPath));
 
-                    if (String.Equals(Path.GetExtension(resolvedPath),".dll"))
+                    if (String.Equals(Path.GetExtension(resolvedPath),".dll", StringComparison.OrdinalIgnoreCase))
                     {
                         if (!File.Exists(resolvedPath))
                         {

--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -1,0 +1,40 @@
+﻿Import-Module PSScriptAnalyzer
+$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$message = "this is help"
+$measure = "Measure-RequiresRunAsAdministrator"
+
+Describe "Test importing customized rules with null return results" {
+    Context "Test Get-ScriptAnalyzer with customized rules" {
+        It "will not terminate the engine" {
+            $customizedRulePath = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $measure}
+            $customizedRulePath.Count | Should Be 1
+        }
+       
+    }
+
+    Context "Test Invoke-ScriptAnalyzer with customized rules" {
+        It "will not terminate the engine" {
+            $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $measure}
+            $customizedRulePath.Count | Should Be 0
+        }
+    }
+
+}
+
+Describe "Test importing correct customized rules" {
+    Context "Test Get-ScriptAnalyzer with customized rules" {
+        It "will show the customized rule" {
+            $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.RuleName -eq $measure}
+            $customizedRulePath.Count | Should Be 1
+        }
+       
+    }
+
+    Context "Test Invoke-ScriptAnalyzer with customized rules" {
+        It "will show the customized rule in the results" {
+            $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.Message -eq $message}
+            $customizedRulePath.Count | Should Be 1
+        }
+    }
+
+}

--- a/Tests/Engine/samplerule/SampleRulesWithErrors.psm1
+++ b/Tests/Engine/samplerule/SampleRulesWithErrors.psm1
@@ -26,20 +26,13 @@ function Measure-RequiresRunAsAdministrator
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.Language.ScriptBlockAst]
-        $testAst
+        $ScriptBlockAst
     )
 
     
         $results = @()
-       
-        $result = [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]]@{"Message"  = "this is help"; 
-                                            "Extent"   = $ast.Extent;
-                                            "RuleName" = $PSCmdlet.MyInvocation.InvocationName;
-                                            "Severity" = "Warning"}
 
-        $results += $result             
-                
-      
+        $results += $null           
         return $results
 
            

--- a/Tests/Engine/samplerule/samplerule.psm1
+++ b/Tests/Engine/samplerule/samplerule.psm1
@@ -1,0 +1,45 @@
+#Requires -Version 3.0
+
+<#
+.SYNOPSIS
+    Uses #Requires -RunAsAdministrator instead of your own methods.
+.DESCRIPTION
+    The #Requires statement prevents a script from running unless the Windows PowerShell version, modules, snap-ins, and module and snap-in version prerequisites are met. 
+    From Windows PowerShell 4.0, the #Requires statement let script developers require that sessions be run with elevated user rights (run as Administrator). 
+    Script developers does not need to write their own methods any more.
+    To fix a violation of this rule, please consider to use #Requires -RunAsAdministrator instead of your own methods.
+.EXAMPLE
+    Measure-RequiresRunAsAdministrator -ScriptBlockAst $ScriptBlockAst
+.INPUTS
+    [System.Management.Automation.Language.ScriptBlockAst]
+.OUTPUTS
+    [OutputType([PSCustomObject[])]
+.NOTES
+    None
+#>
+function Measure-RequiresRunAsAdministrator
+{
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]
+        $Ast
+    )
+
+    
+        $results = @()
+
+        $result = [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]]@{"Message"  = "this is help"; 
+                                            "Extent"   = $FunctionDefinitionAst.Extent;
+                                            "RuleName" = $PSCmdlet.MyInvocation.InvocationName;
+                                            "Severity" = "Warning"}
+
+                $results += $result              
+        return $results
+
+           
+}
+Export-ModuleMember -Function Measure*


### PR DESCRIPTION
When importing customized rules, we take Ast type instead of name to
apply rules.
Modify string comparsion
Add check for null diagnosticRecord returned.