### PR TITLE
Fix typo in rule name output

### DIFF
--- a/Engine/about_PSScriptAnalyzer.help.txt
+++ b/Engine/about_PSScriptAnalyzer.help.txt
@@ -134,14 +134,14 @@ RUNNING SCRIPT ANALYZER ON AN EXISTING SCRIPT, MODULE OR DSC RESOURCE
         Count Name
         ----- ----
            23 PSAvoidUsingInvokeExpression
-            8 PSUseDeclaredVarsMoreThanAssigments
+            8 PSUseDeclaredVarsMoreThanAssignments
             8 PSProvideDefaultParameterValue
             6 PSAvoidUninitializedVariable
             3 PSPossibleIncorrectComparisonWithNull
             1 PSAvoidUsingComputerNameHardcoded
             
         You may decide to exclude the PSAvoidUsingInvokeExpression rule for the moment
-        and focus on the rest, especially the PSUseDeclaredVarsMoreThanAssigments, 
+        and focus on the rest, especially the PSUseDeclaredVarsMoreThanAssignments, 
         PSAvoidUninitializedVariable and PSPossibleIncorrectComparisonWithNull rules.
         
         As you fix rules, go back and enable more rules as you have time to address 

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -1744,7 +1744,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to UseDeclaredVarsMoreThanAssigments.
+        ///   Looks up a localized string similar to UseDeclaredVarsMoreThanAssignments.
         /// </summary>
         internal static string UseDeclaredVarsMoreThanAssignmentsName {
             get {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -445,7 +445,7 @@
     <value>UseApprovedVerbs</value>
   </data>
   <data name="UseDeclaredVarsMoreThanAssignmentsName" xml:space="preserve">
-    <value>UseDeclaredVarsMoreThanAssigments</value>
+    <value>UseDeclaredVarsMoreThanAssignments</value>
   </data>
   <data name="UsePSCredentialTypeName" xml:space="preserve">
     <value>UsePSCredentialType</value>

--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -20,10 +20,10 @@ using System.Globalization;
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
     /// <summary>
-    /// UseDeclaredVarsMoreThanAssigments: Analyzes the ast to check that variables are used in more than just their assignment.
+    /// UseDeclaredVarsMoreThanAssignments: Analyzes the ast to check that variables are used in more than just their assignment.
     /// </summary>
     [Export(typeof(IScriptRule))]
-    public class UseDeclaredVarsMoreThanAssigments : IScriptRule
+    public class UseDeclaredVarsMoreThanAssignments : IScriptRule
     {
         /// <summary>
         /// AnalyzeScript: Analyzes the ast to check that variables are used in more than just there assignment.

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module PSScriptAnalyzer
 $violationMessage = "The variable 'declaredVar2' is assigned but never used."
-$violationName = "PSUseDeclaredVarsMoreThanAssigments"
+$violationName = "PSUseDeclaredVarsMoreThanAssignments"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\UseDeclaredVarsMoreThanAssignments.ps1 | Where-Object {$_.RuleName -eq $violationName}
 $noViolations = Invoke-ScriptAnalyzer $directory\UseDeclaredVarsMoreThanAssignmentsNoViolations.ps1 | Where-Object {$_.RuleName -eq $violationName}


### PR DESCRIPTION
This fix updates a comment and String resource value to fix a typo for the "Use Declared Vars More Than Assignments" rule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/560)
<!-- Reviewable:end -->
