### PR TITLE
Fix for Issue #371

### DIFF
--- a/Rules/AvoidUsingPlainTextForPassword.cs
+++ b/Rules/AvoidUsingPlainTextForPassword.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // Finds all ParamAsts.
             IEnumerable<Ast> paramAsts = ast.FindAll(testAst => testAst is ParameterAst, true);
 
-            List<String> passwords = new List<String>() {"Password", "Passphrase", "Auth", "Cred", "Credential"};
+            List<String> passwords = new List<String>() {"Password", "Passphrase", "Cred", "Credential"};
 
             // Iterrates all ParamAsts and check if their names are on the list.
             foreach (ParameterAst paramAst in paramAsts)

--- a/Tests/Rules/AvoidUsingPlainTextForPassword.tests.ps1
+++ b/Tests/Rules/AvoidUsingPlainTextForPassword.tests.ps1
@@ -9,7 +9,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUsingPlainTextForPasswordN
 Describe "AvoidUsingPlainTextForPassword" {
     Context "When there are violations" {
         It "has 3 avoid using plain text for password violations" {
-            $violations.Count | Should Be 5
+            $violations.Count | Should Be 4
         }
 
         It "has the correct violation message" {


### PR DESCRIPTION
Removes Auth from the list of searched terms for the AvoidUsingPlainTextPasswords Rule