### PR TITLE
Fix Splatted Variable and Pipeline bug in UseCmdletCorrectly and AvoidUsingPositionalParameter

### DIFF
--- a/Rules/AvoidPositionalParameters.cs
+++ b/Rules/AvoidPositionalParameters.cs
@@ -47,8 +47,23 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 if (Helper.Instance.GetCommandInfo(cmdAst.GetCommandName()) != null
                     && Helper.Instance.PositionalParameterUsed(cmdAst))
                 {
-                    yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPositionalParametersError, cmdAst.GetCommandName()),
-                        cmdAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName, cmdAst.GetCommandName());
+                    PipelineAst parent = cmdAst.Parent as PipelineAst;
+
+                    if (parent != null && parent.PipelineElements.Count > 1)
+                    {
+                        // raise if it's the first element in pipeline. otherwise no.
+                        if (parent.PipelineElements[0] == cmdAst)
+                        {
+                            yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPositionalParametersError, cmdAst.GetCommandName()),
+                                cmdAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName, cmdAst.GetCommandName());
+                        }
+                    }
+                    // not in pipeline so just raise it normally
+                    else
+                    {
+                        yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPositionalParametersError, cmdAst.GetCommandName()),
+                            cmdAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName, cmdAst.GetCommandName());
+                    }
                 }
             }
         }

--- a/Rules/UseCmdletCorrectly.cs
+++ b/Rules/UseCmdletCorrectly.cs
@@ -92,6 +92,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return true;
             }
 
+            // ignores if splatted variable is used
+            if (Helper.Instance.HasSplattedVariable(cmdAst))
+            {
+                return true;
+            }
+
             // Gets parameters from command elements.
             ceAsts = cmdAst.CommandElements.Where<CommandElementAst>(foundParamASTs);
 

--- a/Tests/Rules/GoodCmdlet.ps1
+++ b/Tests/Rules/GoodCmdlet.ps1
@@ -85,6 +85,12 @@ function Get-File
             $a
         }
 
+        $a | Write-Warning
+
+        $b = @{"hash"="table"}
+
+        Write-Debug @b
+
         return @{"hash"="true"}
     }
     End

--- a/Tests/Rules/UseCmdletCorrectly.ps1
+++ b/Tests/Rules/UseCmdletCorrectly.ps1
@@ -2,4 +2,4 @@
 Wrong-Cmd
 Write-Verbose -Message "Write Verbose"
 Write-Verbose "Warning" -OutVariable $test
-Write-Verbose "Warning"
+Write-Verbose "Warning" | PipeLineCmdlet


### PR DESCRIPTION
Using Pipeline and Splatted variable will no longer result in errors in these cmdlets.