### PR TITLE
Resolves # 494. Added rule AvoidUsingPing

### DIFF
--- a/RuleDocumentation/AvoidUsingPing.md
+++ b/RuleDocumentation/AvoidUsingPing.md
@@ -1,0 +1,32 @@
+#AvoidUsingPing
+**Severity Level: Warning**
+
+
+##Description
+
+Avoid using the Ping command. 
+
+Test-NetConnection and Test-Connection can directly replace ping and do not require parsing text, using $LASTERRORCODE, or the .Net ping class.
+
+##How to Fix
+
+Use Test-NetConnection or Test-Connection. 
+
+##Example
+
+Wrong:
+```
+$null = ping 127.0.0.1
+
+if($LASTEXITCODE -eq 0)
+{
+	Write-output "Do Work"
+}
+```
+Correct:
+```
+if(Test-NetConnection 127.0.0.1)
+{
+	Write-output "Do Work"
+}
+```

--- a/Rules/AvoidUsingPing.cs
+++ b/Rules/AvoidUsingPing.cs
@@ -1,0 +1,156 @@
+﻿//
+// Copyright (c) Microsoft Corporation.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Management.Automation.Language;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+using System.ComponentModel.Composition;
+using System.Globalization;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
+{
+    /// <summary>
+    /// AvoidUsingPing: Avoid Using Ping
+    /// </summary>
+    [Export(typeof(IScriptRule))]
+    public class AvoidUsingPing : AstVisitor, IScriptRule
+    {
+        List<DiagnosticRecord> records;
+        string fileName;
+
+        /// <summary>
+        /// AnalyzeScript: Avoid Using Ping
+        /// </summary>
+        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
+            if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
+
+            // Rule is applicable only when PowerShell Version is < 5.0, since Test-NetConnection cmdlet was introduced in 5.0
+            int majorPSVersion = GetPSMajorVersion(ast);
+            if (!(5 > majorPSVersion && 0 < majorPSVersion))
+            {
+                records = new List<DiagnosticRecord>();
+                this.fileName = fileName;
+
+                ast.Visit(this);
+            }
+
+            return records;
+        }
+
+        /// <summary>
+        /// Checks that write-host command is not used
+        /// </summary>
+        /// <param name="cmdAst"></param>
+        /// <returns></returns>
+        public override AstVisitAction VisitCommand(CommandAst cmdAst)
+        {
+            if (cmdAst == null)
+            {
+                return AstVisitAction.SkipChildren;
+            }
+
+            if (cmdAst.GetCommandName() != null && String.Equals(cmdAst.GetCommandName(), "ping", StringComparison.OrdinalIgnoreCase))
+            {
+                if (String.IsNullOrWhiteSpace(fileName))
+                {
+                    records.Add(new DiagnosticRecord(String.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPingErrorScriptDefinition),
+                        cmdAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName));
+                }
+                else
+                {
+                    records.Add(new DiagnosticRecord(String.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPingError,
+                        System.IO.Path.GetFileName(fileName)), cmdAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName));
+                }
+            }
+
+            return AstVisitAction.Continue;
+        }
+
+        /// <summary>
+        /// GetPSMajorVersion: Retrieves Major PowerShell Version when supplied using #requires keyword in the script
+        /// </summary>
+        /// <returns>The name of this rule</returns>
+        private int GetPSMajorVersion(Ast ast)
+        {
+            if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
+
+            IEnumerable<Ast> scriptBlockAsts = ast.FindAll(testAst => testAst is ScriptBlockAst, true);
+            
+            foreach (ScriptBlockAst scriptBlockAst in scriptBlockAsts)
+            {
+                if (null != scriptBlockAst.ScriptRequirements && null != scriptBlockAst.ScriptRequirements.RequiredPSVersion)
+                {
+                    return scriptBlockAst.ScriptRequirements.RequiredPSVersion.Major;
+                }
+            }
+
+            // return a non valid Major version if #requires -Version is not supplied in the Script
+            return -1;
+        }
+
+        /// <summary>
+        /// GetName: Retrieves the name of this rule.
+        /// </summary>
+        /// <returns>The name of this rule</returns>
+        public string GetName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.AvoidUsingPingName);
+        }
+
+        /// <summary>
+        /// GetCommonName: Retrieves the common name of this rule.
+        /// </summary>
+        /// <returns>The common name of this rule</returns>
+        public string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPingCommonName);
+        }
+
+        /// <summary>
+        /// GetDescription: Retrieves the description of this rule.
+        /// </summary>
+        /// <returns>The description of this rule</returns>
+        public string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPingDescription);
+        }
+
+        /// <summary>
+        /// GetSourceType: Retrieves the type of the rule: builtin, managed or module.
+        /// </summary>
+        public SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
+        }
+
+
+        /// <summary>
+        /// GetSeverity:Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
+
+
+        /// <summary>
+        /// GetSourceName: Retrieves the module/assembly name the rule is from.
+        /// </summary>
+        public string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+    }
+}

--- a/Rules/AvoidUsingPing.cs
+++ b/Rules/AvoidUsingPing.cs
@@ -35,13 +35,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
+            records = new List<DiagnosticRecord>();
+            this.fileName = fileName;
+
             // Rule is applicable only when PowerShell Version is < 5.0, since Test-NetConnection cmdlet was introduced in 5.0
             int majorPSVersion = GetPSMajorVersion(ast);
             if (!(5 > majorPSVersion && 0 < majorPSVersion))
-            {
-                records = new List<DiagnosticRecord>();
-                this.fileName = fileName;
-
+            {             
                 ast.Visit(this);
             }
 

--- a/Rules/ScriptAnalyzerBuiltinRules.csproj
+++ b/Rules/ScriptAnalyzerBuiltinRules.csproj
@@ -84,6 +84,7 @@
     <Compile Include="AvoidUsingConvertToSecureStringWithPlainText.cs" />
     <Compile Include="AvoidUsingInvokeExpression.cs" />
     <Compile Include="AvoidUsingPlainTextForPassword.cs" />
+    <Compile Include="AvoidUsingPing.cs" />
     <Compile Include="AvoidUsingWMICmdlet.cs" />
     <Compile Include="AvoidUsingWriteHost.cs" />
     <Compile Include="DscTestsPresent.cs" />

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -772,6 +772,51 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Avoid Using Ping.
+        /// </summary>
+        internal static string AvoidUsingPingCommonName {
+            get {
+                return ResourceManager.GetString("AvoidUsingPingCommonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Avoid using the Ping command. Instead, use Test-NetConnection or Test-Connection. Test-NetConnection and Test-Connection can directly replace ping and do not require parsing text, using $LASTERRORCODE, or the .Net ping class..
+        /// </summary>
+        internal static string AvoidUsingPingDescription {
+            get {
+                return ResourceManager.GetString("AvoidUsingPingDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to File &apos;{0}&apos; uses Ping command. For PowerShell 5.0 and above, use Test-NetConnection or Test-Connection cmdlet which perform the same tasks as the Ping command. .
+        /// </summary>
+        internal static string AvoidUsingPingError {
+            get {
+                return ResourceManager.GetString("AvoidUsingPingError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Avoid using the Ping command. For PowerShell 5.0 and above, use Test-NetConnection or Test-Connection cmdlet which perform the same tasks as the Ping command..
+        /// </summary>
+        internal static string AvoidUsingPingErrorScriptDefinition {
+            get {
+                return ResourceManager.GetString("AvoidUsingPingErrorScriptDefinition", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidUsingPing.
+        /// </summary>
+        internal static string AvoidUsingPingName {
+            get {
+                return ResourceManager.GetString("AvoidUsingPingName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Avoid Using Plain Text For Password Parameter.
         /// </summary>
         internal static string AvoidUsingPlainTextForPasswordCommonName {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -810,4 +810,19 @@
   <data name="UseToExportFieldsInManifestName" xml:space="preserve">
     <value>UseToExportFieldsInManifest</value>
   </data>
+  <data name="AvoidUsingPingCommonName" xml:space="preserve">
+    <value>Avoid Using Ping</value>
+  </data>
+  <data name="AvoidUsingPingDescription" xml:space="preserve">
+    <value>Avoid using the Ping command. Instead, use Test-NetConnection or Test-Connection. Test-NetConnection and Test-Connection can directly replace ping and do not require parsing text, using $LASTERRORCODE, or the .Net ping class.</value>
+  </data>
+  <data name="AvoidUsingPingError" xml:space="preserve">
+    <value>File '{0}' uses Ping command. For PowerShell 5.0 and above, use Test-NetConnection or Test-Connection cmdlet which perform the same tasks as the Ping command. </value>
+  </data>
+  <data name="AvoidUsingPingErrorScriptDefinition" xml:space="preserve">
+    <value>Avoid using the Ping command. For PowerShell 5.0 and above, use Test-NetConnection or Test-Connection cmdlet which perform the same tasks as the Ping command.</value>
+  </data>
+  <data name="AvoidUsingPingName" xml:space="preserve">
+    <value>AvoidUsingPing</value>
+  </data>
 </root>

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -56,7 +56,7 @@ Describe "Test Name parameters" {
 
         It "Get Rules with no parameters supplied" {
 			$defaultRules = Get-ScriptAnalyzerRule
-			$defaultRules.Count | Should be 41
+			$defaultRules.Count | Should be 42
 		}
     }
 

--- a/Tests/Rules/AvoidUsingPing.ps1
+++ b/Tests/Rules/AvoidUsingPing.ps1
@@ -1,0 +1,4 @@
+﻿$ipAddress = “127.0.0.1”
+
+ping $ipAddress
+

--- a/Tests/Rules/AvoidUsingPing.test.ps1
+++ b/Tests/Rules/AvoidUsingPing.test.ps1
@@ -1,0 +1,24 @@
+﻿Import-Module PSScriptAnalyzer
+$violationMessage = "File 'AvoidUsingPing.ps1' uses Ping command. For PowerShell 5.0 and above, use Test-NetConnection or Test-Connection cmdlet which perform the same tasks as the Ping command."
+$violationName = "PSAvoidUsingPing"
+$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$violations = Invoke-ScriptAnalyzer $directory\AvoidUsingPing.ps1 | Where-Object {$_.RuleName -eq $violationName}
+$noViolations = Invoke-ScriptAnalyzer $directory\AvoidUsingPingNoViolations.ps1 | Where-Object {$_.RuleName -eq $violationName}
+
+Describe "AvoidUsingAlias" {
+    Context "When there are violations" {
+        It "has 2 Avoid Using Alias Cmdlets violations" {
+            $violations.Count | Should Be 1
+        }
+
+        It "has the correct description message" {
+            $violations[0].Message | Should Match $violationMessage
+        }
+    }
+
+    Context "When there are no violations" {
+        It "returns no violations" {
+            $noViolations.Count | Should Be 0
+        }
+    }
+}

--- a/Tests/Rules/AvoidUsingPingNoViolations.ps1
+++ b/Tests/Rules/AvoidUsingPingNoViolations.ps1
@@ -1,0 +1,9 @@
+$ipAddress = “127.0.0.1”
+
+$pingMethod = new-object system.net.networkinformation.ping
+$null = $pingMethod.send($ipAddress)
+
+$null = Test-Connection $ipAddress
+
+$null = Test-NetConnection $ipAddress 
+


### PR DESCRIPTION
Added new rule, test, and documentation to encourage PowerShell users to use Test-Connection or Test-NetConnection in place of ping when on PowerShell version 5 or greater.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/507)
<!-- Reviewable:end -->