### PR TITLE
Fix false positive for UsingInternalURL

### DIFF
--- a/Rules/AvoidUsingInternalURLs.cs
+++ b/Rules/AvoidUsingInternalURLs.cs
@@ -11,8 +11,10 @@
 //
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Management.Automation.Language;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
@@ -44,8 +46,19 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 foreach (StringConstantExpressionAst expressionAst in expressionAsts)
                 {
-                    //Check if XPath is used. If XPath is used, then we don't throw warnings.
+                    
                     Ast parentAst = expressionAst.Parent;
+                    //Check if -replace is used, if it is string replace, we don't throw warnings.
+                    Ast grandParentAst = parentAst.Parent;
+                    if (grandParentAst is BinaryExpressionAst)
+                    {
+                        if ((grandParentAst as BinaryExpressionAst).Operator.Equals(TokenKind.Ireplace))
+                        {
+                            continue;
+                        }
+                    }
+
+                    //Check if XPath is used. If XPath is used, then we don't throw warnings.
                     if (parentAst is InvokeMemberExpressionAst)
                     {
                         InvokeMemberExpressionAst invocation = parentAst as InvokeMemberExpressionAst;
@@ -55,7 +68,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 String.Equals(invocation.Member.ToString(), "SelectNodes",StringComparison.OrdinalIgnoreCase) ||
                                 String.Equals(invocation.Member.ToString(), "Select", StringComparison.OrdinalIgnoreCase) ||
                                 String.Equals(invocation.Member.ToString(), "Evaluate",StringComparison.OrdinalIgnoreCase) ||
-                                String.Equals(invocation.Member.ToString(), "Matches",StringComparison.OrdinalIgnoreCase))
+                                String.Equals(invocation.Member.ToString(), "Matches",StringComparison.OrdinalIgnoreCase) ||
+                                String.Equals(invocation.Expression.ToString(), "[System.String]",StringComparison.OrdinalIgnoreCase) ||
+                                String.Equals(invocation.Expression.ToString(), "[String]", StringComparison.OrdinalIgnoreCase))
                             {
                                 continue;
                             }

--- a/Tests/Rules/AvoidUsingInternalURLsNoViolations.ps1
+++ b/Tests/Rules/AvoidUsingInternalURLsNoViolations.ps1
@@ -6,3 +6,5 @@ function Test
 	$filesNode = $infoXml.SelectSingleNode("//files")
 }
 $sd = "O:BAG:BAD:(A;;0x800;;;WD)(A;;0x120fff;;;SY)(A;;0x120fff;;;LS)(A;;0x120fff;;;NS)(A;;0x120fff;;;BA)(A;;0xee5;;;LU)(A;;LC;;;MU)(A;;0x800;;;AG)"
+$msg = [System.String]::Format("1:{0}", "test")
+ $internalId = $Id -replace '^([^/])','/$1' -as $Id.GetType()


### PR DESCRIPTION
Add check if -replace is used and check if invocation expression is
[String] or [System.String]. This is to address issue #198 