### PR TITLE
Add suggested correction to PSMissingModuleManifestField rule

### DIFF
--- a/Rules/MissingModuleManifestField.cs
+++ b/Rules/MissingModuleManifestField.cs
@@ -81,23 +81,31 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
 
             var correctionExtents = new List<CorrectionExtent>();
-            string moduleVersionText = @"
-# Version number of this module.
-ModuleVersion = '1.0.0.0'";           
+            string fieldName = "ModuleVersion";
+            string fieldValue = "1.0.0.0";
             int startLineNumber = ast.Extent.StartLineNumber;
             int startColumnNumber = ast.Extent.StartColumnNumber + 2; // 2 for "@{",
-            var correctionText = new StringBuilder();
-            correctionText.AppendLine();
-            correctionText.Append(moduleVersionText);
-            correctionText.AppendLine();
-            correctionText.AppendLine();
+            string description = string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.MissingModuleManifestFieldCorrectionDescription,
+                fieldName,
+                fieldValue);
+            var correctionTextTemplate = @"
+# Version number of this module.
+{0} = {1}
+";
+            var correctionText = string.Format(
+                correctionTextTemplate,
+                fieldName,
+                fieldValue);
             var correctionExtent = new CorrectionExtent(
                 startLineNumber,
                 startLineNumber,
                 startColumnNumber,
                 startColumnNumber + 1,
-                correctionText.ToString(),
-                ast.Extent.File);
+                correctionText,
+                ast.Extent.File,
+                description);
             correctionExtents.Add(correctionExtent);
             return correctionExtents;
         }

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -1114,6 +1114,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add {0} = {1} to the module manifest.
+        /// </summary>
+        internal static string MissingModuleManifestFieldCorrectionDescription {
+            get {
+                return ResourceManager.GetString("MissingModuleManifestFieldCorrectionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Some fields of the module manifest (such as ModuleVersion) are required..
         /// </summary>
         internal static string MissingModuleManifestFieldDescription {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -816,6 +816,9 @@
   <data name="AvoidUsingPlainTextForPasswordCorrectionDescription" xml:space="preserve">
     <value>Set {0} type to SecureString</value>
   </data>
+  <data name="MissingModuleManifestFieldCorrectionDescription" xml:space="preserve">
+    <value>Add {0} = {1} to the module manifest</value>
+  </data>
   <data name="UseToExportFieldsInManifestCorrectionDescription" xml:space="preserve">
     <value>Replace {0} with {1}</value>
   </data>

--- a/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
+++ b/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
@@ -24,17 +24,16 @@ Describe "MissingRequiredFieldModuleManifest" {
             $violations.Message | Should Match $missingMessage
         }
 	
-	$expectedCorrections = 1
-	It "has $expectedCorrections suggested corrections" {
-	   $violations.SuggestedCorrections.Count | Should Be 1
+	$numExpectedCorrections = 1
+	It "has $numExpectedCorrections suggested corrections" {
+	   $violations.SuggestedCorrections.Count | Should Be $numExpectedCorrections
 	}
 	
 
 	It "has the right suggested correction" {	
 	   $expectedText = @'
-
 # Version number of this module.
-ModuleVersion = 1.0.0.0
+ModuleVersion = '1.0.0.0'
 '@
        $violations[0].SuggestedCorrections[0].Text | Should Match $expectedText
        Get-ExtentText $violations[0].SuggestedCorrections[0] $violationFilepath | Should Match ""

--- a/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
+++ b/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
@@ -2,10 +2,19 @@
 $missingMessage = "The member 'ModuleVersion' is not present in the module manifest."
 $missingName = "PSMissingModuleManifestField"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
-$violations = Invoke-ScriptAnalyzer $directory\TestBadModule\TestBadModule.psd1 | Where-Object {$_.RuleName -eq $missingName}
+$violationFilepath = Join-Path $directory "TestBadModule\TestBadModule.psd1"
+$violations = Invoke-ScriptAnalyzer $violationFilepath | Where-Object {$_.RuleName -eq $missingName}
 $noViolations = Invoke-ScriptAnalyzer $directory\TestGoodModule\TestGoodModule.psd1 | Where-Object {$_.RuleName -eq $missingName}
 
 Describe "MissingRequiredFieldModuleManifest" {
+    BeforeAll {
+        Import-Module (Join-Path $directory "PSScriptAnalyzerTestHelper.psm1")
+    }
+    
+    AfterAll{
+        Remove-Module PSScriptAnalyzerTestHelper
+    }    
+    
     Context "When there are violations" {
         It "has 1 missing required field module manifest violation" {
             $violations.Count | Should Be 1
@@ -14,7 +23,23 @@ Describe "MissingRequiredFieldModuleManifest" {
         It "has the correct description message" {
             $violations.Message | Should Match $missingMessage
         }
-    }
+	
+	$expectedCorrections = 1
+	It "has $expectedCorrections suggested corrections" {
+	   $violations.SuggestedCorrections.Count | Should Be 1
+	}
+	
+
+	It "has the right suggested correction" {	
+	   $expectedText = @'
+
+# Version number of this module.
+ModuleVersion = 1.0.0.0
+'@
+       $violations[0].SuggestedCorrections[0].Text | Should Match $expectedText
+       Get-ExtentText $violations[0].SuggestedCorrections[0] $violationFilepath | Should Match ""
+    }       	
+}    
 
     Context "When there are no violations" {
         It "returns no violations" {


### PR DESCRIPTION
The rule is triggered whenever a module manifest doesn't contain module version. This commit sets the suggestedCorrections property to suggest a ModuleVersion field to the manifest. 

Resolves #512

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/515)
<!-- Reviewable:end -->
