### PR TITLE
Fix use declared vars more than assignment

### DIFF
--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -49,11 +49,12 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
             {
                 foreach (AssignmentStatementAst assignmentAst in assignmentAsts)
                 {
-                    assingmentVarAsts = assignmentAst.Left.FindAll(testAst => testAst is VariableExpressionAst, true); ;
+                    // Only checks for the case where lhs is a variable. Ignore things like $foo.property
+                    VariableExpressionAst assignmentVarAst = assignmentAst.Left as VariableExpressionAst;
 
-                    foreach (VariableExpressionAst assignmentVarAst in assingmentVarAsts)
+                    if (assignmentVarAst != null)
                     {
-                         //Ignore if variable is global or environment variable
+                        //Ignore if variable is global or environment variable
                         if (!Helper.Instance.IsVariableGlobalOrEnvironment(assignmentVarAst, ast)
                             && !assignmentVarAst.VariablePath.IsScript)
                         {

--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -54,7 +54,8 @@ namespace Microsoft.Windows.Powershell.ScriptAnalyzer.BuiltinRules
                     foreach (VariableExpressionAst assignmentVarAst in assingmentVarAsts)
                     {
                          //Ignore if variable is global or environment variable
-                        if (!Helper.Instance.IsVariableGlobalOrEnvironment(assignmentVarAst, ast))
+                        if (!Helper.Instance.IsVariableGlobalOrEnvironment(assignmentVarAst, ast)
+                            && !assignmentVarAst.VariablePath.IsScript)
                         {
                             if (!assignments.ContainsKey(assignmentVarAst.VariablePath.UserPath))
                             {

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignmentsNoViolations.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignmentsNoViolations.ps1
@@ -1,3 +1,4 @@
 ﻿$declaredVars = "Declared Vars"
 Write-Ouput $declaredVars
 $script:thisshouldnotraiseerrors = "this should not raise errors"
+$foo.property = "This also should not raise errors"

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignmentsNoViolations.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignmentsNoViolations.ps1
@@ -1,2 +1,3 @@
 ﻿$declaredVars = "Declared Vars"
 Write-Ouput $declaredVars
+$script:thisshouldnotraiseerrors = "this should not raise errors"


### PR DESCRIPTION
Fix this rule being raised for script variables and for setting the property of a variable.