### PR TITLE
Add more type checks to PSAvoidUsingUserNameAndPassWordParams rule

### DIFF
--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -40,7 +40,7 @@ function SuppressUserAndPwdRule()
     param
     (
         [System.String] $username,
-        [System.Boolean] $password
+        [System.String] $password
     )
 }
 '@

--- a/Tests/Rules/AvoidUserNameAndPasswordParamsNoViolations.ps1
+++ b/Tests/Rules/AvoidUserNameAndPasswordParamsNoViolations.ps1
@@ -29,3 +29,19 @@ function MyFunction3
         $Password
     )
 }
+
+function MyFunction3
+{
+    param(
+    [string] $Username,
+    [switch] $HidePassword
+    )
+}
+
+function MyFunction4
+{
+    param(
+    [string] $Username,
+    [bool] $HidePassword
+    )
+}


### PR DESCRIPTION
Adds additional attribute type checks to the password parameter. In addition to checking CredentialAttribute, PSCredential and SecureString we also check for SwitchParameter and boolean type so as to ignore the parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/573)
<!-- Reviewable:end -->
