### PR TITLE
Fix extents of UseSingularNoun and UseApprovedVerbs

### DIFF
--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -656,22 +656,46 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             if (null == functionDefinitionAst)
             {
                 return null;
-            }
-
-            // Obtain the index where the function name is in Tokens
-            int funcTokenIndex = Tokens.Select((s, index) => new { s, index })
-                          .Where(x => x.s.Extent.StartOffset == functionDefinitionAst.Extent.StartOffset)
-                          .Select(x => x.index).FirstOrDefault();
-
-            if (funcTokenIndex > 0 && funcTokenIndex < Helper.Instance.Tokens.Count())
+            }            
+            var funcNameToken = Tokens.Where(
+                token => ContainsExtent(functionDefinitionAst.Extent, token.Extent) 
+                && token.Text.Equals(functionDefinitionAst.Name));
+            if (funcNameToken.Any())
             {
-                // return the extent of the next token - this is the extent for the function name
-                return Tokens[++funcTokenIndex].Extent;
+                return funcNameToken.First().Extent;
             }
-
-            return null;
+            else
+            {
+                return null;
+            }
         }
-        
+
+        /// <summary>
+        /// Return true of subset is contained in set
+        /// </summary>
+        /// <param name="set"></param>
+        /// <param name="subset"></param>
+        /// <returns>True or False</returns>
+        private bool ContainsExtent(IScriptExtent set, IScriptExtent subset)
+        {
+            if (set == null)
+            {
+                throw new ArgumentNullException("set");
+            }
+            if (subset == null)
+            {
+                throw new ArgumentNullException("subset");
+            }
+            if (set.StartOffset <= subset.StartOffset 
+                && set.EndOffset >= subset.EndOffset)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
         private void FindClosingParenthesis(string keyword)
         {
             if (Tokens == null || Tokens.Length == 0)

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -657,44 +657,28 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             {
                 return null;
             }            
-            var funcNameToken = Tokens.Where(
-                token => ContainsExtent(functionDefinitionAst.Extent, token.Extent) 
+            var funcNameTokens = Tokens.Where(
+                token => 
+                ContainsExtent(functionDefinitionAst.Extent, token.Extent) 
                 && token.Text.Equals(functionDefinitionAst.Name));
-            if (funcNameToken.Any())
-            {
-                return funcNameToken.First().Extent;
-            }
-            else
-            {
-                return null;
-            }
+            var funcNameToken = funcNameTokens.FirstOrDefault();
+            return funcNameToken == null ? null : funcNameToken.Extent;
         }
 
         /// <summary>
-        /// Return true of subset is contained in set
+        /// Return true if subset is contained in set
         /// </summary>
         /// <param name="set"></param>
         /// <param name="subset"></param>
         /// <returns>True or False</returns>
         private bool ContainsExtent(IScriptExtent set, IScriptExtent subset)
         {
-            if (set == null)
-            {
-                throw new ArgumentNullException("set");
-            }
-            if (subset == null)
-            {
-                throw new ArgumentNullException("subset");
-            }
-            if (set.StartOffset <= subset.StartOffset 
-                && set.EndOffset >= subset.EndOffset)
-            {
-                return true;
-            }
-            else
+            if (set == null || subset == null)
             {
                 return false;
             }
+            return set.StartOffset <= subset.StartOffset
+                && set.EndOffset >= subset.EndOffset;
         }
         private void FindClosingParenthesis(string keyword)
         {

--- a/Rules/UseApprovedVerbs.cs
+++ b/Rules/UseApprovedVerbs.cs
@@ -64,12 +64,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     if (!approvedVerbs.Contains(verb, StringComparer.OrdinalIgnoreCase))
                     {
                         IScriptExtent extent = Helper.Instance.GetScriptExtentForFunctionName(funcAst);
-
                         if (null == extent)
                         {
                             extent = funcAst.Extent;
                         }
-
                         yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.UseApprovedVerbsError, funcName),
                             extent, GetName(), DiagnosticSeverity.Warning, fileName);
                     }

--- a/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
+++ b/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
@@ -20,6 +20,10 @@ Describe "UseSingularNouns" {
         It "has the correct description message" {
             $nounViolations[0].Message | Should Match $nounViolationMessage
         }
+
+	It "has the correct extent" {
+	   $nounViolations[0].Extent.Text | Should be "Verb-Files"
+	}
     }
 
     Context "When there are no violations" {
@@ -38,6 +42,10 @@ Describe "UseApprovedVerbs" {
         It "has the correct description message" {
             $verbViolations[0].Message | Should Match $verbViolationMessage
         }
+
+	It "has the correct extent" {
+            $verbViolations[0].Extent.Text | Should be "Verb-Files"
+	}
     }
 
     Context "When there are no violations" {


### PR DESCRIPTION
Fixes search logic to find the function name in a function definition.

Prior to the fix, if the function definition started on the first line of a script, the extent would include the entire function definition. This commit fixes that bug.

Fixes #492

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/495)
<!-- Reviewable:end -->