### PR TITLE
Throw error instead of warning for profiles

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -169,6 +169,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         }
         private string configuration;
 
+        private bool stopProcessing;
+
         #endregion Parameters
 
         #region Overrides
@@ -180,6 +182,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         {
             string[] rulePaths = Helper.ProcessCustomRulePaths(customRulePath,
                 this.SessionState, recurseCustomRulePath);
+
+            if (!ScriptAnalyzer.Instance.ParseProfile(this.configuration, this.SessionState.Path, this))
+            {
+                stopProcessing = true;
+                return;
+            }
 
             ScriptAnalyzer.Instance.Initialize(
                 this,
@@ -196,6 +204,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         /// </summary>
         protected override void ProcessRecord()
         {
+            if (stopProcessing)
+            {
+                stopProcessing = false;
+                return;
+            }
+
             if (String.Equals(this.ParameterSetName, "File", StringComparison.OrdinalIgnoreCase))
             {
                 // throws Item Not Found Exception                        

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -281,10 +281,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                                     excludeRuleList = excludeRuleList.Union(rhsList);
                                     break;
                                 default:
-                                    // keep writing warning here, we only stop processing if existing keys are wrong
-                                    writer.WriteWarning(
-                                        string.Format(CultureInfo.CurrentCulture, Strings.WrongKey, key,
-                                            kvp.Item1.Extent.StartLineNumber, kvp.Item1.Extent.StartColumnNumber, profile));
+                                    writer.WriteError(new ErrorRecord(
+                                        new InvalidDataException(string.Format(CultureInfo.CurrentCulture, Strings.WrongKey, key, kvp.Item1.Extent.StartLineNumber, kvp.Item1.Extent.StartColumnNumber, profile)),
+                                        Strings.WrongConfigurationKey, ErrorCategory.InvalidData, profile));
+                                    hasError = true;
                                     break;
                             }
                         }

--- a/Engine/Strings.Designer.cs
+++ b/Engine/Strings.Designer.cs
@@ -367,7 +367,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not a valid key in the profile hashtable: line {1} column {2} in file {3}. This key value pair will not be processed..
+        ///   Looks up a localized string similar to WrongConfigurationKey.
+        /// </summary>
+        internal static string WrongConfigurationKey {
+            get {
+                return ResourceManager.GetString("WrongConfigurationKey", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} is not a valid key in the profile hashtable: line {1} column {2} in file {3}. Valid keys are ExcludeRules, IncludeRules and Severity..
         /// </summary>
         internal static string WrongKey {
             get {

--- a/Engine/Strings.Designer.cs
+++ b/Engine/Strings.Designer.cs
@@ -88,6 +88,51 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to ConfigurationFileHasNoHashTable.
+        /// </summary>
+        internal static string ConfigurationFileHasNoHashTable {
+            get {
+                return ResourceManager.GetString("ConfigurationFileHasNoHashTable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ConfigurationFileNotFound.
+        /// </summary>
+        internal static string ConfigurationFileNotFound {
+            get {
+                return ResourceManager.GetString("ConfigurationFileNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ConfigurationKeyNotAString.
+        /// </summary>
+        internal static string ConfigurationKeyNotAString {
+            get {
+                return ResourceManager.GetString("ConfigurationKeyNotAString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ConfigurationValueNotAString.
+        /// </summary>
+        internal static string ConfigurationValueNotAString {
+            get {
+                return ResourceManager.GetString("ConfigurationValueNotAString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ConfigurationValueWrongFormat.
+        /// </summary>
+        internal static string ConfigurationValueWrongFormat {
+            get {
+                return ResourceManager.GetString("ConfigurationValueWrongFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Writes all diagnostics to WriteObject..
         /// </summary>
         internal static string DefaultLoggerDescription {
@@ -322,7 +367,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not a valid key in the profile hashtable: line {0} column {1} in file {2}.
+        ///   Looks up a localized string similar to {0} is not a valid key in the profile hashtable: line {1} column {2} in file {3}. This key value pair will not be processed..
         /// </summary>
         internal static string WrongKey {
             get {

--- a/Engine/Strings.resx
+++ b/Engine/Strings.resx
@@ -193,7 +193,7 @@
     <value>Cannot find any DiagnosticRecord with the Rule Suppression ID {0}.</value>
   </data>
   <data name="WrongKey" xml:space="preserve">
-    <value>{0} is not a valid key in the profile hashtable: line {1} column {2} in file {3}. This key value pair will not be processed.</value>
+    <value>{0} is not a valid key in the profile hashtable: line {1} column {2} in file {3}. Valid keys are ExcludeRules, IncludeRules and Severity.</value>
   </data>
   <data name="WrongKeyFormat" xml:space="preserve">
     <value>Key in the profile hashtable should be a string: line {0} column {1} in file {2}</value>
@@ -230,5 +230,8 @@
   </data>
   <data name="ConfigurationValueWrongFormat" xml:space="preserve">
     <value>ConfigurationValueWrongFormat</value>
+  </data>
+  <data name="WrongConfigurationKey" xml:space="preserve">
+    <value>WrongConfigurationKey</value>
   </data>
 </root>

--- a/Engine/Strings.resx
+++ b/Engine/Strings.resx
@@ -193,7 +193,7 @@
     <value>Cannot find any DiagnosticRecord with the Rule Suppression ID {0}.</value>
   </data>
   <data name="WrongKey" xml:space="preserve">
-    <value>{0} is not a valid key in the profile hashtable: line {0} column {1} in file {2}</value>
+    <value>{0} is not a valid key in the profile hashtable: line {1} column {2} in file {3}. This key value pair will not be processed.</value>
   </data>
   <data name="WrongKeyFormat" xml:space="preserve">
     <value>Key in the profile hashtable should be a string: line {0} column {1} in file {2}</value>
@@ -215,5 +215,20 @@
   </data>
   <data name="VerboseScriptDefinitionMessage" xml:space="preserve">
     <value>Analyzing Script Definition.</value>
+  </data>
+  <data name="ConfigurationFileHasNoHashTable" xml:space="preserve">
+    <value>ConfigurationFileHasNoHashTable</value>
+  </data>
+  <data name="ConfigurationFileNotFound" xml:space="preserve">
+    <value>ConfigurationFileNotFound</value>
+  </data>
+  <data name="ConfigurationKeyNotAString" xml:space="preserve">
+    <value>ConfigurationKeyNotAString</value>
+  </data>
+  <data name="ConfigurationValueNotAString" xml:space="preserve">
+    <value>ConfigurationValueNotAString</value>
+  </data>
+  <data name="ConfigurationValueWrongFormat" xml:space="preserve">
+    <value>ConfigurationValueWrongFormat</value>
   </data>
 </root>

--- a/Tests/Engine/GlobalSuppression.ps1
+++ b/Tests/Engine/GlobalSuppression.ps1
@@ -5,3 +5,79 @@ gcm "blah"
 $a = "//internal"
 
 Get-Alias -ComputerName dfd
+
+<#
+.Synopsis
+   Short description
+.DESCRIPTION
+   Long description
+.EXAMPLE
+   Example of how to use this cmdlet
+.EXAMPLE
+   Another example of how to use this cmdlet
+.INPUTS
+   Inputs to this cmdlet (if any)
+.OUTPUTS
+   Output from this cmdlet (if any)
+.NOTES
+   General notes
+.COMPONENT
+   The component this cmdlet belongs to
+.ROLE
+   The role this cmdlet belongs to
+.FUNCTIONALITY
+   The functionality that best describes this cmdlet
+#>
+function Verb-Noun
+{
+    [CmdletBinding(DefaultParameterSetName='Parameter Set 1', 
+                  SupportsShouldProcess=$true, 
+                  PositionalBinding=$false,
+                  HelpUri = 'http://www.microsoft.com/',
+                  ConfirmImpact='Medium')]
+    [Alias()]
+    Param
+    (
+        # Param1 help description
+        [Parameter(Mandatory=$true, 
+                   ValueFromPipeline=$true,
+                   ValueFromPipelineByPropertyName=$true, 
+                   ValueFromRemainingArguments=$false, 
+                   Position=0,
+                   ParameterSetName='Parameter Set 1')]
+        [ValidateNotNull()]
+        [ValidateNotNullOrEmpty()]
+        [ValidateCount(0,5)]
+        [ValidateSet("sun", "moon", "earth")]
+        [Alias("p1")] 
+        $Param1,
+
+        # Param2 help description
+        [Parameter(ParameterSetName='Parameter Set 1')]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [AllowEmptyString()]
+        [ValidateScript({$true})]
+        [ValidateRange(0,5)]
+        [int]
+        $Param2,
+
+        # Param3 help description
+        [Parameter(ParameterSetName='Another Parameter Set')]
+        [ValidatePattern("[a-z]*")]
+        [ValidateLength(0,15)]
+        [String]
+        $Param3
+    )
+
+    Begin
+    {
+    }
+    Process
+    {
+        return 1
+    }
+    End
+    {
+    }
+}

--- a/Tests/Engine/GlobalSuppression.test.ps1
+++ b/Tests/Engine/GlobalSuppression.test.ps1
@@ -46,18 +46,38 @@ Describe "GlobalSuppression" {
     }
 
     Context "Severity" {
-        It "Raises 1 violation for internal url without profile" {
-            $withoutProfile = $violations | Where-Object { $_.RuleName -eq "PSAvoidUsingInternalURLs" }
+        It "Raises 1 violation for use output type correctly without profile" {
+            $withoutProfile = $violations | Where-Object { $_.RuleName -eq "PSUseOutputTypeCorrectly" }
             $withoutProfile.Count | Should Be 1
-            $withoutProfile = $violationsUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSAvoidUsingInternalURLs" }
+            $withoutProfile = $violationsUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSUseOutputTypeCorrectly" }
             $withoutProfile.Count | Should Be 1
         }
 
-        It "Does not raise any violations for internal urls with profile" {
-            $withProfile = $suppression | Where-Object { $_.RuleName -eq "PSAvoidUsingInternalURLs" }
+        It "Does not raise any violations for use output type correctly with profile" {
+            $withProfile = $suppression | Where-Object { $_.RuleName -eq "PSUseOutputTypeCorrectly" }
             $withProfile.Count | Should be 0
-            $withProfile = $suppressionUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSAvoidUsingInternalURLs" }
+            $withProfile = $suppressionUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSUseOutputTypeCorrectly" }
             $withProfile.Count | Should be 0
+        }
+    }
+
+    Context "Error Case" {
+        It "Raises Error for file not found" {
+            $invokeWithError = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Configuration ".\ThisFileDoesNotExist.ps1" -ErrorAction SilentlyContinue
+            $invokeWithError.Count | should be 0
+            $Error[0].FullyQualifiedErrorId | should match "ConfigurationFileNotFound,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
+        }
+
+        It "Raises Error for file with no hash table" {
+            $invokeWithError = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Configuration "$directory\GlobalSuppression.ps1" -ErrorAction SilentlyContinue
+            $invokeWithError.Count | should be 0
+            $Error[0].FullyQualifiedErrorId | should match "ConfigurationFileHasNoHashTable,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
+        }
+
+        It "Raises Error for wrong profile" {
+            $invokeWithError = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Configuration "$directory\WrongProfile.ps1" -ErrorAction SilentlyContinue
+            $invokeWithError.Count | should be 0
+            $Error[0].FullyQualifiedErrorId | should match "ConfigurationValueWrongFormat,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
         }
     }
 }

--- a/Tests/Engine/GlobalSuppression.test.ps1
+++ b/Tests/Engine/GlobalSuppression.test.ps1
@@ -77,7 +77,7 @@ Describe "GlobalSuppression" {
         It "Raises Error for wrong profile" {
             $invokeWithError = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Configuration "$directory\WrongProfile.ps1" -ErrorAction SilentlyContinue
             $invokeWithError.Count | should be 0
-            $Error[0].FullyQualifiedErrorId | should match "ConfigurationValueWrongFormat,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
+            $Error[0].FullyQualifiedErrorId | should match "WrongConfigurationKey,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
         }
     }
 }

--- a/Tests/Engine/WrongProfile.ps1
+++ b/Tests/Engine/WrongProfile.ps1
@@ -1,0 +1,9 @@
+﻿@{
+    Severity='Warning'
+    IncludeRules=@('PSAvoidUsingCmdletAliases',
+                    'PSAvoidUsingPositionalParameters',
+                    'PSAvoidUsingInternalURLs'
+                    'PSAvoidUninitializedVariable')
+    ExcludeRules=@(1)
+    Exclude=@('blah')
+}


### PR DESCRIPTION
For most cases, we will throw error and stop executing scriptanalyzer. If the user uses an unknown key, we will just issue warning instead.