### PR TITLE
Optimize dsc class interface invocations

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -129,8 +129,8 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
         #region Private Members
 
         Dictionary<string, List<string>> validationResults = new Dictionary<string, List<string>>();
-        private ScriptBlockAst ast                         = null;
-        private IEnumerable<IRule> rules                   = null;
+        private ScriptBlockAst ast = null;
+        private IEnumerable<IRule> rules = null;
 
         #endregion
 
@@ -163,9 +163,9 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             }
             else
             {
-                validationResults.Add("InvalidPaths",  new List<string>());
+                validationResults.Add("InvalidPaths", new List<string>());
                 validationResults.Add("ValidModPaths", new List<string>());
-                validationResults.Add("ValidDllPaths", new List<string>());                 
+                validationResults.Add("ValidDllPaths", new List<string>());
             }
 
             #endregion
@@ -174,7 +174,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
 
             try
             {
-                if (validationResults["ValidDllPaths"].Count == 0 && 
+                if (validationResults["ValidDllPaths"].Count == 0 &&
                     validationResults["ValidModPaths"].Count == 0)
                 {
                     ScriptAnalyzer.Instance.Initialize();
@@ -185,7 +185,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                 }
             }
             catch (Exception ex)
-            {  
+            {
                 ThrowTerminatingError(new ErrorRecord(ex, ex.HResult.ToString("X", CultureInfo.CurrentCulture),
                     ErrorCategory.NotSpecified, this));
             }
@@ -228,8 +228,8 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
 
             if (path == null)
             {
-                ThrowTerminatingError(new ErrorRecord(new FileNotFoundException(), 
-                    string.Format(CultureInfo.CurrentCulture, Strings.FileNotFound, path), 
+                ThrowTerminatingError(new ErrorRecord(new FileNotFoundException(),
+                    string.Format(CultureInfo.CurrentCulture, Strings.FileNotFound, path),
                     ErrorCategory.InvalidArgument, this));
             }
 
@@ -315,11 +315,11 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             else
             {
                 ThrowTerminatingError(new ErrorRecord(new FileNotFoundException(),
-                    string.Format(CultureInfo.CurrentCulture, Strings.InvalidPath, filePath), 
+                    string.Format(CultureInfo.CurrentCulture, Strings.InvalidPath, filePath),
                     ErrorCategory.InvalidArgument, filePath));
             }
 
-             if (errors != null && errors.Length > 0)
+            if (errors != null && errors.Length > 0)
             {
                 foreach (ParseError error in errors)
                 {
@@ -362,7 +362,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             #region Run ScriptRules
             //Trim down to the leaf element of the filePath and pass it to Diagnostic Record
             string fileName = System.IO.Path.GetFileName(filePath);
-           
+
             if (ScriptAnalyzer.Instance.ScriptRules != null)
             {
                 foreach (IScriptRule scriptRule in ScriptAnalyzer.Instance.ScriptRules)
@@ -433,7 +433,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                             break;
                         }
                     }
-                    if ((includeRule == null || includeRegexMatch) && (excludeRule == null  || !excludeRegexMatch))
+                    if ((includeRule == null || includeRegexMatch) && (excludeRule == null || !excludeRegexMatch))
                     {
                         WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, tokenRule.GetName()));
 
@@ -448,7 +448,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                         catch (Exception tokenRuleException)
                         {
                             WriteError(new ErrorRecord(tokenRuleException, Strings.RuleErrorMessage, ErrorCategory.InvalidOperation, fileName));
-                        } 
+                        }
                     }
                 }
             }
@@ -458,46 +458,50 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
             #region DSC Resource Rules
             if (ScriptAnalyzer.Instance.DSCResourceRules != null)
             {
-                // Run DSC Class rule
-                foreach (IDSCResourceRule dscResourceRule in ScriptAnalyzer.Instance.DSCResourceRules)
+                // Invoke AnalyzeDSCClass only if the ast is a class based resource
+                if (Helper.Instance.IsDscResourceClassBased(ast))
                 {
-                    bool includeRegexMatch = false;
-                    bool excludeRegexMatch = false;
-
-                    foreach (Regex include in includeRegexList)
+                    // Run DSC Class rule
+                    foreach (IDSCResourceRule dscResourceRule in ScriptAnalyzer.Instance.DSCResourceRules)
                     {
-                        if (include.IsMatch(dscResourceRule.GetName()))
-                        {
-                            includeRegexMatch = true;
-                            break;
-                        }
-                    }
+                        bool includeRegexMatch = false;
+                        bool excludeRegexMatch = false;
 
-                    foreach (Regex exclude in excludeRegexList)
-                    {
-                        if (exclude.IsMatch(dscResourceRule.GetName()))
+                        foreach (Regex include in includeRegexList)
                         {
-                            excludeRegexMatch = true;
-                            break;
+                            if (include.IsMatch(dscResourceRule.GetName()))
+                            {
+                                includeRegexMatch = true;
+                                break;
+                            }
                         }
-                    }
 
-                    if ((includeRule == null || includeRegexMatch) && (excludeRule == null || excludeRegexMatch))
-                    {
-                        WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, dscResourceRule.GetName()));
-
-                        // Ensure that any unhandled errors from Rules are converted to non-terminating errors
-                        // We want the Engine to continue functioning even if one or more Rules throws an exception
-                        try
+                        foreach (Regex exclude in excludeRegexList)
                         {
-                            var records = Helper.Instance.SuppressRule(dscResourceRule.GetName(), ruleSuppressions, dscResourceRule.AnalyzeDSCClass(ast, filePath).ToList());
-                            diagnostics.AddRange(records.Item2);
-                            suppressed.AddRange(records.Item1);
+                            if (exclude.IsMatch(dscResourceRule.GetName()))
+                            {
+                                excludeRegexMatch = true;
+                                break;
+                            }
                         }
-                        catch (Exception dscResourceRuleException)
+
+                        if ((includeRule == null || includeRegexMatch) && (excludeRule == null || excludeRegexMatch))
                         {
-                            WriteError(new ErrorRecord(dscResourceRuleException, Strings.RuleErrorMessage, ErrorCategory.InvalidOperation, filePath));
-                        }    
+                            WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, dscResourceRule.GetName()));
+
+                            // Ensure that any unhandled errors from Rules are converted to non-terminating errors
+                            // We want the Engine to continue functioning even if one or more Rules throws an exception
+                            try
+                            {
+                                var records = Helper.Instance.SuppressRule(dscResourceRule.GetName(), ruleSuppressions, dscResourceRule.AnalyzeDSCClass(ast, filePath).ToList());
+                                diagnostics.AddRange(records.Item2);
+                                suppressed.AddRange(records.Item1);
+                            }
+                            catch (Exception dscResourceRuleException)
+                            {
+                                WriteError(new ErrorRecord(dscResourceRuleException, Strings.RuleErrorMessage, ErrorCategory.InvalidOperation, filePath));
+                            }
+                        }
                     }
                 }
 
@@ -543,7 +547,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.Commands
                         }
                     }
 
-                }         
+                }
             }
             #endregion
 

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
         /// <summary>
         /// Given an AST, checks whether dsc resource is class based or not
         /// </summary>
-        /// <param name="fileName"></param>
+        /// <param name="ast"></param>
         /// <returns></returns>
         public bool IsDscResourceClassBased(ScriptBlockAst ast)
         {

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -192,6 +192,35 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
         }
 
         /// <summary>
+        /// Given an AST, checks whether dsc resource is class based or not
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <returns></returns>
+        public bool IsDscResourceClassBased(ScriptBlockAst ast)
+        {
+            if (null == ast)
+            {
+                return false;
+            }
+
+            List<string> dscResourceFunctionNames = new List<string>(new string[] { "Test", "Get", "Set" });
+
+            IEnumerable<Ast> dscClasses = ast.FindAll(item =>
+                item is TypeDefinitionAst
+                && ((item as TypeDefinitionAst).IsClass)
+                && (item as TypeDefinitionAst).Attributes.Any(attr => String.Equals("DSCResource", attr.TypeName.FullName, StringComparison.OrdinalIgnoreCase)), true);
+
+            // Found one or more classes marked with DscResource attribute
+            // So this might be a DscResource. Further validation will be performed by the individual rules
+            if (null != dscClasses && 0 < dscClasses.Count())
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Given a commandast, checks whether positional parameters are used or not.
         /// </summary>
         /// <param name="cmdAst"></param>
@@ -280,7 +309,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
         /// <param name="name"></param>
         /// <param name="commandType"></param>
         /// <returns></returns>
-        public CommandInfo GetCommandInfo(string name, CommandTypes commandType=CommandTypes.All)
+        public CommandInfo GetCommandInfo(string name, CommandTypes commandType = CommandTypes.All)
         {
             return Helper.Instance.MyCmdlet.InvokeCommand.GetCommand(name, commandType);
         }
@@ -294,7 +323,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
         {
             List<string> resourceFunctionNames = new List<string>(new string[] { "Set-TargetResource", "Get-TargetResource", "Test-TargetResource" });
             return ast.FindAll(item => item is FunctionDefinitionAst
-                && resourceFunctionNames.Contains((item as FunctionDefinitionAst).Name, StringComparer.OrdinalIgnoreCase), true);            
+                && resourceFunctionNames.Contains((item as FunctionDefinitionAst).Name, StringComparer.OrdinalIgnoreCase), true);
         }
 
         /// <summary>
@@ -481,7 +510,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
             var analysis = VariableAnalysisDictionary[ast];
             return analysis.Exit._predecessors.All(block => block._returns || block._unreachable || block._throws);
         }
-        
+
         /// <summary>
         /// Initialize variable analysis on the script ast
         /// </summary>
@@ -701,7 +730,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
             {
                 ruleSuppressionList.AddRange(RuleSuppression.GetSuppressions(sbAst.ParamBlock.Attributes, sbAst.Extent.StartOffset, sbAst.Extent.EndOffset, sbAst));
             }
-            
+
             // Get rule suppression from functions
             IEnumerable<FunctionDefinitionAst> funcAsts = ast.FindAll(item => item is FunctionDefinitionAst, true).Cast<FunctionDefinitionAst>();
 
@@ -727,13 +756,13 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
                     List<RuleSuppression> ruleSuppressions = new List<RuleSuppression>();
                     results.Add(ruleSuppression.RuleName, ruleSuppressions);
                 }
-                
+
                 results[ruleSuppression.RuleName].Add(ruleSuppression);
             }
 
             return results;
         }
-        
+
         /// <summary>
         /// Returns a list of rule suppressions from the function
         /// </summary>
@@ -943,11 +972,11 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
             }
         }
     }
-    
+
     /// <summary>
     /// Class used to do variable analysis on the whole script
     /// </summary>
-    public class ScriptAnalysis: ICustomAstVisitor
+    public class ScriptAnalysis : ICustomAstVisitor
     {
         private VariableAnalysis OuterAnalysis;
 
@@ -1148,7 +1177,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
         {
             return null;
         }
-        
+
         /// <summary>
         /// Visits body
         /// </summary>
@@ -2396,7 +2425,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
         {
             return typeof(System.Array).FullName;
         }
-        
+
         /// <summary>
         /// Returns type of array
         /// </summary>
@@ -2499,7 +2528,7 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer
 
             return null;
         }
-        
+
         /// <summary>
         /// Only returns boolean type for unary operator that returns boolean
         /// </summary>


### PR DESCRIPTION
Given a dsc resource, we used to called AnalyzeDSCClass even on non-class based resource.

This fix optimizes the code paths so that we call the class based interface only for resources implemented using classes.

Existing tests already cover testing the invocation of both the interfaces. this change is just a optimization.