### PR TITLE
Handle assembly loading errors at composition time

### DIFF
--- a/Engine/SafeDirectoryCatalog.cs
+++ b/Engine/SafeDirectoryCatalog.cs
@@ -1,0 +1,74 @@
+﻿//
+// Copyright (c) Microsoft Corporation.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.ComponentModel.Composition;
+using System.ComponentModel.Composition.Hosting;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
+{
+    /// <summary>
+    /// Provides a simple DirectoryCatalog implementation that doesn't
+    /// fail assembly loading when it encounters a ReflectionTypeLoadException.
+    /// The default DirectoryCatalog implementation stops evaluating any
+    /// remaining assemblies in the directory if one of these exceptions
+    /// are encountered.
+    /// </summary>
+    internal class SafeDirectoryCatalog : AggregateCatalog
+    {
+        public SafeDirectoryCatalog(string folderLocation, IOutputWriter outputWriter)
+        {
+            if (outputWriter == null)
+            {
+                throw new ArgumentNullException("outputWriter");
+            }
+
+            // Make sure the directory actually exists
+            var directoryInfo = new DirectoryInfo(folderLocation);
+            if (directoryInfo.Exists == false)
+            {
+                throw new CompositionException(
+                    "The specified folder does not exist: " + directoryInfo.FullName);
+            }
+
+            // Load each DLL found in the directory
+            foreach (var dllFile in directoryInfo.GetFileSystemInfos("*.dll"))
+            {
+                try
+                {
+                    // Attempt to create an AssemblyCatalog for this DLL
+                    var assemblyCatalog =
+                        new AssemblyCatalog(
+                            Assembly.LoadFile(
+                                dllFile.FullName));
+
+                    // We must call ToArray here to pre-initialize the Parts
+                    // IEnumerable and cause it to be stored.  The result is
+                    // not used here because it will be accessed later once
+                    // the composition container starts assembling parts.
+                    assemblyCatalog.Parts.ToArray();
+
+                    this.Catalogs.Add(assemblyCatalog);
+                }
+                catch (ReflectionTypeLoadException e)
+                {
+                    // Write out the exception details and allow the
+                    // loading process to continue
+                    outputWriter.WriteWarning(e.ToString());
+                }
+            }
+        }
+    }
+}

--- a/Engine/ScriptAnalyzerEngine.csproj
+++ b/Engine/ScriptAnalyzerEngine.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Helper.cs" />
     <Compile Include="IOutputWriter.cs" />
     <Compile Include="Loggers\WriteObjectsLogger.cs" />
+    <Compile Include="SafeDirectoryCatalog.cs" />
     <Compile Include="ScriptAnalyzer.cs" />
     <Compile Include="SpecialVars.cs" />
     <Compile Include="Strings.Designer.cs">


### PR DESCRIPTION
The default implementation of MEF's DirectoryCatalog does not
handle ReflectionTypeLoadExceptions that occur when assemblies
in the specified directory are loaded.  This causes the full
assembly loading process to stop, meaning that no rules will
be found.  When running Script Analyzer in a folder with a lot
of DLLs, this type of error becomes more likely.  This change
introduces a new SafeDirectoryCatalog type which is more
resilient to this problem.

Also, there is a check that determines whether any rules have
been loaded before continuing.  This check was prone to throwing
NullReferenceExceptions when MEF composition fails.  I changed
that logic to be more resilient to potential null values.