### PR TITLE
Fix AvoidPositionalParameter bug

### DIFF
--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -353,7 +353,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 arguments += 1;
             }
 
-            if (moreThanThreePositional && arguments < 3)
+            // if we are only checking for 3 or more positional parameters, check that arguments < parameters + 3
+            if (moreThanThreePositional && (arguments - parameters) < 3)
             {
                 return false;
             }

--- a/Tests/Rules/AvoidPositionalParametersNoViolations.ps1
+++ b/Tests/Rules/AvoidPositionalParametersNoViolations.ps1
@@ -21,3 +21,5 @@ Get-ChildItem Tests
 Write-Output "I don't want to use positional parameters"
 Split-Path "RandomPath" -Leaf
 Get-Process | ForEach-Object {Write-Host $_.name -foregroundcolor cyan}
+
+$srvc = Get-WmiObject Win32_Service -ComputerName $computername -Filter "name=""$service""" -Credential $credential


### PR DESCRIPTION
Fix a bug where AvoidPositionalParameter is raised based on number of total arguments rather than positional arguments