### PR TITLE
Suppress PSUseOutputTypeCorrectly warning when function outputs System.Void

### DIFF
--- a/Rules/UseOutputTypeCorrectly.cs
+++ b/Rules/UseOutputTypeCorrectly.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
                     || String.Equals(typeof(Unreached).FullName, typeName, StringComparison.OrdinalIgnoreCase)
                     || String.Equals(typeof(Undetermined).FullName, typeName, StringComparison.OrdinalIgnoreCase)
                     || String.Equals(typeof(object).FullName, typeName, StringComparison.OrdinalIgnoreCase)
+                    || String.Equals(typeof(void).FullName, typeName, StringComparison.OrdinalIgnoreCase)
                     || outputTypes.Contains(typeName, StringComparer.OrdinalIgnoreCase))
                 {
                     continue;

--- a/Tests/Rules/GoodCmdlet.ps1
+++ b/Tests/Rules/GoodCmdlet.ps1
@@ -91,6 +91,7 @@ function Get-File
     {
         if ($pscmdlet.ShouldContinue("Yes", "No")) {
         }
+        [System.Void] $Param3
     }
 }
 


### PR DESCRIPTION
Fixes #157 