### PR TITLE
Adding DscExamplesPresent rule

### DIFF
--- a/RuleDocumentation/DscExamplesPresent.md
+++ b/RuleDocumentation/DscExamplesPresent.md
@@ -1,0 +1,55 @@
+#DscExamplesPresent
+**Severity Level: Information**
+
+
+##Description
+
+Checks that DSC examples for given resource are present.
+
+##How to Fix
+
+To fix a violation of this rule, please make sure Examples directory is present:
+* For non-class based resources it should exist at the same folder level as DSCResources folder.
+* For class based resources it should be present at the same folder level as resource psm1 file. 
+
+Examples folder should contain sample configuration for given resource - file name should contain resource's name.
+
+##Example
+
+### Non-class based resource
+
+Let's assume we have non-class based resource with a following file structure:
+
+* xAzure
+  * DSCResources
+    * MSFT_xAzureSubscription
+      * MSFT_xAzureSubscription.psm1
+      * MSFT_xAzureSubscription.schema.mof
+
+In this case, to fix this warning, we should add examples in a following way:
+
+* xAzure
+  * DSCResources
+    * MSFT_xAzureSubscription
+      * MSFT_xAzureSubscription.psm1
+      * MSFT_xAzureSubscription.schema.mof
+  * Examples
+    * MSFT_xAzureSubscription_AddSubscriptionExample.ps1
+    * MSFT_xAzureSubscription_RemoveSubscriptionExample.ps1
+
+### Class based resource
+
+Let's assume we have class based resource with a following file structure:
+
+* MyDscResource
+    * MyDscResource.psm1
+    * MyDscresource.psd1
+
+In this case, to fix this warning, we should add examples in a following way:
+
+* MyDscResource
+    * MyDscResource.psm1
+    * MyDscresource.psd1
+    * Tests
+      * MyDscResource_Example1.ps1
+      * MyDscResource_Example2.ps1

--- a/Rules/DscExamplesPresent.cs
+++ b/Rules/DscExamplesPresent.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
             if (!examplesPresent)
             {
                 yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.DscExamplesPresentNoExamplesError, resourceName),
-                            null, GetName(), DiagnosticSeverity.Information, fileName);
+                            ast.Extent, GetName(), DiagnosticSeverity.Information, fileName);
             }
         }
 
@@ -103,7 +103,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
                 if (!examplesPresent)
                 {
                     yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.DscExamplesPresentNoExamplesError, resourceName),
-                                null, GetName(), DiagnosticSeverity.Information, fileName);
+                                dscClass.Extent, GetName(), DiagnosticSeverity.Information, fileName);
                 }
             }       
         }

--- a/Rules/DscExamplesPresent.cs
+++ b/Rules/DscExamplesPresent.cs
@@ -1,0 +1,105 @@
+﻿//
+// Copyright (c) Microsoft Corporation.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation.Language;
+using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
+using System.ComponentModel.Composition;
+using System.Globalization;
+
+namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
+{
+    /// <summary>
+    /// DscExamplesExist: Checks that DSC examples for given resource are present
+    /// </summary>
+    [Export(typeof(IDSCResourceRule))]
+    public class DscExamplesPresent : IDSCResourceRule
+    {
+        /// <summary>
+        /// AnalyzeDSCResource: Analyzes given DSC Resource
+        /// </summary>
+        /// <param name="ast">The script's ast</param>
+        /// <param name="fileName">The name of the script file being analyzed</param>
+        /// <returns>The results of the analysis</returns>
+        public IEnumerable<DiagnosticRecord> AnalyzeDSCResource(Ast ast, string fileName)
+        {
+
+        }
+
+        /// <summary>
+        /// AnalyzeDSCClass: Analyzes given DSC class
+        /// </summary>
+        /// <param name="ast"></param>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        public IEnumerable<DiagnosticRecord> AnalyzeDSCClass(Ast ast, string fileName)
+        {
+
+        }
+
+
+        /// <summary>
+        /// GetName: Retrieves the name of this rule.
+        /// </summary>
+        /// <returns>The name of this rule</returns>
+        public string GetName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.DscExamplesPresent);
+        }
+
+        /// <summary>
+        /// GetCommonName: Retrieves the Common name of this rule.
+        /// </summary>
+        /// <returns>The common name of this rule</returns>
+        public string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.DscExamplesPresentCommonName);
+        }
+
+        /// <summary>
+        /// GetDescription: Retrieves the description of this rule.
+        /// </summary>
+        /// <returns>The description of this rule</returns>
+        public string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.DscExamplesPresentDescription);
+        }
+
+        /// <summary>
+        /// GetSourceType: Retrieves the type of the rule: builtin, managed or module.
+        /// </summary>
+        public SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning or information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Information;
+        }
+
+        /// <summary>
+        /// GetSourceName: Retrieves the module/assembly name the rule is from.
+        /// </summary>
+        public string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.DSCSourceName);
+        }
+    }
+
+}

--- a/Rules/DscExamplesPresent.cs
+++ b/Rules/DscExamplesPresent.cs
@@ -40,11 +40,11 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         /// <returns>The results of the analysis</returns>
         public IEnumerable<DiagnosticRecord> AnalyzeDSCResource(Ast ast, string fileName)
         {
-            String fileNameOnly = fileName.Substring(fileName.LastIndexOf("\\", StringComparison.Ordinal) + 1);
-            String resourceName = fileNameOnly.Substring(0, fileNameOnly.Length - ".psm1".Length);
-            String examplesQuery = "*" + resourceName + "*";
+            String fileNameOnly = Path.GetFileName(fileName);
+            String resourceName = Path.GetFileNameWithoutExtension(fileNameOnly);
+            String examplesQuery = String.Format("*{0}*", resourceName);
             Boolean examplesPresent = false; 
-            String expectedExamplesPath = fileName + "\\..\\..\\..\\Examples";
+            String expectedExamplesPath = Path.Combine(new String[] {fileName, "..", "..", "..", "Examples"});
 
             // Verify examples are present
             if (Directory.Exists(expectedExamplesPath))
@@ -84,9 +84,9 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
             {
                 resourceName = dscClass.Name;
 
-                String examplesQuery = "*" + resourceName + "*";
+                String examplesQuery = String.Format("*{0}*", resourceName);
                 Boolean examplesPresent = false;
-                String expectedExamplesPath = fileName + "\\..\\Examples";
+                String expectedExamplesPath = Path.Combine(new String[] {fileName, "..", "Examples"});
 
                 // Verify examples are present
                 if (Directory.Exists(expectedExamplesPath))

--- a/Rules/ReturnCorrectTypesForDSCFunctions.cs
+++ b/Rules/ReturnCorrectTypesForDSCFunctions.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         }
 
         /// <summary>
-        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// GetSeverity: Retrieves the severity of the rule: error, warning or information.
         /// </summary>
         /// <returns></returns>
         public RuleSeverity GetSeverity()

--- a/Rules/ScriptAnalyzerBuiltinRules.csproj
+++ b/Rules/ScriptAnalyzerBuiltinRules.csproj
@@ -68,6 +68,7 @@
     <Compile Include="AvoidUsingPlainTextForPassword.cs" />
     <Compile Include="AvoidUsingWMIObjectCmdlet.cs" />
     <Compile Include="AvoidUsingWriteHost.cs" />
+    <Compile Include="DscExamplesPresent.cs" />
     <Compile Include="UseOutputTypeCorrectly.cs" />
     <Compile Include="MissingModuleManifestField.cs" />
     <Compile Include="PossibleIncorrectComparisonWithNull.cs" />

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -853,6 +853,15 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No examples found for resource &apos;{0}&apos;.
+        /// </summary>
+        internal static string DscExamplesPresentNoExamplesError {
+            get {
+                return ResourceManager.GetString("DscExamplesPresentNoExamplesError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to PSDSC.
         /// </summary>
         internal static string DSCSourceName {

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -826,6 +826,33 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to DscExamplesPresent.
+        /// </summary>
+        internal static string DscExamplesPresent {
+            get {
+                return ResourceManager.GetString("DscExamplesPresent", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to DSC examples are present.
+        /// </summary>
+        internal static string DscExamplesPresentCommonName {
+            get {
+                return ResourceManager.GetString("DscExamplesPresentCommonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Every DSC resource module should contain folder &quot;Examples&quot; with sample configurations for every resource. Sample configurations should have resource name they are demonstrating in the title..
+        /// </summary>
+        internal static string DscExamplesPresentDescription {
+            get {
+                return ResourceManager.GetString("DscExamplesPresentDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to PSDSC.
         /// </summary>
         internal static string DSCSourceName {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -699,4 +699,7 @@
   <data name="DscExamplesPresentDescription" xml:space="preserve">
     <value>Every DSC resource module should contain folder "Examples" with sample configurations for every resource. Sample configurations should have resource name they are demonstrating in the title.</value>
   </data>
+  <data name="DscExamplesPresentNoExamplesError" xml:space="preserve">
+    <value>No examples found for resource '{0}'</value>
+  </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -690,4 +690,13 @@
   <data name="UseOutputTypeCorrectlyName" xml:space="preserve">
     <value>UseOutputTypeCorrectly</value>
   </data>
+  <data name="DscExamplesPresent" xml:space="preserve">
+    <value>DscExamplesPresent</value>
+  </data>
+  <data name="DscExamplesPresentCommonName" xml:space="preserve">
+    <value>DSC examples are present</value>
+  </data>
+  <data name="DscExamplesPresentDescription" xml:space="preserve">
+    <value>Every DSC resource module should contain folder "Examples" with sample configurations for every resource. Sample configurations should have resource name they are demonstrating in the title.</value>
+  </data>
 </root>

--- a/Tests/Rules/DscExamplesPresent.tests.ps1
+++ b/Tests/Rules/DscExamplesPresent.tests.ps1
@@ -35,3 +35,36 @@ Describe "DscExamplesPresent rule in class based resource" {
         Remove-Item -Path $examplesPath -Recurse -Force
     }
 }
+
+Describe "DscExamplesPresent rule in regular (non-class) based resource" {
+    
+    $examplesPath = "$currentPath\Examples"
+    $resourcePath = "$currentPath\DSCResources\MSFT_WaitForAll\MSFT_WaitForAll.psm1"
+
+    Context "When examples absent" {
+        
+        $violations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $resourcePath | Where-Object {$_.RuleName -eq $ruleName}
+        $violationMessage = "No examples found for resource 'MSFT_WaitForAll'"
+
+        It "has 1 missing examples violation" {
+            $violations.Count | Should Be 1
+        }
+
+        It "has the correct description message" {
+            $violations[0].Message | Should Match $violationMessage
+        }
+    }
+
+    Context "When examples present" {  
+        New-Item -Path $examplesPath -ItemType Directory
+        New-Item -Path "$examplesPath\MSFT_WaitForAll_Example.psm1" -ItemType File
+
+        $noViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $resourcePath | Where-Object {$_.RuleName -eq $ruleName}
+
+        It "returns no violations" {
+            $noViolations.Count | Should Be 0
+        }
+
+        Remove-Item -Path $examplesPath -Recurse -Force
+    }
+}

--- a/Tests/Rules/DscExamplesPresent.tests.ps1
+++ b/Tests/Rules/DscExamplesPresent.tests.ps1
@@ -1,0 +1,37 @@
+Import-Module -Verbose PSScriptAnalyzer
+
+$currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ruleName = "PSDSCDscExamplesPresent"
+
+Describe "DscExamplesPresent rule in class based resource" {
+    
+    $examplesPath = "$currentPath\DSCResources\MyDscResource\Examples"
+    $classResourcePath = "$currentPath\DSCResources\MyDscResource\MyDscResource.psm1"
+
+    Context "When examples absent" {
+        
+        $violations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $classResourcePath | Where-Object {$_.RuleName -eq $ruleName}
+        $violationMessage = "No examples found for resource 'FileResource'"
+
+        It "has 1 missing examples violation" {
+            $violations.Count | Should Be 1
+        }
+
+        It "has the correct description message" {
+            $violations[0].Message | Should Match $violationMessage
+        }
+    }
+
+    Context "When examples present" {  
+        New-Item -Path $examplesPath -ItemType Directory
+        New-Item -Path "$examplesPath\FileResource_Example.psm1" -ItemType File
+
+        $noViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $classResourcePath | Where-Object {$_.RuleName -eq $ruleName}
+
+        It "returns no violations" {
+            $noViolations.Count | Should Be 0
+        }
+
+        Remove-Item -Path $examplesPath -Recurse -Force
+    }
+}


### PR DESCRIPTION
Adding DscExamplesPresent rule (addressing Issue #84  )
DscExamplesPresent: Checks that DSC examples for given resource are present.
Rule expects directory Examples to be present:
    For non-class based resources it should exist at the same folder level as DSCResources folder.
    For class based resources it should be present at the same folder level as resource psm1 file. 
Examples folder should contain sample configuration for given resource - file name should contain resource's name.
