### PR TITLE
Fix settings hashtable input

### DIFF
--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -28,6 +28,7 @@ using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using System.Collections.ObjectModel;
 using System.Collections;
+using System.Diagnostics;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 {
@@ -216,13 +217,19 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             return true;
         }
 
-        private bool TryAddingProfileItem(
+        private bool AddProfileItem(
             string key,
             List<string> values,
             List<string> severityList,
             List<string> includeRuleList,
             List<string> excludeRuleList)
         {
+            Debug.Assert(key != null);
+            Debug.Assert(values != null);
+            Debug.Assert(severityList != null);
+            Debug.Assert(includeRuleList != null);
+            Debug.Assert(excludeRuleList != null);
+
             switch (key.ToLower())
             {
                 case "severity":
@@ -317,7 +324,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     }
                 }
 
-                TryAddingProfileItem(key, values, severityList, includeRuleList, excludeRuleList);
+                AddProfileItem(key, values, severityList, includeRuleList, excludeRuleList);
             
             }
 
@@ -437,7 +444,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                         string key = (kvp.Item1 as StringConstantExpressionAst).Value.ToLower();
 
-                        if(!TryAddingProfileItem(key, rhsList, severityList, includeRuleList, excludeRuleList))
+                        if(!AddProfileItem(key, rhsList, severityList, includeRuleList, excludeRuleList))
                         {
                             writer.WriteError(new ErrorRecord(
                                     new InvalidDataException(string.Format(CultureInfo.CurrentCulture, Strings.WrongKey, key, kvp.Item1.Extent.StartLineNumber, kvp.Item1.Extent.StartColumnNumber, profile)),


### PR DESCRIPTION
Hashtable keys were compared in case-sensitive manner to lower case valid
keys while adding values to the lists of severity, rule inclusion and rule
exclusion.

This commit also remove the relevant code duplication in ParseProfileHashtable
and ParseProfileString while adding the values to the respective lists.

Fixes #475

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/491)
<!-- Reviewable:end -->