### PR TITLE
Fix invoking WriteError from rule execution threads

### DIFF
--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -1190,12 +1190,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// </summary>
         /// <param name="ruleSuppressions"></param>
         /// <param name="diagnostics"></param>
-        public Tuple<List<SuppressedRecord>, List<DiagnosticRecord>> SuppressRule(string ruleName, Dictionary<string, List<RuleSuppression>> ruleSuppressionsDict, List<DiagnosticRecord> diagnostics)
+        public Tuple<List<SuppressedRecord>, List<DiagnosticRecord>> SuppressRule(
+            string ruleName,
+            Dictionary<string, List<RuleSuppression>> ruleSuppressionsDict,
+            List<DiagnosticRecord> diagnostics,
+            out List<ErrorRecord> errorRecords)
         {
             List<SuppressedRecord> suppressedRecords = new List<SuppressedRecord>();
             List<DiagnosticRecord> unSuppressedRecords = new List<DiagnosticRecord>();
             Tuple<List<SuppressedRecord>, List<DiagnosticRecord>> result = Tuple.Create(suppressedRecords, unSuppressedRecords);
-
+            errorRecords = new List<ErrorRecord>();
             if (diagnostics == null || diagnostics.Count == 0)
             {
                 return result;
@@ -1261,8 +1265,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                         ruleSuppression.Error = String.Format(CultureInfo.CurrentCulture, Strings.RuleSuppressionErrorFormat, ruleSuppression.StartAttributeLine,
                                 System.IO.Path.GetFileName(diagnostics.First().Extent.File), String.Format(Strings.RuleSuppressionIDError, ruleSuppression.RuleSuppressionID));
                     }
-
-                    this.outputWriter.WriteError(new ErrorRecord(new ArgumentException(ruleSuppression.Error), ruleSuppression.Error, ErrorCategory.InvalidArgument, ruleSuppression));
+                    errorRecords.Add(new ErrorRecord(new ArgumentException(ruleSuppression.Error), ruleSuppression.Error, ErrorCategory.InvalidArgument, ruleSuppression));
+                    //this.outputWriter.WriteError(new ErrorRecord(new ArgumentException(ruleSuppression.Error), ruleSuppression.Error, ErrorCategory.InvalidArgument, ruleSuppression));
                 }
             }
 

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -49,12 +49,15 @@ Describe "RuleSuppressionWithoutScope" {
         }
     }
 
-    Context "Bad Rule Suppression" {
-    	It "Throws a non-terminating error" {
-	   Invoke-ScriptAnalyzer -ScriptDefinition $ruleSuppressionBad -IncludeRule "PSAvoidUsingUserNameAndPassWordParams" -ErrorVariable errorRecord 2>$null
-	   $errorRecord.Count | Should Be 1
-	   $errorRecord.FullyQualifiedErrorId | Should match "suppression message attribute error"
+    if (!$testingLibraryUsage)
+    {
+	Context "Bad Rule Suppression" {
+    		It "Throws a non-terminating error" {
+	   	   Invoke-ScriptAnalyzer -ScriptDefinition $ruleSuppressionBad -IncludeRule "PSAvoidUsingUserNameAndPassWordParams" -ErrorVariable errorRecord -ErrorAction SilentlyContinue
+	   	   $errorRecord.Count | Should Be 1
+	   	   $errorRecord.FullyQualifiedErrorId | Should match "suppression message attribute error"
 	}
+    }
     }
 }
 


### PR DESCRIPTION
Whenever Helper.SuppressRule encounters any error, it invokes Cmdlet.WriteError. When running script rules, SuppressRule is called from rule execution threads. As such, Cmdlet.WriteError gets called from the rule execution threads. This results in an InvalidOperationException because this method can be called only from within BeginProcessing, ProcessRecord and EndProcessing and only within the main program thread.

Fixes #496

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/497)
<!-- Reviewable:end -->
