### PR TITLE
Improved heuristics for Singular noun rule

### DIFF
--- a/Engine/PSScriptAnalyzer.psd1
+++ b/Engine/PSScriptAnalyzer.psd1
@@ -11,7 +11,7 @@ Author = 'Microsoft Corporation'
 RootModule = 'PSScriptAnalyzer.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.3.0'
+ModuleVersion = '1.3.1'
 
 # ID used to uniquely identify this module
 GUID = '324fc715-36bf-4aee-8e58-72e9b4a08ad9'

--- a/Rules/UseSingularNouns.cs
+++ b/Rules/UseSingularNouns.cs
@@ -17,6 +17,7 @@ using System.Management.Automation.Language;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
@@ -46,6 +47,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     funcNamePieces = funcAst.Name.Split(funcSeperator);
                     String noun = funcNamePieces[1];
+
+                    // Convert the noun part of the function into a series of space delimited words
+                    // This helps the PluralizationService to provide an accurate determination about the plurality of the string
+                    noun = SplitCamelCaseString(noun);
+
                     var ps = System.Data.Entity.Design.PluralizationServices.PluralizationService.CreateService(CultureInfo.GetCultureInfo("en-us"));
 
                     if (!ps.IsSingular(noun) && ps.IsPlural(noun))
@@ -107,6 +113,19 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         public string GetSourceName()
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+
+        /// <summary>
+        /// SplitCamelCaseString: Splits a Camel Case'd string into individual words with space delimited
+        /// </summary>
+        private string SplitCamelCaseString(string input)
+        {
+            if (String.IsNullOrEmpty(input))
+            {
+                return String.Empty;
+            }
+
+            return Regex.Replace(input, "([A-Z])", " $1", RegexOptions.Compiled).Trim();
         }
     }
 

--- a/Tests/Rules/GoodCmdlet.ps1
+++ b/Tests/Rules/GoodCmdlet.ps1
@@ -261,3 +261,18 @@ function Get-Reserved*
     {
     }
 }
+
+<#
+.Synopsis
+   function that has a noun that is singular  
+.DESCRIPTION
+   
+.EXAMPLE
+   
+.EXAMPLE
+   
+#>
+function Get-MyWidgetStatus
+{
+
+}


### PR DESCRIPTION
Pluralization service now consumes the noun part of the function name that is converted to a sentence.

This makes the response of the service deterministic