### PR TITLE
Add ScriptPath property to DiagnosticRecord

### DIFF
--- a/Engine/Generic/DiagnosticRecord.cs
+++ b/Engine/Generic/DiagnosticRecord.cs
@@ -10,6 +10,7 @@
 // THE SOFTWARE.
 //
 
+using System;
 using System.Management.Automation.Language;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
@@ -24,7 +25,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         private IScriptExtent extent;
         private string ruleName;
         private DiagnosticSeverity severity;
-        private string scriptName;
+        private string scriptPath;
         private string ruleSuppressionId;
 
         /// <summary>
@@ -33,7 +34,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         public string Message
         {
             get { return message; }
-            set { message = value; }
+            protected set { message = string.IsNullOrEmpty(value) ? string.Empty : value; }
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         public IScriptExtent Extent
         {
             get { return extent; }
-            set { extent = value; }
+            protected set { extent = value; }
         }
 
         /// <summary>
@@ -51,7 +52,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         public string RuleName
         {
             get { return ruleName; }
-            set { ruleName = value; }
+            protected set { ruleName = string.IsNullOrEmpty(value) ? string.Empty : value; }
         }
 
         /// <summary>
@@ -68,18 +69,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// </summary>
         public string ScriptName
         {
-            get { return scriptName; }
-            //Trim down to the leaf element of the filePath and pass it to Diagnostic Record
-            set {
-                if (!string.IsNullOrWhiteSpace(value))
-                {
-                    scriptName = System.IO.Path.GetFileName(value);
-                }
-                else
-                {
-                    scriptName = string.Empty;
-                }
-            }
+            get { return string.IsNullOrEmpty(scriptPath) ? string.Empty : System.IO.Path.GetFileName(scriptPath);}
+        }
+
+        /// <summary>
+        /// Returns the path of the script.
+        /// </summary>
+        public string ScriptPath
+        {
+            get { return scriptPath; }
+            protected set { scriptPath = string.IsNullOrEmpty(value) ? string.Empty : value; }
         }
 
         /// <summary>
@@ -106,15 +105,27 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <param name="extent">The place in the script this diagnostic refers to</param>
         /// <param name="ruleName">The name of the rule that created this diagnostic</param>
         /// <param name="severity">The severity of this diagnostic</param>
-        /// <param name="scriptName">The name of the script file being analyzed</param>
-        public DiagnosticRecord(string message, IScriptExtent extent, string ruleName, DiagnosticSeverity severity, string scriptName, string ruleId = null)
+        /// <param name="scriptName">The path of the script file being analyzed</param>
+        public DiagnosticRecord(string message, IScriptExtent extent, string ruleName, DiagnosticSeverity severity, string scriptPath, string ruleId = null)
         {
-            Message  = string.IsNullOrEmpty(message)  ? string.Empty : message;
-            RuleName = string.IsNullOrEmpty(ruleName) ? string.Empty : ruleName;
+            Message  = message;
+            RuleName = ruleName;
             Extent   = extent;
             Severity = severity;
-            ScriptName = string.IsNullOrEmpty(scriptName) ? string.Empty : scriptName;
+            ScriptPath = scriptPath;
             ruleSuppressionId = ruleId;
+        }
+
+        /// <summary>
+        /// Copy Constructor
+        /// </summary>
+        /// <param name="record"></param>
+        public DiagnosticRecord(DiagnosticRecord diagnosticRecord)
+        {
+            if (diagnosticRecord == null)
+            {
+                throw new ArgumentNullException("diagnosticRecord");
+            }
         }
     }
 

--- a/Engine/Generic/SuppressedRecord.cs
+++ b/Engine/Generic/SuppressedRecord.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
                 Message = record.Message;
                 Extent = record.Extent;
                 Severity = record.Severity;
-                ScriptName = record.ScriptName;
+                ScriptPath = record.ScriptPath;
                 RuleSuppressionID = record.RuleSuppressionID;
             }
         }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -124,6 +124,23 @@ Describe "Test Path" {
         }
     }
 
+    Context "DiagnosticRecord  " {
+	It "has valid ScriptPath and ScriptName properties when an input file is given" {
+	   $scriptName = "TestScript.ps1"
+	   $scriptPath = Join-Path $directory $scriptName
+	   $expectedScriptPath = Resolve-Path $directory\TestScript.ps1
+	   $diagnosticRecords = Invoke-ScriptAnalyzer $scriptPath -IncludeRule "PSAvoidUsingEmptyCatchBlock"
+	   $diagnosticRecords[0].ScriptPath | Should Be $expectedScriptPath.Path
+	   $diagnosticRecords[0].ScriptName | Should Be $scriptName
+	}
+
+	It "has empty ScriptPath and ScriptName properties when a script definition is given" {
+	   $diagnosticRecords = Invoke-ScriptAnalyzer -ScriptDefinition gci -IncludeRule "PSAvoidUsingCmdletAliases"
+	   $diagnosticRecords[0].ScriptPath | Should Be ([System.String]::Empty)
+	   $diagnosticRecords[0].ScriptName | Should Be ([System.String]::Empty)
+	}
+    }
+
 	if (!$testingLibraryUsage)
 	{
 		#There is probably a more concise way to do this but for now we will settle for this!
@@ -177,7 +194,6 @@ Describe "Test Path" {
             Write-Output $writeHostViolation.Count
             $globalVarsViolation.Count -eq 1 -and $writeHostViolation.Count -eq 1 | Should Be $true
         }
-
     }
 }
 


### PR DESCRIPTION
This lets the user have easy access the script path property. Prior to this, the user needed to probe the Extent property of DiagnosticRecord to get the script path.

Resolves #504

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/509)
<!-- Reviewable:end -->
