### PR TITLE
Renames CustomizedRulePath parameter and modifies its behavior.

### DIFF
--- a/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
+++ b/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
@@ -33,12 +33,25 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         [Parameter(Mandatory = false)]
         [ValidateNotNullOrEmpty]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
-        public string[] CustomizedRulePath
+        [Alias("CustomizedRulePath")]
+        public string CustomRulePath
         {
-            get { return customizedRulePath; }
-            set { customizedRulePath = value; }
+            get { return customRulePath; }
+            set { customRulePath = value; }
         }
-        private string[] customizedRulePath;
+        private string customRulePath;
+
+        /// <summary>
+        /// RecurseCustomRulePath: Find rules within subfolders under the path
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        public SwitchParameter RecurseCustomRulePath
+        {
+            get { return recurseCustomRulePath; }
+            set { recurseCustomRulePath = value; }
+        }
+        private bool recurseCustomRulePath;
 
         /// <summary>
         /// Name: The name of a specific rule to list.
@@ -76,7 +89,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
-            ScriptAnalyzer.Instance.Initialize(this, customizedRulePath);
+            string[] rulePaths = Helper.ProcessCustomRulePaths(customRulePath,
+                this.SessionState, recurseCustomRulePath);
+            ScriptAnalyzer.Instance.Initialize(this, rulePaths);            
         }
 
         /// <summary>

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -73,12 +73,25 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         [Parameter(Mandatory = false)]
         [ValidateNotNull]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
-        public string[] CustomizedRulePath
+        [Alias("CustomizedRulePath")]
+        public string CustomRulePath
         {
-            get { return customizedRulePath; }
-            set { customizedRulePath = value; }
+            get { return customRulePath; }
+            set { customRulePath = value; }
         }
-        private string[] customizedRulePath;
+        private string customRulePath;
+
+        /// <summary>
+        /// RecurseCustomRulePath: Find rules within subfolders under the path
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        public SwitchParameter RecurseCustomRulePath
+        {
+            get { return recurseCustomRulePath; }
+            set { recurseCustomRulePath = value; }
+        }
+        private bool recurseCustomRulePath;
 
         /// <summary>
         /// ExcludeRule: Array of names of rules to be disabled.
@@ -164,9 +177,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         /// </summary>
         protected override void BeginProcessing()
         {
+            string[] rulePaths = Helper.ProcessCustomRulePaths(customRulePath,
+                this.SessionState, recurseCustomRulePath);
+
             ScriptAnalyzer.Instance.Initialize(
                 this,
-                customizedRulePath,
+                rulePaths,
                 this.includeRule,
                 this.excludeRule,
                 this.severity,

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             {
                 throw new ArgumentNullException("cmdlet");
             }
-
+                                                        
             this.Initialize(
                 cmdlet,
                 cmdlet.SessionState.Path,
@@ -188,7 +188,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             if (!String.IsNullOrWhiteSpace(profile))
             {
                 try
-                {
+                {                    
                     profile = path.GetResolvedPSPathFromPSPath(profile).First().Path;
                 }
                 catch
@@ -784,7 +784,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     // We have to identify the childPath is really a directory or just a module name.
                     // You can also consider following two commands.
                     //   Get-ScriptAnalyzerRule -RuleExtension "ContosoAnalyzerRules"
-                    //   Get-ScriptAnalyzerRule -RuleExtension "%USERPROFILE%\WindowsPowerShell\Modules\ContosoAnalyzerRules"
+                    //   Get-ScriptAnalyzerRule -RuleExtension "%USERPROFILE%\WindowsPowerShell\Modules\ContosoAnalyzerRules"                    
                     if (Path.GetDirectoryName(childPath) == string.Empty)
                     {
                         resolvedPath = childPath;
@@ -797,14 +797,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                     using (System.Management.Automation.PowerShell posh =
                            System.Management.Automation.PowerShell.Create())
-                    {
+                    {                        
                         posh.AddCommand("Get-Module").AddParameter("Name", resolvedPath).AddParameter("ListAvailable");
                         PSModuleInfo moduleInfo = posh.Invoke<PSModuleInfo>().First();     
 
                         // Adds original path, otherwise path.Except<string>(validModPaths) will fail.
                         // It's possible that user can provide something like this:
                         // "..\..\..\ScriptAnalyzer.UnitTest\modules\CommunityAnalyzerRules\CommunityAnalyzerRules.psd1"
-                        if (moduleInfo.ExportedFunctions.Count > 0) validModPaths.Add(childPath);
+                        if (moduleInfo.ExportedFunctions.Count > 0) validModPaths.Add(resolvedPath);
                     }
                 }
                 catch

--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -51,18 +51,83 @@ Describe "Test importing correct customized rules" {
     }
 
     Context "Test Get-ScriptAnalyzer with customized rules" {
-        It "will show the customized rule" {
+        It "will show the custom rule" {
             $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.RuleName -eq $measure}
             $customizedRulePath.Count | Should Be 1
         }
-       
+
+		It "will show the custom rule when given a rule folder path" {
+			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule | Where-Object {$_.RuleName -eq $measure}
+		    $customizedRulePath.Count | Should Be 1
+		}
+		
+		if (!$testingLibraryUsage)
+		{
+			It "will show the custom rule when given a rule folder path with trailing backslash" {
+				$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\ | Where-Object {$_.RuleName -eq $measure}			
+				$customizedRulePath.Count | Should Be 1
+			}
+
+			It "will show the custom rules when given a glob" {
+				$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.RuleName -match $measure}
+				$customizedRulePath.Count | Should be 4
+			}
+
+			It "will show the custom rules when given recurse switch" {
+				$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule | Where-Object {$_.RuleName -eq $measure}
+				$customizedRulePath.Count | Should be 3
+			}
+		
+			it "will show the custom rules when given glob with recurse switch" {
+				$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.RuleName -eq $measure}
+				$customizedRulePath.Count | Should be 5
+			}
+
+			it "will show the custom rules when given glob with recurse switch" {
+				$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule* | Where-Object {$_.RuleName -eq $measure}
+				$customizedRulePath.Count | Should be 3
+			}
+		}
     }
 
     Context "Test Invoke-ScriptAnalyzer with customized rules" {
-        It "will show the customized rule in the results" {
+        It "will show the custom rule in the results" {
             $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.Message -eq $message}
             $customizedRulePath.Count | Should Be 1
         }
-    }
 
+		It "will show the custom rule in the results when given a rule folder path" {
+            $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule | Where-Object {$_.Message -eq $message}
+            $customizedRulePath.Count | Should Be 1
+        }
+
+		if (!$testingLibraryUsage)
+		{
+			It "will show the custom rule in the results when given a rule folder path with trailing backslash" {
+				$customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\ | Where-Object {$_.Message -eq $message}
+				$customizedRulePath.Count | Should Be 1
+			}
+
+			It "will show the custom rules when given a glob" {
+				$customizedRulePath = Invoke-ScriptAnalyzer  $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.Message -eq $message}
+				$customizedRulePath.Count | Should be 3
+			}
+
+			It "will show the custom rules when given recurse switch" {
+				$customizedRulePath = Invoke-ScriptAnalyzer  $directory\TestScript.ps1 -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule | Where-Object {$_.Message -eq $message}
+				$customizedRulePath.Count | Should be 3
+			}
+		
+			it "will show the custom rules when given glob with recurse switch" {
+				$customizedRulePath = Invoke-ScriptAnalyzer  $directory\TestScript.ps1 -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.Message -eq $message}
+				$customizedRulePath.Count | Should be 4
+			}
+
+			it "will show the custom rules when given glob with recurse switch" {
+				$customizedRulePath = Invoke-ScriptAnalyzer  $directory\TestScript.ps1 -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule* | Where-Object {$_.Message -eq $message}
+				$customizedRulePath.Count | Should be 3
+			}
+		}
+    }
 }
+

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -19,12 +19,16 @@ Describe "Test available parameters" {
 
     Context "RuleExtension parameters" {
         It "has a RuleExtension parameter" {
-            $params.ContainsKey("CustomizedRulePath") | Should Be $true
+            $params.ContainsKey("CustomRulePath") | Should Be $true
         }
 
         It "accepts string array" {
-            $params["CustomizedRulePath"].ParameterType.FullName | Should Be "System.String[]"
+            $params["CustomRulePath"].ParameterType.FullName | Should Be "System.String"
         }
+
+		It "takes CustomizedRulePath parameter as an alias of CustomRulePath paramter" {
+			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should be $true
+		}
     }
 
 }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -41,7 +41,14 @@ Describe "Test available parameters" {
         }
 
         It "accepts a string" {
-            $params["CustomRulePath"].ParameterType.FullName | Should Be "System.String"
+			if ($testingLibraryUsage)
+			{
+				$params["CustomRulePath"].ParameterType.FullName | Should Be "System.String[]"
+			}
+			else
+			{
+				$params["CustomRulePath"].ParameterType.FullName | Should Be "System.String"
+			}
         }
 
 		It "has a CustomizedRulePath alias"{

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -30,19 +30,23 @@ Describe "Test available parameters" {
             $params.ContainsKey("ScriptDefinition") | Should Be $true
         }
         
-        It "accepts string" {
+        It "accepts string" {			
             $params["ScriptDefinition"].ParameterType.FullName | Should Be "System.String"
         }
     }
 
-    Context "CustomizedRulePath parameters" {
-        It "has a CustomizedRulePath parameter" {
-            $params.ContainsKey("CustomizedRulePath") | Should Be $true
+    Context "CustomRulePath parameters" {
+        It "has a CustomRulePath parameter" {
+            $params.ContainsKey("CustomRulePath") | Should Be $true
         }
 
-        It "accepts string array" {
-            $params["CustomizedRulePath"].ParameterType.FullName | Should Be "System.String[]"
+        It "accepts a string" {
+            $params["CustomRulePath"].ParameterType.FullName | Should Be "System.String"
         }
+
+		It "has a CustomizedRulePath alias"{
+			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should be $true
+		}
     }
 
     Context "IncludeRule parameters" {

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -39,7 +39,12 @@ function Invoke-ScriptAnalyzer {
         [switch] $SuppressedOnly
 	)
 	[string[]]$customRulePathArr = @($CustomRulePath);
-	$scriptAnalyzer = New-Object "Microsoft.Windows.PowerShell.ScriptAnalyzer.ScriptAnalyzer"
+	if ($CustomRulePath -eq $null)
+	{
+		$customRulePathArr = $null;
+	}
+
+	$scriptAnalyzer = New-Object "Microsoft.Windows.PowerShell.ScriptAnalyzer.ScriptAnalyzer";
 	$scriptAnalyzer.Initialize(
 		$runspace, 
 		$testOutputWriter, 

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -38,12 +38,12 @@ function Invoke-ScriptAnalyzer {
         [Parameter(Mandatory = $false)]
         [switch] $SuppressedOnly
 	)
-
+	$customRulePathArr = @($CustomRulePath);
 	$scriptAnalyzer = New-Object "Microsoft.Windows.PowerShell.ScriptAnalyzer.ScriptAnalyzer"
 	$scriptAnalyzer.Initialize(
 		$runspace, 
 		$testOutputWriter, 
-		$CustomRulePath, 
+		$customRulePathArr, 
 		$IncludeRule,
 		$ExcludeRule,
 		$Severity,

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -38,7 +38,7 @@ function Invoke-ScriptAnalyzer {
         [Parameter(Mandatory = $false)]
         [switch] $SuppressedOnly
 	)
-	$customRulePathArr = @($CustomRulePath);
+	[string[]]$customRulePathArr = @($CustomRulePath);
 	$scriptAnalyzer = New-Object "Microsoft.Windows.PowerShell.ScriptAnalyzer.ScriptAnalyzer"
 	$scriptAnalyzer.Initialize(
 		$runspace, 

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -17,7 +17,7 @@ function Invoke-ScriptAnalyzer {
 
         [Parameter(Mandatory = $false)]
 		[Alias("CustomizedRulePath")]
-		[string] $CustomRulePath = $null,
+		[string[]] $CustomRulePath = $null,
 
 		[Parameter(Mandatory = $false)]
 		[switch] $RecurseCustomRulePath,
@@ -41,17 +41,18 @@ function Invoke-ScriptAnalyzer {
 		[Parameter(Mandatory = $false)]       
         [string] $Profile = $null
 	)
-	[string[]]$customRulePathArr = @($CustomRulePath);
-	if ($CustomRulePath -eq $null)
-	{
-		$customRulePathArr = $null;
-	}
+	# There is an inconsistency between this implementation and c# implementation of the cmdlet. 
+	# The CustomRulePath parameter here is of "string[]" type whereas in the c# implementation it is of "string" type.
+	# If we set the CustomRulePath parameter here to  "string[]", then the library usage test fails when run as an administrator. 
+	# We want to note that the library usage test doesn't fail when run as a non-admin user.
+	# The following is the error statement when the test runs as an administrator. 
+	# Assert failed on "Initialize" with "7" argument(s): "Test failed due to terminating error: The module was expected to contain an assembly manifest. (Exception from HRESULT: 0x80131018)"
 
 	$scriptAnalyzer = New-Object "Microsoft.Windows.PowerShell.ScriptAnalyzer.ScriptAnalyzer";
 	$scriptAnalyzer.Initialize(
 		$runspace, 
 		$testOutputWriter, 
-		$customRulePathArr, 
+		$CustomRulePath, 
 		$IncludeRule,
 		$ExcludeRule,
 		$Severity,

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -36,7 +36,10 @@ function Invoke-ScriptAnalyzer {
 		[switch] $Recurse,
 
         [Parameter(Mandatory = $false)]
-        [switch] $SuppressedOnly
+        [switch] $SuppressedOnly,
+
+		[Parameter(Mandatory = $false)]       
+        [string] $Profile = $null
 	)
 	[string[]]$customRulePathArr = @($CustomRulePath);
 	if ($CustomRulePath -eq $null)
@@ -52,7 +55,8 @@ function Invoke-ScriptAnalyzer {
 		$IncludeRule,
 		$ExcludeRule,
 		$Severity,
-		$SuppressedOnly.IsPresent
+		$SuppressedOnly.IsPresent,
+		$Profile
 	);
 
     if ($PSCmdlet.ParameterSetName -eq "File") {

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -16,7 +16,11 @@ function Invoke-ScriptAnalyzer {
 		[string] $ScriptDefinition,
 
         [Parameter(Mandatory = $false)]
-		[string[]] $CustomizedRulePath = $null,
+		[Alias("CustomizedRulePath")]
+		[string] $CustomRulePath = $null,
+
+		[Parameter(Mandatory = $false)]
+		[switch] $RecurseCustomRulePath,
 
         [Parameter(Mandatory=$false)]
         [string[]] $ExcludeRule = $null,
@@ -39,7 +43,7 @@ function Invoke-ScriptAnalyzer {
 	$scriptAnalyzer.Initialize(
 		$runspace, 
 		$testOutputWriter, 
-		$CustomizedRulePath, 
+		$CustomRulePath, 
 		$IncludeRule,
 		$ExcludeRule,
 		$Severity,

--- a/Tests/Engine/samplerule/samplerule1.psm1
+++ b/Tests/Engine/samplerule/samplerule1.psm1
@@ -1,0 +1,47 @@
+#Requires -Version 3.0
+
+<#
+.SYNOPSIS
+    Uses #Requires -RunAsAdministrator instead of your own methods.
+.DESCRIPTION
+    The #Requires statement prevents a script from running unless the Windows PowerShell version, modules, snap-ins, and module and snap-in version prerequisites are met. 
+    From Windows PowerShell 4.0, the #Requires statement let script developers require that sessions be run with elevated user rights (run as Administrator). 
+    Script developers does not need to write their own methods any more.
+    To fix a violation of this rule, please consider to use #Requires -RunAsAdministrator instead of your own methods.
+.EXAMPLE
+    Measure-RequiresRunAsAdministrator -ScriptBlockAst $ScriptBlockAst
+.INPUTS
+    [System.Management.Automation.Language.ScriptBlockAst]
+.OUTPUTS
+    [OutputType([PSCustomObject[])]
+.NOTES
+    None
+#>
+function Measure-RequiresRunAsAdministrator
+{
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]
+        $testAst
+    )
+
+    
+        $results = @()
+       
+        $result = [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]]@{"Message"  = "this is help"; 
+                                            "Extent"   = $ast.Extent;
+                                            "RuleName" = $PSCmdlet.MyInvocation.InvocationName;
+                                            "Severity" = "Warning"}
+
+        $results += $result             
+                
+      
+        return $results
+
+           
+}
+Export-ModuleMember -Function Measure*

--- a/Tests/Engine/samplerule/samplerule2/samplerule2.psm1
+++ b/Tests/Engine/samplerule/samplerule2/samplerule2.psm1
@@ -1,0 +1,47 @@
+#Requires -Version 3.0
+
+<#
+.SYNOPSIS
+    Uses #Requires -RunAsAdministrator instead of your own methods.
+.DESCRIPTION
+    The #Requires statement prevents a script from running unless the Windows PowerShell version, modules, snap-ins, and module and snap-in version prerequisites are met. 
+    From Windows PowerShell 4.0, the #Requires statement let script developers require that sessions be run with elevated user rights (run as Administrator). 
+    Script developers does not need to write their own methods any more.
+    To fix a violation of this rule, please consider to use #Requires -RunAsAdministrator instead of your own methods.
+.EXAMPLE
+    Measure-RequiresRunAsAdministrator -ScriptBlockAst $ScriptBlockAst
+.INPUTS
+    [System.Management.Automation.Language.ScriptBlockAst]
+.OUTPUTS
+    [OutputType([PSCustomObject[])]
+.NOTES
+    None
+#>
+function Measure-RequiresRunAsAdministrator
+{
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]
+        $testAst
+    )
+
+    
+        $results = @()
+       
+        $result = [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]]@{"Message"  = "this is help"; 
+                                            "Extent"   = $ast.Extent;
+                                            "RuleName" = $PSCmdlet.MyInvocation.InvocationName;
+                                            "Severity" = "Warning"}
+
+        $results += $result             
+                
+      
+        return $results
+
+           
+}
+Export-ModuleMember -Function Measure*

--- a/Tests/Engine/samplerule/samplerule2/samplerule3/samplerule3.psm1
+++ b/Tests/Engine/samplerule/samplerule2/samplerule3/samplerule3.psm1
@@ -1,0 +1,47 @@
+#Requires -Version 3.0
+
+<#
+.SYNOPSIS
+    Uses #Requires -RunAsAdministrator instead of your own methods.
+.DESCRIPTION
+    The #Requires statement prevents a script from running unless the Windows PowerShell version, modules, snap-ins, and module and snap-in version prerequisites are met. 
+    From Windows PowerShell 4.0, the #Requires statement let script developers require that sessions be run with elevated user rights (run as Administrator). 
+    Script developers does not need to write their own methods any more.
+    To fix a violation of this rule, please consider to use #Requires -RunAsAdministrator instead of your own methods.
+.EXAMPLE
+    Measure-RequiresRunAsAdministrator -ScriptBlockAst $ScriptBlockAst
+.INPUTS
+    [System.Management.Automation.Language.ScriptBlockAst]
+.OUTPUTS
+    [OutputType([PSCustomObject[])]
+.NOTES
+    None
+#>
+function Measure-RequiresRunAsAdministrator
+{
+    [CmdletBinding()]
+    [OutputType([Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]
+        $testAst
+    )
+
+    
+        $results = @()
+       
+        $result = [Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord[]]@{"Message"  = "this is help"; 
+                                            "Extent"   = $ast.Extent;
+                                            "RuleName" = $PSCmdlet.MyInvocation.InvocationName;
+                                            "Severity" = "Warning"}
+
+        $results += $result             
+                
+      
+        return $results
+
+           
+}
+Export-ModuleMember -Function Measure*


### PR DESCRIPTION
* Renames CustomizedRulePath parameter to CustomRulePath.
* Adds CustromizedRulePath as an alias of CustomRulePath.
* Adds RecurseCustomRulePath switch to recursively retrieve custom rules.
* Fixes a bug: CustomRulePath can now accept paths with a trailing
backslash.
* CustomRulePath parameter now takes only one string, instead of an array
of strings.