### PR TITLE
Fix AvoidUsingPlainTextForPassword raised for types other than strings or object

### DIFF
--- a/Rules/AvoidUsingPlainTextForPassword.cs
+++ b/Rules/AvoidUsingPlainTextForPassword.cs
@@ -55,8 +55,8 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
                     }
                 }
 
-                if (hasPwd && (!paramType.IsArray && paramType != typeof(System.Security.SecureString)
-                              || (paramType.IsArray && paramType.GetElementType() != typeof(System.Security.SecureString))))
+                if (hasPwd && (!paramType.IsArray && (paramType == typeof(String) || paramType == typeof(object)))
+                              || (paramType.IsArray && (paramType.GetElementType() == typeof(String) || paramType.GetElementType() == typeof(object))))
                 {
                     yield return new DiagnosticRecord(
                         String.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPlainTextForPasswordError, paramAst.Name),

--- a/Tests/Rules/AvoidUsingPlainTextForPasswordNoViolations.ps1
+++ b/Tests/Rules/AvoidUsingPlainTextForPasswordNoViolations.ps1
@@ -10,7 +10,8 @@
                    ValueFromPipelineByPropertyName=$true,
                    Position=0)]
         $Param1,
-
+        [int]
+        $passwordinteger,
         # Param2 help description
         [int]
         $Param2,


### PR DESCRIPTION
Only raise this rule if the parameter is of type string or object