### PR TITLE
Only Trigger PSProvideVerboseMessage in Advanced Scripts or Functions

### DIFF
--- a/Rules/ProvideVerboseMessage.cs
+++ b/Rules/ProvideVerboseMessage.cs
@@ -12,10 +12,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Management.Automation.Language;
 using Microsoft.Windows.Powershell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
+using System.Management.Automation;
 
 namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
 {
@@ -33,11 +35,11 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
         public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
         {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
-            
+
             ClearList();
             this.AddNames(new List<string>() { "Configuration", "Workflow" });
             DiagnosticRecords.Clear();
-            
+
             this.fileName = fileName;
             //We only check that advanced functions should have Write-Verbose
             ast.Visit(this);
@@ -55,6 +57,17 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
             if (funcAst == null)
             {
                 return AstVisitAction.SkipChildren;
+            }
+
+            //Write-Verbose is not required for non-advanced functions
+            if (funcAst.Body != null && funcAst.Body.ParamBlock != null
+           && funcAst.Body.ParamBlock.Attributes != null &&
+           funcAst.Body.ParamBlock.Parameters != null)
+            {
+                if (!funcAst.Body.ParamBlock.Attributes.Any(attr => attr.TypeName.GetReflectionType() == typeof(CmdletBindingAttribute)))
+                {
+                    return AstVisitAction.Continue;
+                }
             }
 
             var commandAsts = funcAst.Body.FindAll(testAst => testAst is CommandAst, false);


### PR DESCRIPTION
Community rule [OUT-04](https://www.penflip.com/powershellorg/the-community-book-of-powershell-practices/blob/master/out-04-use-cmdletbinding-if-you-are-using-write-debug-or-write-verbose.txt)

The comment on line 44 seems like this was already the intended behavior, but the rule appears to be triggering regardless if [CmdletBinding()] is specified or not.