### PR TITLE
Fix crash in ScriptRule parsing when PowerShell help system is not initialized on a machine

### DIFF
--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -231,6 +231,12 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                     string script = string.Format(CultureInfo.CurrentCulture, "Get-Module -Name '{0}' -ListAvailable", moduleName);
                     shortModuleName = posh.AddScript(script).Invoke<PSModuleInfo>().First().Name;
 
+                    // Invokes Update-Help for this module
+                    // Required since when invoking Get-Help later on, the cmdlet prompts for Update-Help interactively
+                    // By invoking Update-Help first, Get-Help will not prompt for downloading help later
+                    script = string.Format(CultureInfo.CurrentCulture, "Update-Help -Module '{0}' -Force", shortModuleName);
+                    posh.AddScript(script).Invoke();
+
                     // Invokes Get-Command and Get-Help for each functions in the module.
                     script = string.Format(CultureInfo.CurrentCulture, "Get-Command -Module '{0}'", shortModuleName);
                     var psobjects = posh.AddScript(script).Invoke();

--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -22,6 +22,27 @@ Describe "Test importing customized rules with null return results" {
 }
 
 Describe "Test importing correct customized rules" {
+    
+    Context "Test Get-Help functionality in ScriptRule parsing logic" {
+        It "ScriptRule help section must be correctly processed when Get-Help is called for the first time" {
+            
+            # Force Get-Help to prompt for interactive input to download help using Update-Help
+            # By removing this registry key we force to turn on Get-Help interactivity logic during ScriptRule parsing
+            $null,"Wow6432Node" | ForEach-Object {
+                try
+                {
+                    Remove-ItemProperty -Name "DisablePromptToUpdateHelp" -Path "HKLM:\SOFTWARE\$($_)\Microsoft\PowerShell" -ErrorAction Stop
+                } catch {
+                    #Ignore for cases when tests are running in non-elevated more or registry key does not exist or not accessible
+                }
+            }
+
+            $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.Message -eq $message}
+            $customizedRulePath.Count | Should Be 1
+        }
+       
+    }
+
     Context "Test Get-ScriptAnalyzer with customized rules" {
         It "will show the customized rule" {
             $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.RuleName -eq $measure}


### PR DESCRIPTION
Verified the fix in elevated/non-elevated environment with/without help system initialization