### PR TITLE
Fix for hang issue

### DIFF
--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
         private CommandInvocationIntrinsics invokeCommand;
         private IOutputWriter outputWriter;
+        private Object getCommandLock = new object();
 
         #endregion
 
@@ -567,7 +568,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// <returns></returns>
         public CommandInfo GetCommandInfo(string name, CommandTypes commandType = CommandTypes.Alias | CommandTypes.Cmdlet | CommandTypes.Configuration | CommandTypes.ExternalScript | CommandTypes.Filter | CommandTypes.Function | CommandTypes.Script | CommandTypes.Workflow)
         {
-            return this.invokeCommand.GetCommand(name, commandType);
+            lock (getCommandLock)
+            {
+                return this.invokeCommand.GetCommand(name, commandType);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
PowerShell GetCommandInfo hangs when used in a multi threaded environment (with the same Runspace)

Fix is to put a lock around the usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/481)
<!-- Reviewable:end -->
