### PR TITLE
Documentation fixes for AvoidUsingPlainTextForPassword.md

### DIFF
--- a/RuleDocumentation/AvoidUsingPlainTextForPassword.md
+++ b/RuleDocumentation/AvoidUsingPlainTextForPassword.md
@@ -8,39 +8,28 @@ Password parameters that take in plaintext will expose passwords and compromise 
 
 ##How to Fix
 
-To fix a violation of this rule, please use SecurityString as the type of password parameter.
+To fix a violation of this rule, please use SecureString as the type of password parameter.
 
 ##Example
 
 Wrong： 
 ```
-    function Verb-Noun
+    function Test-Script
     {
         [CmdletBinding()]
         [Alias()]
         [OutputType([int])]
         Param
         (
-            # Param1 help description
-            [Parameter(Mandatory=$true,
-                       ValueFromPipelineByPropertyName=$true,
-                       Position=0)]
-            $Param1,
-            # Param2 help description
-            [int]
-            $Param2,
-            [SecureString]
+            [string]
             $Password,
-            [System.Security.SecureString]
+            [string]
             $Pass,
-            [SecureString[]]
+            [string[]]
             $Passwords,
             $Passphrases,
             $Passwordparam
         )
-    }
-
-    function TestFunction($password, [System.Security.SecureString[]]passphrases, [String]$passThru){
     }
 ```
 
@@ -54,30 +43,18 @@ Correct:
 	    [OutputType([Int])]
 	    Param
 	    (
-	        # Param1 help description
-	        [Parameter(Mandatory=$true,
-	                   ValueFromPipelineByPropertyName=$true,
-	                   Position=0)]
-	        $Param1,
-	        # Param2 help description
-	        [int]
-	        $Param2,
-	        [SecureString]
-	        $Password,
-	        [System.Security.SecureString]
-	        $Pass,
-		[SecureString[]]
-	        $Passwords,
-	        [SecureString]
-    		$Passphrases,
-    	    	[SecureString]
-    		$PasswordParam,
-    	    	[string]
-    	    	$PassThru
-    	    )
-    	    ...
+			[SecureString]
+			$Password,
+			[System.Security.SecureString]
+			$Pass,
+			[SecureString[]]
+			$Passwords,
+			[SecureString]
+			$Passphrases,
+			[SecureString]
+			$PasswordParam
+		)
+	        ...
 	}
 
-	function TestFunction([SecureString]$Password, [System.Security.SecureString[]]$Passphrases, [SecureString[]]$passes){
-	}
 ```

--- a/RuleDocumentation/AvoidUsingPlainTextForPassword.md
+++ b/RuleDocumentation/AvoidUsingPlainTextForPassword.md
@@ -30,32 +30,32 @@ Wrong：
             $Passphrases,
             $Passwordparam
         )
-	        ...
+        ...
     }
 ```
 
 Correct: 
 
 ```
-	function Test-Script
-	{
-		[CmdletBinding()]
-		[Alias()]
-		[OutputType([Int])]
-		Param
-	    (
-			[SecureString]
-			$Password,
-			[System.Security.SecureString]
-			$Pass,
-			[SecureString[]]
-			$Passwords,
-			[SecureString]
-			$Passphrases,
-			[SecureString]
-			$PasswordParam
-		)
-	        ...
-	}
+    function Test-Script
+    {
+        [CmdletBinding()]
+        [Alias()]
+        [OutputType([Int])]
+        Param
+        (
+            [SecureString]
+            $Password,
+            [System.Security.SecureString]
+            $Pass,
+            [SecureString[]]
+            $Passwords,
+            [SecureString]
+            $Passphrases,
+            [SecureString]
+            $PasswordParam
+        )
+        ...
+    }
 
 ```

--- a/RuleDocumentation/AvoidUsingPlainTextForPassword.md
+++ b/RuleDocumentation/AvoidUsingPlainTextForPassword.md
@@ -30,6 +30,7 @@ Wrong：
             $Passphrases,
             $Passwordparam
         )
+	        ...
     }
 ```
 
@@ -38,10 +39,10 @@ Correct:
 ```
 	function Test-Script
 	{
-	    [CmdletBinding()]
-	    [Alias()]
-	    [OutputType([Int])]
-	    Param
+		[CmdletBinding()]
+		[Alias()]
+		[OutputType([Int])]
+		Param
 	    (
 			[SecureString]
 			$Password,


### PR DESCRIPTION
Hello,

Some proposed fixes to the documentation:

* The recommended type in the How to Fix section has a typo.
* The 'wrong' example was using the correct approach (used SecureString).
* The 'wrong' example was inconsistent with the 'correct' example in terms of naming and spacing. 
* Examples included extra parameters which (in my opinion) distracted from the point being conveyed.

regards,
Avner

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/553)
<!-- Reviewable:end -->
