### PR TITLE
Improve post-build command, fix spelling mistakes.

### DIFF
--- a/Engine/Generic/AvoidCmdletGeneric.cs
+++ b/Engine/Generic/AvoidCmdletGeneric.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
     public abstract class AvoidCmdletGeneric : IScriptRule
     {
         /// <summary>
-        /// AnalyzeScript: Analyzes the given Ast and returns DiagnosticRecords based on the anaylsis.
+        /// AnalyzeScript: Analyzes the given Ast and returns DiagnosticRecords based on the analysis.
         /// </summary>
         /// <param name="ast">The script's ast</param>
         /// <param name="fileName">The name of the script file being analyzed</param>
@@ -38,7 +38,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
 
             List<String> cmdletNameAndAliases = Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper.Instance.CmdletNameAndAliases(GetCmdletName());
 
-            // Iterrates all CommandAsts and check the command name.
+            // Iterates all CommandAsts and check the command name.
             foreach (CommandAst cmdAst in commandAsts)
             {
                 if (cmdAst.GetCommandName() == null) continue;

--- a/Engine/Generic/AvoidParameterGeneric.cs
+++ b/Engine/Generic/AvoidParameterGeneric.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
     public abstract class AvoidParameterGeneric : IScriptRule
     {
         /// <summary>
-        /// AnalyzeScript: Analyzes the given Ast and returns DiagnosticRecords based on the anaylsis.
+        /// AnalyzeScript: Analyzes the given Ast and returns DiagnosticRecords based on the analysis.
         /// </summary>
         /// <param name="ast">The script's ast</param>
         /// <param name="fileName">The name of the script file being analyzed</param>
@@ -35,7 +35,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             // Finds all CommandAsts.
             IEnumerable<Ast> commandAsts = ast.FindAll(testAst => testAst is CommandAst, true);
 
-            // Iterrates all CommandAsts and check the condition.
+            // Iterates all CommandAsts and check the condition.
             foreach (CommandAst cmdAst in commandAsts)
             {
                 if (CommandCondition(cmdAst) && cmdAst.CommandElements != null)

--- a/Engine/Generic/ILogger.cs
+++ b/Engine/Generic/ILogger.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         string GetName();
 
         /// <summary>
-        /// GetDescription: Retrives the description of the logger.
+        /// GetDescription: Retrieves the description of the logger.
         /// </summary>
         /// <returns>The description of the logger</returns>
         string GetDescription();

--- a/Engine/Generic/IScriptRule.cs
+++ b/Engine/Generic/IScriptRule.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
     public interface IScriptRule : IRule
     {
         /// <summary>
-        /// AnalyzeScript: Analyzes the given Ast and returns DiagnosticRecords based on the anaylsis.
+        /// AnalyzeScript: Analyzes the given Ast and returns DiagnosticRecords based on the analysis.
         /// </summary>
         /// <param name="ast">The script's ast</param>
         /// <param name="fileName">The name of the script file being analyzed</param>

--- a/Engine/Generic/SourceType.cs
+++ b/Engine/Generic/SourceType.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         Builtin = 0,
 
         /// <summary>
-        /// MANAGED: Indicates the script analyzer rule is contirbuted as a managed rule.
+        /// MANAGED: Indicates the script analyzer rule is contributed as a managed rule.
         /// </summary>
         Managed = 1,
 

--- a/Engine/PSScriptAnalyzer.psd1
+++ b/Engine/PSScriptAnalyzer.psd1
@@ -23,7 +23,7 @@ CompanyName = 'Microsoft Corporation'
 Copyright = '(c) Microsoft Corporation 2015. All rights reserved.'
 
 # Description of the functionality provided by this module
-Description = 'PSScriptAnalyzer provides script analysis and checks for potential code defects in the scripts by applying a group of builtin or customized rules on the scripts being analyzed.'
+Description = 'PSScriptAnalyzer provides script analysis and checks for potential code defects in the scripts by applying a group of built-in or customized rules on the scripts being analyzed.'
 
 # Minimum version of the Windows PowerShell engine required by this module
 PowerShellVersion = '5.0'

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -888,7 +888,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 }
             }
 
-            // Resloves relative paths.
+            // Resolves relative paths.
             try
             {
                 for (int i = 0; i < validModPaths.Count; i++)

--- a/Engine/ScriptAnalyzerEngine.csproj
+++ b/Engine/ScriptAnalyzerEngine.csproj
@@ -101,14 +101,15 @@
     <VisualStudio AllowExistingFolder="true" />
   </ProjectExtensions>
   <PropertyGroup>
-    <PostBuildEvent>mkdir "$(SolutionDir)$(SolutionName)"
-copy /y "$(ProjectDir)\*.ps1xml" "$(SolutionDir)$(SolutionName)"
-copy /y "$(ProjectDir)\*.psd1" "$(SolutionDir)$(SolutionName)"
-mkdir "$(SolutionDir)$(SolutionName)\Configurations"
-copy /y "$(ProjectDir)\Configurations\*.psd1" "$(SolutionDir)$(SolutionName)\Configurations"
-copy /y "$(TargetPath)" "$(SolutionDir)$(SolutionName)"
-mkdir "$(SolutionDir)$(SolutionName)\en-US"
-copy /y "$(ProjectDir)\about_*.help.txt" "$(SolutionDir)$(SolutionName)\en-US"
-copy /y "$(ProjectDir)\*Help.xml" "$(SolutionDir)$(SolutionName)\en-US"</PostBuildEvent>
+    <PostBuildEvent>
+        if not exist "$(SolutionDir)$(SolutionName)" mkdir "$(SolutionDir)$(SolutionName)"
+        copy /y "$(ProjectDir)*.ps1xml" "$(SolutionDir)$(SolutionName)"
+        copy /y "$(ProjectDir)*.psd1" "$(SolutionDir)$(SolutionName)"
+        if not exist "$(SolutionDir)$(SolutionName)\Configurations" mkdir "$(SolutionDir)$(SolutionName)\Configurations"
+        copy /y "$(ProjectDir)Configurations\*.psd1" "$(SolutionDir)$(SolutionName)\Configurations"
+        copy /y "$(TargetPath)" "$(SolutionDir)$(SolutionName)"
+        if not exist "$(SolutionDir)$(SolutionName)\en-US" mkdir "$(SolutionDir)$(SolutionName)\en-US"
+        copy /y "$(ProjectDir)about_*.help.txt" "$(SolutionDir)$(SolutionName)\en-US"
+        copy /y "$(ProjectDir)*Help.xml" "$(SolutionDir)$(SolutionName)\en-US"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Engine/VariableAnalysis.cs
+++ b/Engine/VariableAnalysis.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         }
 
         /// <summary>
-        /// Used to analyze scriptbloct, functionmemberast or functiondefinitionast
+        /// Used to analyze scriptblock, functionmemberast or functiondefinitionast
         /// </summary>
         /// <param name="ast"></param>
         /// <returns></returns>

--- a/Engine/VariableAnalysisBase.cs
+++ b/Engine/VariableAnalysisBase.cs
@@ -552,7 +552,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                     Block dom = block._predecessors[0];
 
-                    // Get first proccessed node
+                    // Get first processed node
                     foreach (var pred in block._predecessors)
                     {
                         if (dominators[pred.PostOrder] != null)
@@ -828,14 +828,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 }
             }
 
-            // Initialize variables in internaldictionary to undetermined
+            // Initialize variables in internal dictionary to undetermined
             foreach (var key in InternalVariablesDictionary.Keys.ToList())
             {
                 InternalVariablesDictionary[key].Constant = Undetermined.UndeterminedConstant;
                 InternalVariablesDictionary[key].Type = typeof(Undetermined);
             }
 
-            // Initialze DefinedBlock of phi function. If it is null then that phi function is not initialized;
+            // Initialize DefinedBlock of phi function. If it is null then that phi function is not initialized;
             foreach (var block in blocks)
             {
                 foreach (var phi in block.Phis)
@@ -956,7 +956,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                         {
                             CommandExpressionAst cmeAst = assigned._rightAst as CommandExpressionAst;
                             MemberExpressionAst memAst = (cmeAst != null) ? (cmeAst.Expression as MemberExpressionAst) : null;
-                            // Don't handle the this case because this is handled in assignmenttarget
+                            // Don't handle the this case because this is handled in assignment target
 
                             if (memAst != null && memAst.Expression is VariableExpressionAst)
                             {
@@ -2042,7 +2042,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// <returns></returns>
         public object VisitParameter(ParameterAst parameterAst)
         {
-            // Nothing to do now, we've already allocated parameters in the first pass looking for all variable naems.
+            // Nothing to do now, we've already allocated parameters in the first pass looking for all variable names.
             System.Diagnostics.Debug.Assert(false, "Code is unreachable");
             return null;
         }
@@ -2812,7 +2812,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 // left operand is always evaluated, visit it's expression in the current block.
                 binaryExpressionAst.Left.Visit(this.Decorator);
 
-                // The right operand is condtionally evaluated.  We aren't generating any code here, just
+                // The right operand is conditionally evaluated.  We aren't generating any code here, just
                 // modeling the flow graph, so we just visit the right operand in a new block, and have
                 // both the current and new blocks both flow to a post-expression block.
                 var targetBlock = new Block();

--- a/Engine/about_PSScriptAnalyzer.help.txt
+++ b/Engine/about_PSScriptAnalyzer.help.txt
@@ -88,7 +88,7 @@ RUNNING SCRIPT ANALYZER ON AN EXISTING SCRIPT, MODULE OR DSC RESOURCE
         see if the output is "manageable".  If it isn't, then you will want to "ease 
         into" things by starting with the most serious violations first - errors.
         
-        You may be temtped to use the Invoke-ScriptAnalyzer command's Severity 
+        You may be tempted to use the Invoke-ScriptAnalyzer command's Severity 
         parameter with the argument Error to do this - don't.  This will run every 
         built-in rule and then filter the results during output.  The more rules the 
         script analyzer runs, the longer it will take to analyze a file.  You can 

--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // Finds all CommandAsts.
             IEnumerable<Ast> foundAsts = ast.FindAll(testAst => testAst is CommandAst, true);
 
-            // Iterrates all CommandAsts and check the command name.
+            // Iterates all CommandAsts and check the command name.
             foreach (Ast foundAst in foundAsts)
             {
                 CommandAst cmdAst = (CommandAst)foundAst;

--- a/Rules/AvoidDefaultTrueValueSwitchParameter.cs
+++ b/Rules/AvoidDefaultTrueValueSwitchParameter.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // Finds all ParamAsts.
             IEnumerable<Ast> paramAsts = ast.FindAll(testAst => testAst is ParameterAst, true);
 
-            // Iterrates all ParamAsts and check if any are switch.
+            // Iterates all ParamAsts and check if any are switch.
             foreach (ParameterAst paramAst in paramAsts)
             {
                 if (paramAst.Attributes.Any(attr => attr.TypeName.GetReflectionType() == typeof(System.Management.Automation.SwitchParameter))

--- a/Rules/AvoidEmptyCatchBlock.cs
+++ b/Rules/AvoidEmptyCatchBlock.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // Finds all CommandAsts.
             IEnumerable<Ast> foundAsts = ast.FindAll(testAst => testAst is CatchClauseAst, true);
 
-            // Iterrates all CatchClauseAst and check the statements count.
+            // Iterates all CatchClauseAst and check the statements count.
             foreach (Ast foundAst in foundAsts)
             {
                 CatchClauseAst catchAst = (CatchClauseAst)foundAst;

--- a/Rules/AvoidPositionalParameters.cs
+++ b/Rules/AvoidPositionalParameters.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // Finds all CommandAsts.
             IEnumerable<Ast> foundAsts = ast.FindAll(testAst => testAst is CommandAst, true);
 
-            // Iterrates all CommandAsts and check the command name.
+            // Iterates all CommandAsts and check the command name.
             foreach (Ast foundAst in foundAsts)
             {
                 CommandAst cmdAst = (CommandAst)foundAst;

--- a/Rules/AvoidShouldContinueWithoutForce.cs
+++ b/Rules/AvoidShouldContinueWithoutForce.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // Finds all ParamAsts.
             IEnumerable<Ast> funcAsts = ast.FindAll(testAst => testAst is FunctionDefinitionAst, true);
 
-            // Iterrates all ParamAsts and check if there are any force.
+            // Iterates all ParamAsts and check if there are any force.
             foreach (FunctionDefinitionAst funcAst in funcAsts)
             {
                 IEnumerable<Ast> paramAsts = funcAst.FindAll(testAst => testAst is ParameterAst, true);

--- a/Rules/AvoidUserNameAndPasswordParams.cs
+++ b/Rules/AvoidUserNameAndPasswordParams.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 // Finds all ParamAsts.
                 IEnumerable<Ast> paramAsts = funcAst.FindAll(testAst => testAst is ParameterAst, true);
-                // Iterrates all ParamAsts and check if their names are on the list.
+                // Iterates all ParamAsts and check if their names are on the list.
                 foreach (ParameterAst paramAst in paramAsts)
                 {
                     var psCredentialType = paramAst.Attributes.FirstOrDefault(paramAttribute =>

--- a/Rules/AvoidUsingPlainTextForPassword.cs
+++ b/Rules/AvoidUsingPlainTextForPassword.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             List<String> passwords = new List<String>() {"Password", "Passphrase", "Cred", "Credential"};
 
-            // Iterrates all ParamAsts and check if their names are on the list.
+            // Iterates all ParamAsts and check if their names are on the list.
             foreach (ParameterAst paramAst in paramAsts)
             {
                 TypeInfo paramType = (TypeInfo) paramAst.StaticType;

--- a/Rules/ScriptAnalyzerBuiltinRules.csproj
+++ b/Rules/ScriptAnalyzerBuiltinRules.csproj
@@ -111,7 +111,7 @@
     <VisualStudio AllowExistingFolder="true" />
   </ProjectExtensions>
   <PropertyGroup>
-    <PostBuildEvent>mkdir "$(SolutionDir)$(SolutionName)"
+    <PostBuildEvent>if not exist "$(SolutionDir)$(SolutionName)" mkdir "$(SolutionDir)$(SolutionName)"
 copy /y "$(TargetPath)" "$(SolutionDir)$(SolutionName)"</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Rules/ScriptAnalyzerBuiltinRules.csproj
+++ b/Rules/ScriptAnalyzerBuiltinRules.csproj
@@ -111,7 +111,9 @@
     <VisualStudio AllowExistingFolder="true" />
   </ProjectExtensions>
   <PropertyGroup>
-    <PostBuildEvent>if not exist "$(SolutionDir)$(SolutionName)" mkdir "$(SolutionDir)$(SolutionName)"
-copy /y "$(TargetPath)" "$(SolutionDir)$(SolutionName)"</PostBuildEvent>
+    <PostBuildEvent>
+        if not exist "$(SolutionDir)$(SolutionName)" mkdir "$(SolutionDir)$(SolutionName)"
+        copy /y "$(TargetPath)" "$(SolutionDir)$(SolutionName)"
+    </PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                             {
                                 assignments.Remove(varKey);
                             }
-                            //Check if variable belongs to PowerShell builtin variables
+                            //Check if variable belongs to PowerShell built-in variables
                             if (Helper.Instance.HasSpecialVars(varKey))
                             {
                                 assignments.Remove(varKey);


### PR DESCRIPTION
This is captured as bug #398.

The post-build command gives an error when run multiple time because the directory already exists. A simple IF can fix that. Also, the file appears to have LF and not CRLF in it which causes VS2015 to treat the command as one instead of multiple commands. There are also some spelling mistakes in various files, the worst being in about_PSScriptAnalyzer.help.txt. I have fixes for all the above and will submit a pull request shortly.