### PR TITLE
Fix loading custom rules that do not have comment help

### DIFF
--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -764,8 +764,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                             {
                                 dynamic description = helpContent[0].Properties["Description"];
 
-                                if (null != description)
-                                {
+                                if (null != description && null != description.Value && description.Value.GetType().IsArray)
+                                {                                    
                                     desc = description.Value[0].Text;
                                 }
                             }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-# WS2012R2 image with April WMF5.0
-os: unstable
+# Image with WMF5.0 RTM
+os: "WMF 5"
 
 # clone directory
 clone_folder: c:\projects\psscriptanalyzer


### PR DESCRIPTION
Add conditions to check if indexing does not take place on a null valued Value property.

If a PowerShell based custom rule does't have comment based help, the engine throws an error. This occurs because the lack of comment based help results in a null value for the Value property of the dynamically typed description variable.

Fixes #463

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/464)
<!-- Reviewable:end -->
