### PR TITLE
Suppress External Rules

### DIFF
--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1730,7 +1730,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             if (this.ExternalRules != null && !helpFile)
             {
-                List<ExternalRule> exRules = new List<ExternalRule>();
 
                 foreach (ExternalRule exRule in this.ExternalRules)
                 {
@@ -1743,19 +1742,26 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                         // We want the Engine to continue functioning even if one or more Rules throws an exception
                         try
                         {
+
+                            List<ExternalRule> exRules = new List<ExternalRule>();
                             exRules.Add(exRule);
+                            var ruleRecords = this.GetExternalRecord(scriptAst, scriptTokens, exRules.ToArray(), fileName);
+                            var records = SuppressRule(exRule.GetName(), ruleSuppressions, ruleRecords.ToList<DiagnosticRecord>());
+                            foreach (var record in records.Item2)
+                            {
+                                diagnostics.Add(record);
+                            }
+                            foreach (var suppressedRec in records.Item1)
+                            {
+                                suppressed.Add(suppressedRec);
+                            }
                         }
                         catch (Exception externalRuleException)
                         {
                             this.outputWriter.WriteError(new ErrorRecord(externalRuleException, Strings.RuleErrorMessage, ErrorCategory.InvalidOperation, fileName));
                         }
                     }
-                }
-
-                foreach (var record in this.GetExternalRecord(scriptAst, scriptTokens, exRules.ToArray(), fileName))
-                {
-                    diagnostics.Add(record);
-                }
+                }                
             }
 
 #endregion

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1454,6 +1454,23 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
             return records;
         }
+        private Tuple<List<SuppressedRecord>, List<DiagnosticRecord>> SuppressRule(
+            DiagnosticRecord ruleDiagnosticRecord,
+            Dictionary<string, List<RuleSuppression>> ruleSuppressions
+            )
+        {
+            List<ErrorRecord> suppressRuleErrors;
+            var records = Helper.Instance.SuppressRule(
+                ruleDiagnosticRecord.RuleName,
+                ruleSuppressions,
+                new List<DiagnosticRecord> { ruleDiagnosticRecord },
+                out suppressRuleErrors);
+            foreach (var error in suppressRuleErrors)
+            {
+                this.outputWriter.WriteError(error);
+            }
+            return records;
+        }
 
         /// <summary>
         /// Analyzes the syntax tree of a script file that has already been parsed.
@@ -1730,6 +1747,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             if (this.ExternalRules != null && !helpFile)
             {
+                List<ExternalRule> exRules = new List<ExternalRule>();
 
                 foreach (ExternalRule exRule in this.ExternalRules)
                 {
@@ -1742,29 +1760,30 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                         // We want the Engine to continue functioning even if one or more Rules throws an exception
                         try
                         {
-
-                            List<ExternalRule> exRules = new List<ExternalRule>();
                             exRules.Add(exRule);
-                            var ruleRecords = this.GetExternalRecord(scriptAst, scriptTokens, exRules.ToArray(), fileName);
-                            var records = SuppressRule(exRule.GetName(), ruleSuppressions, ruleRecords.ToList<DiagnosticRecord>());
-                            foreach (var record in records.Item2)
-                            {
-                                diagnostics.Add(record);
-                            }
-                            foreach (var suppressedRec in records.Item1)
-                            {
-                                suppressed.Add(suppressedRec);
-                            }
                         }
                         catch (Exception externalRuleException)
                         {
                             this.outputWriter.WriteError(new ErrorRecord(externalRuleException, Strings.RuleErrorMessage, ErrorCategory.InvalidOperation, fileName));
                         }
                     }
-                }                
-            }
+                }
 
-#endregion
+                foreach (var ruleRecord in this.GetExternalRecord(scriptAst, scriptTokens, exRules.ToArray(), fileName))
+                {
+                    var records = SuppressRule(ruleRecord, ruleSuppressions);
+                    foreach (var record in records.Item2)
+                    {
+                        diagnostics.Add(record);
+                    }
+                    foreach (var suppressedRec in records.Item1)
+                    {
+                        suppressed.Add(suppressedRec);
+                    }
+                }
+            }
+            
+            #endregion
 
             // Need to reverse the concurrentbag to ensure that results are sorted in the increasing order of line numbers
             IEnumerable<DiagnosticRecord> diagnosticsList = diagnostics.Reverse();


### PR DESCRIPTION
External/custom rules can now be suppressed with the same DiagnosticRecord decoration on functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/585)
<!-- Reviewable:end -->
