### PR TITLE
Use full function names

### DIFF
--- a/RuleDocumentation/UseStandardDSCFunctionsInResource.md
+++ b/RuleDocumentation/UseStandardDSCFunctionsInResource.md
@@ -4,7 +4,7 @@
 
 ##Description
 
-DSC Resource must implement Get, Set and Test-TargetResource functions. DSC Class must implement Get, Set and Test functions.
+DSC Resource must implement Get-TargetResource, Set-TargetResource and Test-TargetResource functions. DSC Class must implement Get, Set and Test functions.
 
 
 ##How to Fix


### PR DESCRIPTION
Whilst we all understood the original meaning, using the full names makes it much clearer (especially to non-native English speakers).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/592)
<!-- Reviewable:end -->
