### PR TITLE
Correct PSAvoidDefaultTrueValueSwitchParameter rule to work with both [switch] and [System.Management.Automation.SwitchParameter] attributes

### DIFF
--- a/Rules/AvoidDefaultTrueValueSwitchParameter.cs
+++ b/Rules/AvoidDefaultTrueValueSwitchParameter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
             // Iterrates all ParamAsts and check if any are switch.
             foreach (ParameterAst paramAst in paramAsts)
             {
-                if (paramAst.Attributes.Any(attr => String.Equals(attr.TypeName.FullName, "switch", StringComparison.OrdinalIgnoreCase))
+                if (paramAst.Attributes.Any(attr => attr.TypeName.FullName.ToLower().Contains("switch"))
                     && paramAst.DefaultValue != null && String.Equals(paramAst.DefaultValue.Extent.Text, "$true", StringComparison.OrdinalIgnoreCase))
                 {
                     yield return new DiagnosticRecord(

--- a/Rules/AvoidDefaultTrueValueSwitchParameter.cs
+++ b/Rules/AvoidDefaultTrueValueSwitchParameter.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
             // Iterrates all ParamAsts and check if any are switch.
             foreach (ParameterAst paramAst in paramAsts)
             {
-                if (paramAst.Attributes.Any(attr => attr.TypeName.FullName.ToLower().Contains("switch"))
+                if (paramAst.Attributes.Any(attr => string.Equals(attr.TypeName.GetReflectionType().FullName, "system.management.automation.switchparameter", StringComparison.OrdinalIgnoreCase))
                     && paramAst.DefaultValue != null && String.Equals(paramAst.DefaultValue.Extent.Text, "$true", StringComparison.OrdinalIgnoreCase))
                 {
                     yield return new DiagnosticRecord(

--- a/Tests/Rules/AvoidDefaultTrueValueSwitchParameter.ps1
+++ b/Tests/Rules/AvoidDefaultTrueValueSwitchParameter.ps1
@@ -13,7 +13,11 @@
 
         # Param2 help description
         [switch]
-        $switch=$true
+        $switch=$true,
+        
+        # Param3 help description
+        [System.Management.Automation.SwitchParameter]
+        $switch2 = $true
     )
 
     Begin

--- a/Tests/Rules/AvoidDefaultTrueValueSwitchParameter.tests.ps1
+++ b/Tests/Rules/AvoidDefaultTrueValueSwitchParameter.tests.ps1
@@ -7,8 +7,8 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidDefaultTrueValueSwitchPara
 
 Describe "AvoidDefaultTrueValueSwitchParameter" {
     Context "When there are violations" {
-        It "has 1 avoid using switch parameter default to true violation" {
-            $violations.Count | Should Be 1
+        It "has 2 avoid using switch parameter default to true violation" {
+            $violations.Count | Should Be 2
         }
 
         It "has the correct description message" {


### PR DESCRIPTION
FIx for #158.

May need to check the rest of the code for other attributes that won't work if using the full name of the type.