### PR TITLE
Fix a bug where avoidusernameandpasswordparam is too noisy

### DIFF
--- a/Rules/AvoidUserNameAndPasswordParams.cs
+++ b/Rules/AvoidUserNameAndPasswordParams.cs
@@ -53,19 +53,21 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // Iterates all ParamAsts and check if their names are on the list.
                 foreach (ParameterAst paramAst in paramAsts)
                 {
+                    // this will be null if there is no [pscredential] attached to the parameter
                     var psCredentialType = paramAst.Attributes.FirstOrDefault(paramAttribute =>
                         (paramAttribute.TypeName.IsArray && (paramAttribute.TypeName as ArrayTypeName).ElementType.GetReflectionType() == typeof(PSCredential))
                         || paramAttribute.TypeName.GetReflectionType() == typeof(PSCredential));
 
+                    // this will be null if there are no [credential()] attribute attached
                     var credentialAttribute = paramAst.Attributes.FirstOrDefault(paramAttribute => paramAttribute.TypeName.GetReflectionType() == typeof(CredentialAttribute));
 
-                    String paramName = paramAst.Name.VariablePath.ToString();
-
-                    // check that the type is securestring
+                    // this will be null if there are no [securestring] attached to the parameter
                     var secureStringType = paramAst.Attributes.FirstOrDefault(paramAttribute =>
                         (paramAttribute.TypeName.IsArray && (paramAttribute.TypeName as ArrayTypeName).ElementType.GetReflectionType() == typeof (System.Security.SecureString))
                         || paramAttribute.TypeName.GetReflectionType() == typeof(System.Security.SecureString));
-                    
+
+                    String paramName = paramAst.Name.VariablePath.ToString();                    
+
                     foreach (String password in passwords)
                     {
                         if (paramName.IndexOf(password, StringComparison.OrdinalIgnoreCase) != -1)

--- a/Tests/Rules/AvoidUserNameAndPasswordParams.tests.ps1
+++ b/Tests/Rules/AvoidUserNameAndPasswordParams.tests.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module PSScriptAnalyzer
 
-$violationMessage = "Function 'Verb-Noun' has both username and password parameters. A credential parameter of type PSCredential with a CredentialAttribute where PSCredential comes before CredentialAttribute should be used."
+$violationMessage = "Function 'TestFunction' has both username and password parameters. A credential parameter of type PSCredential with a CredentialAttribute where PSCredential comes before CredentialAttribute should be used."
 $violationName = "PSAvoidUsingUserNameAndPasswordParams"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidUserNameAndPasswordParams.ps1 | Where-Object {$_.RuleName -eq $violationName}
@@ -8,8 +8,8 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUserNameAndPasswordParamsN
 
 Describe "AvoidUserNameAndPasswordParams" {
     Context "When there are violations" {
-        It "has 3 avoid username and password parameter violations" {
-            $violations.Count | Should Be 3
+        It "has 1 avoid username and password parameter violations" {
+            $violations.Count | Should Be 1
         }
 
         It "has the correct violation message" {


### PR DESCRIPTION
Don't raise the rule if the password is a securestring, pscredentialtype or pscredential

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/442)
<!-- Reviewable:end -->
