### PR TITLE
PSAvoidUsingPositionalParameters should not be applied to external applications

### DIFF
--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// <param name="name"></param>
         /// <param name="commandType"></param>
         /// <returns></returns>
-        public CommandInfo GetCommandInfo(string name, CommandTypes commandType = CommandTypes.All)
+        public CommandInfo GetCommandInfo(string name, CommandTypes commandType = CommandTypes.Alias | CommandTypes.Cmdlet | CommandTypes.Configuration | CommandTypes.ExternalScript | CommandTypes.Filter | CommandTypes.Function | CommandTypes.Script | CommandTypes.Workflow)
         {
             return Helper.Instance.MyCmdlet.InvokeCommand.GetCommand(name, commandType);
         }

--- a/Tests/Rules/AvoidPositionalParametersNoViolations.ps1
+++ b/Tests/Rules/AvoidPositionalParametersNoViolations.ps1
@@ -5,3 +5,12 @@ Split-Path -Path "Random" -leaf
 Get-Process | Where-Object {$_.handles -gt 200}
 get-service-computername localhost | where {($_.status -eq "Running") -and ($_.CanStop -eq $true)}
 1, 2, $null, 4 | ForEach-Object {"Hello"}
+& "$env:Windir\System32\Calc.exe" Parameter1 Parameter2
+
+# There was a bug in Positional Parameter rule that resulted in the rule being fired 
+# when using external application with absolute paths
+# The below function is to validate the fix - rule must not get triggered
+function TestExternalApplication
+{    
+    & "c:\Windows\System32\Calc.exe" parameter1
+}


### PR DESCRIPTION
Fix for https://github.com/PowerShell/PSScriptAnalyzer/issues/266

