### PR TITLE
Fix to consider the usage of [switch] type along with [boolean] for proper SupportsShouldContinue use

### DIFF
--- a/Rules/AvoidShouldContinueWithoutForce.cs
+++ b/Rules/AvoidShouldContinueWithoutForce.cs
@@ -46,7 +46,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 foreach (ParameterAst paramAst in paramAsts)
                 {
                     if (String.Equals(paramAst.Name.VariablePath.ToString(), "force", StringComparison.OrdinalIgnoreCase)
-                        && String.Equals(paramAst.StaticType.FullName, "System.Boolean", StringComparison.OrdinalIgnoreCase))
+                        && (String.Equals(paramAst.StaticType.FullName, "System.Boolean", StringComparison.OrdinalIgnoreCase) 
+                        || String.Equals(paramAst.StaticType.FullName, "System.Management.Automation.SwitchParameter", StringComparison.OrdinalIgnoreCase)))
                     {
                         hasForce = true;
                         break;

--- a/Tests/Rules/GoodCmdlet.ps1
+++ b/Tests/Rules/GoodCmdlet.ps1
@@ -276,3 +276,16 @@ function Get-MyWidgetStatus
 {
 
 }
+
+function Get-MyFood
+{
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    param([Switch]$Force)
+
+    process
+    {
+        if ($PSCmdlet.ShouldContinue("Are you sure?"))
+        {
+        }
+    }
+}


### PR DESCRIPTION
Refer these issues for context:

https://github.com/PowerShell/vscode-powershell/issues/72

https://github.com/PowerShell/PSScriptAnalyzer/issues/427

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/445)
<!-- Reviewable:end -->
