### PR TITLE
Fix extent of AvoidUsernameAndPasswordParams rule

### DIFF
--- a/Tests/Rules/AvoidUserNameAndPasswordParams.ps1
+++ b/Tests/Rules/AvoidUserNameAndPasswordParams.ps1
@@ -53,7 +53,8 @@ function MyFunction3
     )
 }
 
-function TestFunction($password, [PSCredential[]]$passwords, $username){
+function TestFunction1($password, $username, [PSCredential[]]$passwords){
 }
 
-
+function TestFunction2($username, $password, [PSCredential[]]$passwords){
+}

--- a/Tests/Rules/AvoidUserNameAndPasswordParams.tests.ps1
+++ b/Tests/Rules/AvoidUserNameAndPasswordParams.tests.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module PSScriptAnalyzer
 
-$violationMessage = "Function 'TestFunction' has both Username and Password parameters. Either set the type of the Password parameter to SecureString or replace the Username and Password parameters with a Credential parameter of type PSCredential. If using a Credential parameter in PowerShell 4.0 or earlier, please define a credential transformation attribute after the PSCredential type attribute."
+$violationMessage = "Function 'TestFunction1' has both Username and Password parameters. Either set the type of the Password parameter to SecureString or replace the Username and Password parameters with a Credential parameter of type PSCredential. If using a Credential parameter in PowerShell 4.0 or earlier, please define a credential transformation attribute after the PSCredential type attribute."
 $violationName = "PSAvoidUsingUserNameAndPasswordParams"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidUserNameAndPasswordParams.ps1 | Where-Object {$_.RuleName -eq $violationName}
@@ -9,12 +9,20 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUserNameAndPasswordParamsN
 Describe "AvoidUserNameAndPasswordParams" {
     Context "When there are violations" {
         It "has 1 avoid username and password parameter violations" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should Be 2
         }
 
         It "has the correct violation message" {
             $violations[0].Message | Should Be $violationMessage
         }
+
+	It "has correct extent" {
+	   $expectedExtent = '$password, $username'
+	   $violations[0].Extent.Text | Should Be $expectedExtent
+
+	   $expectedExtent = '$username, $password'
+	   $violations[1].Extent.Text | Should Be $expectedExtent
+	}
     }
 
     Context "When there are no violations" {


### PR DESCRIPTION
The new extent includes only the region between the username and password parameters rather than the entire function.

Fixes #482

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/493)
<!-- Reviewable:end -->
