### PR TITLE
Updates to all marked up documentation

### DIFF
--- a/PowerShellBestPractices.md
+++ b/PowerShellBestPractices.md
@@ -5,6 +5,7 @@ The following guidelines come from a combined effort from both the PowerShell te
 
 ##Cmdlet Design Rules
 ###Severity: Error
+
 ###Severity: Warning
   - Use Only Approved Verbs [UseApprovedVerbs](https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/UseApprovedVerbs.md)
   - Cmdlets Names: Characters that cannot be Used [AvoidReservedCharInCmdlet](https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/AvoidReservedCharInCmdlet.md)
@@ -65,8 +66,6 @@ The following guidelines come from a combined effort from both the PowerShell te
     - Copy $Error[0] to your own variable
   - Avoid using pipelines in scripts
   - If a return type is declared, the cmdlet must return that type. If a type is returned, a return type must be declared.
-  
-
 
 ##Scripting Style
 ###Severity: Error
@@ -101,7 +100,6 @@ The following guidelines come from a combined effort from both the PowerShell te
 ###Severity: TBD
   - APIKey and Credentials variables that are initialized (information disclosure)
 
-
 ##DSC Related Rules
 ###Severity: Error
   - Use standard DSC methods [UseStandardDSCFunctionsInResource](https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/UseStandardDSC FunctionsInResource.md)
@@ -112,9 +110,9 @@ The following guidelines come from a combined effort from both the PowerShell te
 
 ###Severity: Information
   - All of the following three rule are grouped by: [ReturnCorrectTypeDSCFunctions](https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/ReturnCorrectTypeDSCFunctions.md)
-    - Avoid return any object from a Set-TargetResource function
-    - Returning a Boolean object from a Test-TargetResource function
-    - Returning an object from a Get-TargetResource function
+    - Avoid return any object from a Set-TargetResource or Set (Class Based) function
+    - Returning a Boolean object from a Test-TargetResource or Test (Class Based) function
+    - Returning an object from a Get-TargetResource or Get (Class Based) function
   - DSC resources should have DSC tests [DSCTestsPresent](https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/DscTestsPresent.md)
   - DSC resources should have DSC examples [DSCExamplesPresent](https://github.com/PowerShell/PSScriptAnalyzer/blob/master/RuleDocumentation/DscExamplesPresent.md)
   
@@ -125,11 +123,9 @@ The following guidelines come from a combined effort from both the PowerShell te
   - Use ShouldProcess for a Set DSC method
   - Resource module contains DscResources folder which contains the resources [IssueOpened](https://github.com/PowerShell/PSScriptAnalyzer/issues/130)
 
-
-
 ###Reference:
-* Cmdlet Development Guidelines from MSDN site (Cmdlet Development Guidelines)
-
-* The Community Book of PowerShell Practices (Compiled by Don Jones and Matt Penny and the Windows PowerShell Community)
-
-* [PowerShell DSC Resource Design and Testing Checklist](http://blogs.msdn.com/b/powershell/archive/2014/11/18/powershell-dsc-resource-design-and-testing-checklist.aspx)
+* Cmdlet Development Guidelines from MSDN site (Cmdlet Development Guidelines): https://msdn.microsoft.com/en-us/library/ms714657(v=vs.85).aspx 
+* The Community Book of PowerShell Practices (Compiled by Don Jones and Matt Penny and the Windows PowerShell Community): https://powershell.org/community-book-of-powershell-practices/
+* PowerShell DSC Resource Design and Testing Checklist: http://blogs.msdn.com/b/powershell/archive/2014/11/18/powershell-dsc-resource-design-and-testing-checklist.aspx
+* DSC Guidelines can also be found in the DSC Resources Repository: https://github.com/PowerShell/DscResources
+* The Unofficial PowerShell Best Practices and Style Guide: https://github.com/PoshCode/PowerShellPracticeAndStyle

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Announcements
 =============
-
 ###### [Get the latest PSScriptAnalyzer version from PowerShellGallery](https://www.powershellgallery.com/packages/PSScriptAnalyzer)
 
 ###### [VSCode-PowerShell has built-in ScriptAnalyzer support](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell)
@@ -11,15 +10,11 @@ Announcements
 
 ###### [ISE Add-On for ScriptAnalyzer is available in PowerShellGallery](https://www.powershellgallery.com/packages/ISEScriptAnalyzerAddOn/)
 
-
 =============
-
 ##### ScriptAnalyzer community meeting schedule:
-
  - Next Meeting - June 2, 2016 - 11am to 12pm PDT
     - [Meeting Agenda](https://github.com/PowerShell/PSScriptAnalyzer/wiki/Community-Meeting-Agenda)
  - [Notes and recordings from earlier meetings](https://github.com/PowerShell/PSScriptAnalyzer/wiki)
-
 
 =============
 #####Builds
@@ -33,14 +28,16 @@ Announcements
 
 Introduction
 ============
+PSScriptAnalyzer is a static code checker for Windows PowerShell modules and scripts. PSScriptAnalyzer checks the quality of Windows PowerShell code by running a set of rules. 
+The rules are based on PowerShell best practices identified by PowerShell Team and the community. It generates DiagnosticResults (errors and warnings) to inform users about potential 
+code defects and suggests possible solutions for improvements.
 
-PSScriptAnalyzer is a static code checker for Windows PowerShell modules and scripts. PSScriptAnalyzer checks the quality of Windows PowerShell code by running a set of rules. The rules are based on PowerShell best practices identified by PowerShell Team and the community. It generates DiagnosticResults (errors and warnings) to inform users about potential code defects and suggests possible solutions for improvements.
+PSScriptAnalyzer is shipped with a collection of built-in rules that checks various aspects of PowerShell code such as presence of uninitialized variables, usage of PSCredential Type, 
+usage of Invoke-Expression etc. Additional functionalities such as exclude/include specific rules are also supported.
 
-PSScriptAnalyzer is shipped with a collection of built-in rules that checks various aspects of PowerShell code such as presence of uninitialized variables, usage of PSCredential Type, usage of Invoke-Expression etc. Additional functionalities such as exclude/include specific rules are also supported.
-
-PSScriptAnalyzer cmdlets
+PSScriptAnalyzer CMDLets
 ======================
-```
+``` PowerShell
 Get-ScriptAnalyzerRule [-CustomizedRulePath <string[]>] [-Name <string[]>] [<CommonParameters>] [-Severity <string[]>]
 
 Invoke-ScriptAnalyzer [-Path] <string> [-CustomizedRulePath <string[]>] [-ExcludeRule <string[]>] [-IncludeRule <string[]>] [-Severity <string[]>] [-Recurse] [<CommonParameters>]
@@ -48,19 +45,13 @@ Invoke-ScriptAnalyzer [-Path] <string> [-CustomizedRulePath <string[]>] [-Exclud
 
 Requirements
 ============
-
-WS2012R2 / Windows 8.1 / Windows OS running a **minimum of PowerShell v3.0**
-
-A Windows OS with PowerShell v5.0 [Windows Management Framework 5.0 Preview](http://go.microsoft.com/fwlink/?LinkId=398175) is also supported
-
+Windows Server 2012 R2 / Windows 8.1 / Windows OS running a **minimum of PowerShell v3.0**
 
 Installation
 ============
-
-1. Build the Code using Visual Studio [solution part of the repo] and navigate to the binplace location [``~/ProjectRoot/PSScriptAnalyzer``]
-
+1. Build the Code using Visual Studio [solution part of the repository] and navigate to the binplace location [``~/ProjectRoot/PSScriptAnalyzer``]
 2. In PowerShell Console:
-```powershell
+``` PowerShell
 Import-Module PSScriptAnalyzer
 ```
 If you have previous version of PSScriptAnalyzer installed on your machine, you may need to override old binaries by copying content of [``~/ProjectRoot/PSScriptAnalyzer``] to PSModulePath.
@@ -71,125 +62,132 @@ To confirm installation: run ```Get-ScriptAnalyzerRule``` in the PowerShell cons
 Suppressing Rules
 =================
 
-You can suppress a rule by decorating a script/function or script/function parameter with .NET's [SuppressMessageAttribute](https://msdn.microsoft.com/en-us/library/system.diagnostics.codeanalysis.suppressmessageattribute.aspx).  `SuppressMessageAttribute`'s constructor takes two parameters: a category and a check ID. Set the `categoryID` parameter to the name of the rule you want to suppress and set the `checkID` parameter to a null or empty string:
+You can suppress a rule by decorating a script/function or script/function parameter with .NET's [SuppressMessageAttribute](https://msdn.microsoft.com/en-us/library/system.diagnostics.codeanalysis.suppressmessageattribute.aspx).
+`SuppressMessageAttribute`'s constructor takes two parameters: a category and a check ID. Set the `categoryID` parameter to the name of the rule you want to suppress and set the `checkID` parameter to a null or empty string:
 
-    function SuppressMe()
-    {
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSProvideCommentHelp", "")]
-        param()
+``` PowerShell
+function SuppressMe()
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSProvideCommentHelp", "")]
+    param()
 
-        Write-Verbose -Message "I'm making a difference!"
+    Write-Verbose -Message "I'm making a difference!"
 
-    }
+}
+```
 
 All rule violations within the scope of the script/function/parameter you decorate will be suppressed.
 
 To suppress a message on a specific parameter, set the `SuppressMessageAttribute`'s `CheckId` parameter to the name of the parameter:
-
-    function SuppressTwoVariables()
+``` PowerShell
+function SuppressTwoVariables()
+{
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSProvideDefaultParameterValue", "b")]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSProvideDefaultParameterValue", "a")]
+    param([string]$a, [int]$b)
     {
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSProvideDefaultParameterValue", "b")]
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSProvideDefaultParameterValue", "a")]
-        param([string]$a, [int]$b)
-        {
-        }
     }
+}
+```
 
-Use the `SuppressMessageAttribute`'s `Scope` property to limit rule suppression to functions or classes within the attribute's scope. Use the value `Function` to suppress violations on all functions within the attribute's scope. Use the value `Class` to suppress violoations on all classes within the attribute's scope:
+Use the `SuppressMessageAttribute`'s `Scope` property to limit rule suppression to functions or classes within the attribute's scope. 
 
+Use the value `Function` to suppress violations on all functions within the attribute's scope. Use the value `Class` to suppress violations on all classes within the attribute's scope:
 
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSProvideCommentHelp", "", Scope="Function")]
-    param(
-    )
+``` PowerShell
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSProvideCommentHelp", "", Scope="Function")]
+param(
+)
 
-    function InternalFunction
-    {
-        param()
+function InternalFunction
+{
+    param()
 
-        Write-Verbose -Message "I am invincible!"
-    }
+    Write-Verbose -Message "I am invincible!"
+}
+```
 
 The above example demonstrates how to suppress rule violations for internal functions using the `SuppressMessageAttribute`'s `Scope` property.
 
 You can further restrict suppression based on a function/parameter/class/variable/object's name by setting the `SuppressMessageAttribute's` `Target` property to a regular expression. Any function/parameter/class/variable/object whose name matches the regular expression is skipped.
 
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPositionalParameters", Scope="Function", Target="PositionalParametersAllowed")]
-    Param(
-    )
+``` PowerShell
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPositionalParameters", Scope="Function", Target="PositionalParametersAllowed")]
+Param(
+)
 
-    function PositionalParametersAllowed()
+function PositionalParametersAllowed()
+{
+    Param([string]$Parameter1)
     {
-        Param([string]$Parameter1)
-        {
-            Write-Verbose $Parameter1
-        }
-
+        Write-Verbose $Parameter1
     }
 
-    function PositionalParametersNotAllowed()
+}
+
+function PositionalParametersNotAllowed()
+{
+    param([string]$Parameter1)
     {
-        param([string]$Parameter1)
-        {
-            Write-Verbose $Parameter1
-        }
+        Write-Verbose $Parameter1
     }
+}
 
-    # The script analyzer will skip this violation
-    PositionalParametersAllowed 'value1'
+# The script analyzer will skip this violation
+PositionalParametersAllowed 'value1'
 
-    # The script analyzer will report this violation
-    PositionalParametersNotAllowed 'value1
+# The script analyzer will report this violation
+PositionalParametersNotAllowed 'value1
+```
 
 To match all functions/variables/parameters/objects, use `*` as the value of the Target parameter:
-
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPositionalParameters", Scope="Function", Target="*")]
-    Param(
-    )
+``` PowerShell
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingPositionalParameters", Scope="Function", Target="*")]
+Param(
+)
+```
 
 **Note**: Rule suppression is currently supported only for built-in rules. 
 
 Settings Support in ScriptAnalyzer
 ========================================
-
-Settings that describe ScriptAnalyzer rules to include/exclude based on `Severity` can be created and supplied to
-`Invoke-ScriptAnalyzer` using the `-Setting` parameter. This enables a user to create a custom configuration for a specific environment.
+Settings that describe ScriptAnalyzer rules to include/exclude based on ```Severity``` can be created and supplied to
+```Invoke-ScriptAnalyzer``` using the ```Setting``` parameter. This enables a user to create a custom configuration for a specific environment.
 
 Using Settings support:
 
 The following example excludes two rules from the default set of rules and any rule
 that does not output an Error or Warning diagnostic record.
 
-```powershell
+``` PowerShell
 # ScriptAnalyzerSettings.psd1
 @{
     Severity=@('Error','Warning')
     ExcludeRules=@('PSAvoidUsingCmdletAliases',
-                   'PSAvoidUsingWriteHost')
+                'PSAvoidUsingWriteHost')
 }
 ```
 
 Then invoke that settings file when using `Invoke-ScriptAnalyzer`:
 
-```powershell
+``` PowerShell
 Invoke-ScriptAnalyzer -Path MyScript.ps1 -Setting ScriptAnalyzerSettings.psd1
 ```
 
 The next example selects a few rules to execute instead of all the default rules.
 
-```powershell
+``` PowerShell
 # ScriptAnalyzerSettings.psd1
 @{
     IncludeRules=@('PSAvoidUsingPlainTextForPassword',
-                   'PSAvoidUsingConvertToSecureStringWithPlainText')
+                'PSAvoidUsingConvertToSecureStringWithPlainText')
 }
 ```
 
-Then invoke that settings file when using `Invoke-ScriptAnalyzer`:
-
-```powershell
+Then invoke that settings file when using:
+``` PowerShell
 Invoke-ScriptAnalyzer -Path MyScript.ps1 -Setting ScriptAnalyzerSettings.psd1
 ```
-
 
 ScriptAnalyzer as a .NET library
 ================================
@@ -197,8 +195,7 @@ ScriptAnalyzer as a .NET library
 ScriptAnalyzer engine and functionality can now be directly consumed as a library.
 
 Here are the public interfaces:
-
-```c#
+``` c#
 using Microsoft.Windows.PowerShell.ScriptAnalyzer;
 
 public void Initialize(System.Management.Automation.Runspaces.Runspace runspace,
@@ -211,34 +208,35 @@ Microsoft.Windows.PowerShell.ScriptAnalyzer.IOutputWriter outputWriter,
 [string profile = null])
 
 public System.Collections.Generic.IEnumerable<DiagnosticRecord> AnalyzePath(string path,
-[bool searchRecursively = false])
+    [bool searchRecursively = false])
 
-public System.Collections.Generic.IEnumerable<IRule> GetRule(string[] moduleNames,
-string[] ruleNames)
+public System.Collections.Generic.IEnumerable<IRule> GetRule(string[] moduleNames, string[] ruleNames)
 ```
 
 Violation Correction
 ====================
+Most violations can be fixed by replacing the violation causing content with the correct alternative. 
 
-Most violations can be fixed by replacing the violation causing content with the correct alternative. In an attempt to provide the user with the ability to correct the violation we provide a property - `SuggestedCorrections`, in each DiagnosticRecord instance. This property contains the information needed to rectify the violation. For example, consider a script `C:\tmp\test.ps1` with the following content.
+In an attempt to provide the user with the ability to correct the violation we provide a property, ```SuggestedCorrections```, in each DiagnosticRecord instance,
+that contains information needed to rectify the violation.
 
-```powershell
+For example, consider a script ```C:\tmp\test.ps1``` with the following content:
+``` PowerShell
 PS> Get-Content C:\tmp\test.ps1
 gci C:\
 ```
 
-Invoking PSScriptAnalyzer on the file gives the following output. 
-
-```powershell
+Invoking PSScriptAnalyzer on the file gives the following output:
+``` PowerShell
 PS>$diagnosticRecord = Invoke-ScriptAnalyzer -Path C:\tmp\test.p1
 PS>$diagnosticRecord | select SuggestedCorrections | Format-Custom
 
 class DiagnosticRecord
 {
-  SuggestedCorrections =
+SuggestedCorrections =
     [
-      class CorrectionExtent
-      {
+    class CorrectionExtent
+    {
         EndColumnNumber = 4
         EndLineNumber = 1
         File = C:\Users\kabawany\tmp\test3.ps1
@@ -246,21 +244,22 @@ class DiagnosticRecord
         StartLineNumber = 1
         Text = Get-ChildItem
         Description = Replace gci with Get-ChildItem
-      }
+    }
     ]
 
 }
 ```
 
-The `*LineNumber` and `*ColumnNumber` properties give the region of the script that can be replaced by the contents of `Text` property, i.e., replace gci with Get-ChildItem.
+The ```*LineNumber``` and ```*ColumnNumber``` properties give the region of the script that can be replaced by the contents of ```Text``` property, i.e., replace gci with Get-ChildItem.
 
-The main motivation behind having `SuggestedCorrections` is to enable quick-fix like scenarios in editors like VSCode, Sublime, etc. At present, we provide valid `SuggestedCorrection` only for the following rules, while gradually adding this feature to more rules. 
+The main motivation behind having ```SuggestedCorrections``` is to enable quick-fix like scenarios in editors like VSCode, Sublime, etc. At present, we provide valid ```SuggestedCorrection``` only for the following rules, 
+while gradually adding this feature to more rules. 
 
-  * AvoidAlias.cs 
-  * AvoidUsingPlainTextForPassword.cs
-  * MisleadingBacktick.cs
-  * MissingModuleManifestField.cs
-  * UseToExportFieldsInManifest.cs
+* AvoidAlias.cs 
+* AvoidUsingPlainTextForPassword.cs
+* MisleadingBacktick.cs
+* MissingModuleManifestField.cs
+* UseToExportFieldsInManifest.cs
 
 Building the Code
 =================
@@ -273,19 +272,22 @@ Use Visual Studio to build "PSScriptAnalyzer.sln". Use ~/PSScriptAnalyzer/ folde
 Running Tests
 =============
 
-Pester-based ScriptAnalyzer Tests are located in ```<branch>/PSScriptAnalyzer/Tests``` folder
+Pester-based ScriptAnalyzer Tests are located in ```<branch>/PSScriptAnalyzer/Tests``` folder.
 
-* Ensure Pester is installed on the machine
-* Go the Tests folder in your local repository
-* Run Engine Tests:
+1. Ensure Pester is installed on the machine
+2. Go the Tests folder in your local repository
+3. Run Engine Tests:
+``` PowerShell
 .\InvokeScriptAnalyzer.tests.ps1
-* Run Tests for Built-in rules:
+```
+4. Run Tests for Built-in rules:
+``` PowerShell
 .\*.ps1 (Example - .\ AvoidConvertToSecureStringWithPlainText.ps1)
-*You can also run all tests under \Engine or \Rules by calling Invoke-Pester in the Engine/Rules directory.
+```
+You can also run all tests under \Engine or \Rules by calling Invoke-Pester in the Engine/Rules directory.
 
 Project Management Dashboard
 ==============================
-
 You can track issues, pull requests, backlog items here:
 
 [![Stories in progress](https://badge.waffle.io/PowerShell/PSScriptAnalyzer.png?label=In%20Progress&title=In%20Progress)](https://waffle.io/PowerShell/PSScriptAnalyzer)
@@ -298,11 +300,8 @@ Throughput Graph
 
 [![Throughput Graph](https://graphs.waffle.io/powershell/psscriptanalyzer/throughput.svg)](https://waffle.io/powershell/psscriptanalyzer/metrics)
 
-
-
 Contributing to ScriptAnalyzer
 ==============================
-
 You are welcome to contribute to this project. There are many ways to contribute:
 
 1. Submit a bug report via [Issues]( https://github.com/PowerShell/PSScriptAnalyzer/issues). For a guide to submitting good bug reports, please read [Painless Bug Tracking](http://www.joelonsoftware.com/articles/fog0000000029.html).

--- a/RuleDocumentation/AvoidAlias.md
+++ b/RuleDocumentation/AvoidAlias.md
@@ -1,17 +1,27 @@
 #AvoidAlias 
 **Severity Level: Warning**
 
-
 ##Description
+An alias is an alternate name or nickname for a CMDLet or for a command element, such as a function, script, file, or executable file. 
+You can use the alias instead of the command name in any Windows PowerShell commands.
 
-An alias is an alternate name or nickname for a cmdlet or for a command element, such as a function, script, file, or executable file. But when writing scripts that will potentially need to be maintained over time, either by the original author or another Windows PowerShell scripter, please consider using full cmdlet name instead of alias. Aliases can introduce these problems, readability, understandability and availability.
+Every PowerShell author learns the actual command names, but different authors learn and use different aliases. Aliases can make code difficult to read, understand and 
+impact availability.
+
+When developing PowerShell content that will potentially need to be maintained over time, either by the original author or others, you should use full command names.
+
+The use of full command names also allows for syntax highlighting in sites and applications like GitHub and Visual Studio Code.
 
 ##How to Fix
-
-Please consider using full cmdlet name instead of alias. 
+Use the full CMDLet name and not an alias.
 
 ##Example
+###Wrong： 
+``` PowerShell
+gps | Where-Object {$_.WorkingSet -gt 20000000}
+```
 
-Wrong： gps | Where-Object {$_.WorkingSet -gt 20000000}
-
-Correct: Get-Process | Where-Object {$_.WorkingSet -gt 20000000}
+###Correct: 
+``` PowerShell
+Get-Process | Where-Object {$_.WorkingSet -gt 20000000}
+```

--- a/RuleDocumentation/AvoidDefaultTrueValueSwitchParameter.md
+++ b/RuleDocumentation/AvoidDefaultTrueValueSwitchParameter.md
@@ -1,32 +1,43 @@
 #AvoidDefaultTrueValueSwitchParameter 
 **Severity Level: Warning**
 
-
 ##Description
-
-Switch Parameters Should Not Default To True
-
+Switch parameters for commands should default to false.
 
 ##How to Fix
-
-Please change the default value of the switch parameter to be false.
+Change the default value of the switch parameter to be false.
 
 ##Example
-
-Wrong：    
-
+###Wrong：    
+``` PowerShell
+function Test-Script
+{
+    [CmdletBinding()]
     Param
-    (      …
+    (
+        [String]
         $Param1,
+        
         [switch]
         $Switch=$True
     )
+    ...
+}
+```
 
-Correct:    
-
+###Correct:    
+``` PowerShell
+function Test-Script
+{
+    [CmdletBinding()]
     Param
-    (      …
+    (
+        [String]
         $Param1,
+
         [switch]
         $Switch=$False
     )
+    ...
+}
+```

--- a/RuleDocumentation/AvoidEmptyCatchBlock.md
+++ b/RuleDocumentation/AvoidEmptyCatchBlock.md
@@ -2,31 +2,42 @@
 **Severity Level: Warning**
 
 ##Description
-
-Empty catch blocks are considered poor design decisions because if an error occurs in the try block, this error is simply swallowed and not acted upon. While this does not inherently lead to bad things. It can and this should be avoided if possible. 
+Empty catch blocks are considered a poor design choice as they result in the errors occurring in a ```try``` block not being acted upon.
+ 
+While this does not inherently lead to issues, they should be avoid where possible. 
 
 ##How to Fix
-
-To fix a violation of this rule, using Write-Error or throw statements in catch blocks.
+Use ```Write-Error``` or ```throw``` statements within the catch block.
 
 ##Example
-Wrong:
+###Wrong:
+``` PowerShell
+try
+{
+	1/0
+}
+catch [DivideByZeroException]
+{
+}
+```
 
-	try
-	{
-	    1/0
-	}
-	catch [DivideByZeroException]
-	{
-	}
+###Correct:
+``` PowerShell
+try
+{
+	1/0
+}
+catch [DivideByZeroException]
+{
+	Write-Error "DivideByZeroException"
+}
 
-Correct:
-
-	try
-	{
-	    1/0
-	}
-	catch [DivideByZeroException]
-	{
-		Write-Error "DivideByZeroException"
-	}
+try
+{
+	1/0
+}
+catch [DivideByZeroException]
+{
+	Throw "DivideByZeroException"
+}
+```

--- a/RuleDocumentation/AvoidGlobalVars.md
+++ b/RuleDocumentation/AvoidGlobalVars.md
@@ -6,9 +6,9 @@ A variable is a unit of memory in which values are stored. Windows PowerShell co
 Variables and functions that are present when Windows PowerShell starts have been created in the global scope. 
 
 Globally scoped variables include:
-	- automatic variables
-	- preference variables
-	- variables, aliases, and functions that are in your Windows PowerShell profiles
+	*Automatic variables
+	*Preference variables
+	*Variables, aliases, and functions that are in your Windows PowerShell profiles
 
 To understand more about scoping, see ```Get-Help about_Scopes```.
 

--- a/RuleDocumentation/AvoidGlobalVars.md
+++ b/RuleDocumentation/AvoidGlobalVars.md
@@ -6,9 +6,9 @@ A variable is a unit of memory in which values are stored. Windows PowerShell co
 Variables and functions that are present when Windows PowerShell starts have been created in the global scope. 
 
 Globally scoped variables include:
-	*Automatic variables
-	*Preference variables
-	*Variables, aliases, and functions that are in your Windows PowerShell profiles
+	* Automatic variables
+	* Preference variables
+	* Variables, aliases, and functions that are in your Windows PowerShell profiles
 
 To understand more about scoping, see ```Get-Help about_Scopes```.
 

--- a/RuleDocumentation/AvoidGlobalVars.md
+++ b/RuleDocumentation/AvoidGlobalVars.md
@@ -19,7 +19,7 @@ Use other scope modifiers for variables.
 ###Wrong:
 ``` PowerShell
 $Global:var1 = $null
-function NotGlobal ($var)
+function Test-NotGlobal ($var)
 {
 	$a = $var + $var1
 }
@@ -28,7 +28,7 @@ function NotGlobal ($var)
 ###Correct:
 ``` PowerShell
 $var1 = $null
-function NotGlobal ($var1, $var2)
+function Test-NotGlobal ($var1, $var2)
 {
 		$a = $var1 + $var2
 }

--- a/RuleDocumentation/AvoidGlobalVars.md
+++ b/RuleDocumentation/AvoidGlobalVars.md
@@ -6,9 +6,9 @@ A variable is a unit of memory in which values are stored. Windows PowerShell co
 Variables and functions that are present when Windows PowerShell starts have been created in the global scope. 
 
 Globally scoped variables include:
-	* Automatic variables
-	* Preference variables
-	* Variables, aliases, and functions that are in your Windows PowerShell profiles
+* Automatic variables
+* Preference variables
+* Variables, aliases, and functions that are in your Windows PowerShell profiles
 
 To understand more about scoping, see ```Get-Help about_Scopes```.
 

--- a/RuleDocumentation/AvoidGlobalVars.md
+++ b/RuleDocumentation/AvoidGlobalVars.md
@@ -2,26 +2,34 @@
 **Severity Level: Warning**
 
 ##Description
+A variable is a unit of memory in which values are stored. Windows PowerShell controls access to variables, functions, aliases, and drives through a mechanism known as scoping. 
+Variables and functions that are present when Windows PowerShell starts have been created in the global scope. 
 
-A variable is a unit of memory in which values are stored. Windows PowerShell controls access to variables, functions, aliases, and drives through a mechanism known as scoping. Variables and functions that are present when Windows PowerShell starts have been created in the global scope. This includes automatic variables and preference variables. This also includes the variables, aliases, and functions that are in your Windows PowerShell profiles.A variable is a unit of memory in which values are stored. Windows PowerShell controls access to variables, functions, aliases, and drives through a mechanism known as scoping. Variables and functions that are present when Windows PowerShell starts have been created in the global scope. This includes automatic variables and preference variables. This also includes the variables, aliases, and functions that are in your Windows PowerShell profiles.
+Globally scoped variables include:
+	- automatic variables
+	- preference variables
+	- variables, aliases, and functions that are in your Windows PowerShell profiles
+
+To understand more about scoping, see ```Get-Help about_Scopes```.
 
 ##How to Fix
-
-To fix a violation of this rule, please consider to use other scope modifiers.
+Use other scope modifiers for variables.
 
 ##Example
-Wrong:
+###Wrong:
+``` PowerShell
+$Global:var1 = $null
+function NotGlobal ($var)
+{
+	$a = $var + $var1
+}
+```
 
-	$Global:var1 = $null
-	function NotGlobal ($var)
-	{
-    		$a = $var + $var1
-	}
-
-Correct:
-
-	$Global:var1 = $null
-	function NotGlobal ($var1, $var2)
-	{
-    		$a = $var1 + $var2
-	}
+###Correct:
+``` PowerShell
+$var1 = $null
+function NotGlobal ($var1, $var2)
+{
+		$a = $var1 + $var2
+}
+```

--- a/RuleDocumentation/AvoidInvokingEmptyMembers.md
+++ b/RuleDocumentation/AvoidInvokingEmptyMembers.md
@@ -1,22 +1,21 @@
 #AvoidInvokingEmptyMembers
 **Severity Level: Warning**
 
-
 ##Description
-
-Invoking non-constant members would cause potential bugs. Please double check the syntax to make sure that invoked members are constants.
-
+Invoking non-constant members can cause potential bugs. Please double check the syntax to make sure that invoked members are constants.
 
 ##How to Fix
-
-To fix a violation of this rule, please provide requested members for given types or classes.
+Provide the requested members for a given type or class. 
 
 ##Example
+###Wrong：    
+``` PowerShell
+$MyString = "abc"
+$MyString.('len'+'gth')
+```
 
-Wrong：    
-
-    "abc".('len'+'gth')
-
-Correct:    
-
-    "abc".('length')
+###Correct:    
+``` PowerShell
+$MyString = "abc"
+$MyString.('length')
+```

--- a/RuleDocumentation/AvoidNullOrEmptyHelpMessageAttribute.md
+++ b/RuleDocumentation/AvoidNullOrEmptyHelpMessageAttribute.md
@@ -1,58 +1,60 @@
 #AvoidNullOrEmtpyHelpMessageAttribute
 **Severity Level: Warning**
 
-
 ##Description
-
-Setting the HelpMessage attribute to an empty string or null value causes PowerShell interpreter to throw an error while executing the corresponding function.
+The value of the ```HelpMessage``` attribute should not be an empty string or a null value as this causes PowerShell's interpreter to throw an mirror when executing the
+function or CMDLet.
 
 ##How to Fix
-
-To fix a violation of this rule, please set its value to a non-empty string.
+Specify a value for the HelpMessage attribute.
 
 ##Example
-
-Wrong:
-
-Function BadFuncEmtpyHelpMessageEmpty
+###Wrong:
+``` PowerShell
+Function BadFuncEmptyHelpMessageEmpty
 {
 	Param(
 		[Parameter(HelpMessage='')]
-		[String] $Param
+		[String] 
+		$Param
 	)
 
 	$Param
 }
 
-Function BadFuncEmtpyHelpMessageNull
+Function BadFuncEmptyHelpMessageNull
 {
 	Param(
 		[Parameter(HelpMessage=$null)]
-		[String] $Param
+		[String] 
+		$Param
 	)
 
 	$Param
 }
 
-Function BadFuncEmtpyHelpMessageNoAssignment
+Function BadFuncEmptyHelpMessageNoAssignment
 {
 	Param(
 		[Parameter(HelpMessage)]
-		[String] $Param
+		[String] 
+		$Param
 	)
 
 	$Param
 }
+```
 
-
-Correct:
-
-Function GoodFuncEmtpyHelpMessage
+###Correct:
+``` PowerShell
+Function GoodFuncHelpMessage
 {
 	Param(
 		[Parameter(HelpMessage='This is helpful')]
-		[String] $Param
+		[String] 
+		$Param
 	)
 
 	$Param
 }
+```

--- a/RuleDocumentation/AvoidNullOrEmptyHelpMessageAttribute.md
+++ b/RuleDocumentation/AvoidNullOrEmptyHelpMessageAttribute.md
@@ -6,7 +6,7 @@ The value of the ```HelpMessage``` attribute should not be an empty string or a 
 function or CMDLet.
 
 ##How to Fix
-Specify a value for the HelpMessage attribute.
+Specify a value for the ```HelpMessage``` attribute.
 
 ##Example
 ###Wrong:

--- a/RuleDocumentation/AvoidReservedCharInCmdlet.md
+++ b/RuleDocumentation/AvoidReservedCharInCmdlet.md
@@ -1,25 +1,23 @@
 #AvoidReservedCharInCmdlet
 **Severity Level: Error**
 
-
 ##Description
+You cannot use following reserved characters in a function or CMDLet name as these can cause parsing or runtime errors.
 
-You cannot use following reserved characters in a function name. These characters usually cause a parsing error. Otherwise they will generally cause runtime errors.
-'#,(){}[]&/\\$^;:\"'<>|?@`*%+=~'
-
+Reserved Characters include: ```#,(){}[]&/\\$^;:\"'<>|?@`*%+=~``` 
 
 ##How to Fix
-
-To fix a violation of this rule, please remove reserved characters from your advanced function name.
+Remove reserved characters from names.
 
 ##Example
-
-Wrong： 
-
-function Test[1]
+###Wrong： 
+``` PowerShell
+function MyFunction[1]
 {...}
+```
 
-Correct:
-
-function Test
+###Correct:
+``` PowerShell
+function MyFunction
 {...}
+```

--- a/RuleDocumentation/AvoidReservedParams.md
+++ b/RuleDocumentation/AvoidReservedParams.md
@@ -1,31 +1,35 @@
 #AvoidReservedParams
 **Severity Level: Error**
 
-
 ##Description
-
-You cannot use reserved common parameters in an advanced function. If these parameters are defined by the user, an error generally occurs.
+You cannot use reserved common parameters in an advanced function.
 
 ##How to Fix
-
-To fix a violation of this rule, please change the name of your parameter.
+Change the name of the parameter.
 
 ##Example
-
-Wrong： 
-```
+###Wrong： 
+``` PowerShell
 function Test
 {
     [CmdletBinding]
-    Param($ErrorVariable, $b)
+    Param
+    (
+        $ErrorVariable, 
+        $Parameter2
+    )
 }
 ```
 
-Correct:
-```
+###Correct:
+``` PowerShell
 function Test
 {
     [CmdletBinding]
-    Param($err, $b)
+    Param
+    (
+        $Err, 
+        $Parameter2
+    )
 }
 ```

--- a/RuleDocumentation/AvoidShouldContinueWithoutForce.md
+++ b/RuleDocumentation/AvoidShouldContinueWithoutForce.md
@@ -1,135 +1,46 @@
 #AvoidShouldContinueWithoutForce
 **Severity Level: Warning**
 
-
 ##Description
-
 Functions that use ShouldContinue should have a boolean force parameter to allow user to bypass it.
 
 ##How to Fix
+Call the ```ShouldContinue``` method in advanced functions when ```ShouldProcess``` method returns $true. 
 
-To fix a violation of this rule, please call ShouldContinue method in advanced functions when ShouldProcess method returns $true. You can get more details by running “Get-Help about_Functions_CmdletBindingAttribute” and “Get-Help about_Functions_Advanced_Methods” command in Windows PowerShell.
+You can get more details by running ```Get-Help about_Functions_CmdletBindingAttribute``` and ```Get-Help about_Functions_Advanced_Methods``` command in Windows PowerShell.
 
 ##Example
-Wrong:
+###Wrong:
+``` PowerShell 
+Function Test-ShouldContinue
+{
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    Param
+    (
+        $MyString = 'blah'
+    )
 
-	function Verb-Noun
+    if ($PsCmdlet.ShouldContinue("ShouldContinue Query", "ShouldContinue Caption")) 
 	{
-	    [CmdletBinding(DefaultParameterSetName='Parameter Set 1', 
-	                  SupportsShouldProcess=$true, 
-	                  PositionalBinding=$false,
-	                  HelpUri = 'http://www.microsoft.com/',
-	                  ConfirmImpact='Medium')]
-	    [Alias()]
-	    [OutputType([string])]
-	    Param
-	    (
-	        # Param1 help description
-	        [Parameter(Mandatory=$true, 
-	                   ValueFromPipeline=$true,
-	                   ValueFromPipelineByPropertyName=$true, 
-	                   ValueFromRemainingArguments=$false, 
-	                   Position=0,
-	                   ParameterSetName='Parameter Set 1')]
-	        [ValidateNotNull()]
-	        [ValidateNotNullOrEmpty()]
-	        [ValidateCount(0,5)]
-	        [ValidateSet("sun", "moon", "earth")]
-	        [Alias("p1")] 
-	        $Param1,
-	        # Param2 help description
-	        [Parameter(ParameterSetName='Parameter Set 1')]
-	        [AllowNull()]
-	        [AllowEmptyCollection()]
-	        [AllowEmptyString()]
-	        [ValidateScript({$true})]
-	        [ValidateRange(0,5)]
-	        [int]
-	        $Param2,
-	        # Param3 help description
-	        [Parameter(ParameterSetName='Another Parameter Set')]
-	        [ValidatePattern("[a-z]*")]
-	        [ValidateLength(0,15)]
-	        [string]
-	        $Param3
-	    )
+        ...
+    }
+}
+```
 
-	    Begin
-	    {
-	        $pscmdlet.ShouldContinue("Yes", "No")
-	    }
-	    Process
-	    {
-	        if ($pscmdlet.ShouldProcess("Target", "Operation"))
-	        {
-	        }
-	    }
-	    End
-	    {
-	    }
-	}
+###Correct:
+``` PowerShell
+Function Test-ShouldContinue
+{
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    Param
+    (
+        $MyString = 'blah',
+        [Switch]$Force
+    )
 
-Correct:
-
-	function Get-File
+    if ($PsBoundParameters.ContainsKey('force') -or $PsCmdlet.ShouldContinue("ShouldContinue Query", "ShouldContinue Caption")) 
 	{
-	    [CmdletBinding(DefaultParameterSetName='Parameter Set 1', 
-	                  SupportsShouldProcess=$true, 
-	                  PositionalBinding=$false,
-	                  HelpUri = 'http://www.microsoft.com/',
-	                  ConfirmImpact='Medium')]
-	    [Alias()]
-	    [OutputType([string])]
-	    Param
-	    (
-	        # Param1 help description
-	        [Parameter(Mandatory=$true, 
-	                   ValueFromPipeline=$true,
-	                   ValueFromPipelineByPropertyName=$true, 
-	                   ValueFromRemainingArguments=$false, 
-	                   Position=0,
-	                   ParameterSetName='Parameter Set 1')]
-	        [ValidateNotNull()]
-	        [ValidateNotNullOrEmpty()]
-	        [ValidateCount(0,5)]
-	        [ValidateSet("sun", "moon", "earth")]
-	        [Alias("p1")] 
-	        $Param1,
-
-	        # Param2 help description
-	        [Parameter(ParameterSetName='Parameter Set 1')]
-	        [AllowNull()]
-	        [AllowEmptyCollection()]
-	        [AllowEmptyString()]
-	        [ValidateScript({$true})]
-	        [ValidateRange(0,5)]
-	        [int]
-	        $Param2,
-
-	        # Param3 help description
-	        [Parameter(ParameterSetName='Another Parameter Set')]
-	        [ValidatePattern("[a-z]*")]
-	        [ValidateLength(0,15)]
-	        [string]
-	        $Param3,
-	        [bool]
-	        $Force
-	    )
-
-	    Begin
-	    {
-	    }
-	    Process
-	    {
-	        if ($pscmdlet.ShouldProcess("Target", "Operation"))
-	        {
-	            Write-Verbose "Write Verbose"
-	            Get-Process
-	        }
-	    }
-	    End
-	    {
-	        if ($pscmdlet.ShouldContinue("Yes", "No")) {
-	        }
-	    }
-	}
+        ...
+    }
+}
+```

--- a/RuleDocumentation/AvoidShouldContinueWithoutForce.md
+++ b/RuleDocumentation/AvoidShouldContinueWithoutForce.md
@@ -4,10 +4,10 @@
 ##Description
 Functions that use ShouldContinue should have a boolean force parameter to allow user to bypass it.
 
+You can get more details by running ```Get-Help about_Functions_CmdletBindingAttribute``` and ```Get-Help about_Functions_Advanced_Methods``` command in Windows PowerShell.
+
 ##How to Fix
 Call the ```ShouldContinue``` method in advanced functions when ```ShouldProcess``` method returns ```$true```. 
-
-You can get more details by running ```Get-Help about_Functions_CmdletBindingAttribute``` and ```Get-Help about_Functions_Advanced_Methods``` command in Windows PowerShell.
 
 ##Example
 ###Wrong:

--- a/RuleDocumentation/AvoidShouldContinueWithoutForce.md
+++ b/RuleDocumentation/AvoidShouldContinueWithoutForce.md
@@ -5,7 +5,7 @@
 Functions that use ShouldContinue should have a boolean force parameter to allow user to bypass it.
 
 ##How to Fix
-Call the ```ShouldContinue``` method in advanced functions when ```ShouldProcess``` method returns $true. 
+Call the ```ShouldContinue``` method in advanced functions when ```ShouldProcess``` method returns ```$true```. 
 
 You can get more details by running ```Get-Help about_Functions_CmdletBindingAttribute``` and ```Get-Help about_Functions_Advanced_Methods``` command in Windows PowerShell.
 

--- a/RuleDocumentation/AvoidTrapStatement.md
+++ b/RuleDocumentation/AvoidTrapStatement.md
@@ -1,40 +1,42 @@
 #AvoidTrapStatement
 **Severity Level: Warning**
 
-
 ##Description
+The ```Trap``` keyword specifies a list of statements to run when a terminating error occurs. 
+T
+rap statements handle the terminating errors and allow execution of the script or function to continue instead of stopping.
 
-The Trap keyword specifies a list of statements to run when a terminating error occurs. It is designed for administrators. For script developers, you should use try-catch-finally statement.
+Traps are intended for the use of administrators and not for script and CMDLet developers. PowerShell scripts and CMDLets should make use 
+of ```try{} catch{} finally{}``` statements.
 
 ##How to Fix
-
-To fix a violation of this rule, please remove Trap statements and use try-catch-finally statement instead.
+Replace ```Trap``` statements with ```try{} catch{} finally{}``` statements.
 
 ##Example
+###Wrong：    
+``` PowerShell
+function Test-Trap 
+{
+    trap {"Error found: $_"}
+}
+```
 
-Wrong：    
-```
-    function TrapTest 
+###Correct:    
+``` PowerShell
+function Test-Trap 
+{
+    try 
     {
-    	trap {"Error found: $_"}
-	}
-```
-Correct:    
-```
-    function TrapTest 
+        $a = New-Object "NonExistentObjectType"
+        $a | Get-Member
+    }
+    catch [System.Exception]
     {
-    	try 
-    	{
-            $a = New-Object "dafdf"
-            $a | Get-Member
-        }
-    	catch [System.Exception]
-    	{
-            "Found error"
-    	}
-    	finally
-    	{
-            "End the script"
-    	}
-     }
+        "Found error"
+    }
+    finally
+    {
+        "End the script"
+    }
+    }
  ```

--- a/RuleDocumentation/AvoidTrapStatement.md
+++ b/RuleDocumentation/AvoidTrapStatement.md
@@ -3,8 +3,8 @@
 
 ##Description
 The ```Trap``` keyword specifies a list of statements to run when a terminating error occurs. 
-T
-rap statements handle the terminating errors and allow execution of the script or function to continue instead of stopping.
+
+Trap statements handle the terminating errors and allow execution of the script or function to continue instead of stopping.
 
 Traps are intended for the use of administrators and not for script and CMDLet developers. PowerShell scripts and CMDLets should make use 
 of ```try{} catch{} finally{}``` statements.

--- a/RuleDocumentation/AvoidUninitializedVariable.md
+++ b/RuleDocumentation/AvoidUninitializedVariable.md
@@ -1,30 +1,27 @@
 #AvoidUninitializedVariable
 **Severity Level: Warning**
 
-
 ##Description
+A variable is a unit of memory in which values are stored. Windows PowerShell controls access to variables, functions, aliases, and drives through a mechanism known as scoping. 
 
-A variable is a unit of memory in which values are stored. Windows PowerShell controls access to variables, functions, aliases, and drives through a mechanism known as scoping. The scope of an item is another term for its visibility. Non-global variables must be initialized. 
-
+All non-global variables must be initialized.
 
 ##How to Fix
-
-To fix a violation of this rule, please initialize non-global variables.
+Initialize non-global variables.
 
 ##Example
+###Wrong：    
+``` PowerShell
+function NotGlobal {
+	$localVars = "Localization?"
+	$uninitialized
+	Write-Output $uninitialized
+}
 
-Wrong：    
-
-	function NotGlobal {
-	    $localVars = "Localization?"
-	    $uninitialized
-	    Write-Output $uninitialized
-	}
-
-
-Correct:   
-
-	function NotGlobal {
-	    $localVars = "Localization?"
-	    Write-Output $localVars
-	}
+###Correct:   
+``` PowerShell
+function NotGlobal {
+	$localVars = "Localization?"
+	Write-Output $localVars
+}
+```

--- a/RuleDocumentation/AvoidUninitializedVariable.md
+++ b/RuleDocumentation/AvoidUninitializedVariable.md
@@ -4,7 +4,7 @@
 ##Description
 A variable is a unit of memory in which values are stored. Windows PowerShell controls access to variables, functions, aliases, and drives through a mechanism known as scoping. 
 
-All non-global variables must be initialized.
+All non-global variables must be initialized, otherwise potential bugs could be introduced.
 
 ##How to Fix
 Initialize non-global variables.

--- a/RuleDocumentation/AvoidUsingComputerNameHardcoded.md
+++ b/RuleDocumentation/AvoidUsingComputerNameHardcoded.md
@@ -1,24 +1,42 @@
 #AvoidUsingComputerNameHardcoded 
 **Severity Level: Error**
 
-
 ##Description
-
-The ComputerName parameter of a cmdlet should not be hardcoded as this will expose sensitive information about the system.
+The names of computers should never be hard coded as this will expose sensitive information. The ```ComputerName``` parameter should never have a hard coded value.
 
 ##How to Fix
+Remove hard coded computer names.
 
-Please consider using full cmdlet name instead of alias. 
+##Example 1
+###Wrong： 
+``` PowerShell
+Function Invoke-MyRemoteCommand ()
+{
+	Invoke-Command -Port 343 -ComputerName "hardcoderemotehostname"
+} 
+```
 
-##Example
+###Correct: 
+``` PowerShell
+Function Invoke-MyCommand ($ComputerName)
+{
+	Invoke-Command -Port 343 -ComputerName $ComputerName
+} 
+```
 
-Wrong： 
+##Example 2
+###Wrong： 
+``` PowerShell
+Function Invoke-MyLocalCommand ()
+{
+	Invoke-Command -Port 343 -ComputerName "hardcodelocalhostname"
+} 
+```
 
-	Invoke-Command -Port 343 -ComputerName "hardcode1"
-	Invoke-Command -ComputerName:"hardcode2"
-
-
-Correct: 
-
-	Invoke-Command -ComputerName $comp
-	Invoke-Command -ComputerName $env:COMPUTERNAME
+###Correct: 
+``` PowerShell
+Function Invoke-MyLocalCommand ()
+{
+	Invoke-Command -Port 343 -ComputerName $env:COMPUTERNAME
+} 
+```

--- a/RuleDocumentation/AvoidUsingConvertToSecureStringWithPlainText.md
+++ b/RuleDocumentation/AvoidUsingConvertToSecureStringWithPlainText.md
@@ -1,30 +1,21 @@
 #AvoidUsingConvertToSecureStringWithPlainText
 **Severity Level: Error**
 
-
 ##Description
-
-Information in the script should be protected properly. Using ConvertTo-SecureString with plain text will expose secure information.
+The use of the ```AsPlainText``` parameter with the ```ConvertTo-SecureString``` command can expose secure information. 
 
 ##How to Fix
-
-To fix a violation of this rule, please use a standard encrypted variable to do the conversion.
+Use a standard encrypted variable to perform any SecureString conversions.
 
 ##Example
-
-Wrong： 
-
-```
-$notsecure = convertto-securestring "abc" -asplaintext -force
-
-New-Object System.Management.Automation.PSCredential -ArgumentList "username", (ConvertTo-SecureString "notsecure" -AsPlainText -Force)
-
+###Wrong： 
+``` PowerShell
+$UserInput = Read-Host "Please enter your secure code"
+$EncryptedInput = ConvertTo-SecureString -String $UserInput -AsPlainText -Force
 ```
 
-Correct: 
-
-```
-$secure = read-host -assecurestring
-$encrypted = convertfrom-securestring -securestring $secure
-convertto-securestring -string $encrypted
+###Correct:
+``` PowerShell
+$SecureUserInput = Read-Host "Please enter your secure code" -AsSecureString
+$EncryptedInput = ConvertTo-SecureString -String $SecureUserInput
 ```

--- a/RuleDocumentation/AvoidUsingDeprecatedManifestFields.md
+++ b/RuleDocumentation/AvoidUsingDeprecatedManifestFields.md
@@ -1,26 +1,24 @@
 #AvoidUsingDeprecatedManifestFields	
 **Severity Level: Warning**
 
-
 ##Description
+In PowerShell 5.0, a number of fields in module manifest files (.psd1) have been changed.
 
-PowerShell V5.0 introduced some new fields and replaced some old fields with in module manifest files (.psd1). Therefore, fields such as "ModuleToProcess" is replaced with "RootModule". Using the deprecated manifest fields will result in PSScriptAnalyzer warnings.
+The field ```ModuleToProcess``` has been replaced with the ```RootModule``` field.
 
 ##How to Fix
-
-To fix a violation of this, please replace "ModuleToProcess" with "RootModule".
+Replace ```ModuleToProcess``` with ```RootModule``` in the module manifest.
 
 ##Example
-
-Wrong： 
-```
+###Wrong： 
+``` PowerShell
 ModuleToProcess ='psscriptanalyzer'
 
 ModuleVersion = '1.0'
 ```
 
-Correct: 
-```
+###Correct: 
+``` PowerShell
 RootModule ='psscriptanalyzer'
 
 ModuleVersion = '1.0'

--- a/RuleDocumentation/AvoidUsingFilePath.md
+++ b/RuleDocumentation/AvoidUsingFilePath.md
@@ -1,23 +1,41 @@
 #AvoidUsingFilePath 
 **Severity Level: Error**
 
-
 ##Description
+If a file path is used in a script that refers to a file on the computer or on the shared network, this could expose sensitive information or result in availability issues. 
 
-If a file path is used in a script that refers to a file on the computer or on the shared network, this may expose information about your computer. Furthermore, the file path may not work on other computer when they try to use the script.
+Care should be taken to ensure that no computer or network paths are hard coded, instead non-rooted paths should be used.
 
 ##How to Fix
-
-Please change the path of the file to non-rooted.
+Ensure that no network paths are hard coded and that file paths are non-rooted.
 
 ##Example
+###Wrong： 
+``` PowerShell
+Function Get-MyCSVFile 
+{
+	$FileContents = Get-FileContents -Path "\\scratch2\scratch\"
+	...
+}
 
-Wrong： 
-	
+Function Write-Documentation
+{
 	Write-Warning "E:\Code"
-	Get-ChildItem \\scratch2\scratch\
+	...
+}
+```
 
+###Correct:
+``` PowerShell
+Function Get-MyCSVFile ($NetworkPath)
+{
+	$FileContents = Get-FileContents -Path $NetworkPath
+	...
+}
 
-Correct:
-
-	Get-ChildItem "..\Test"
+Function Write-Documentation
+{
+	Write-Warning "..\Code"
+	...
+}
+``` 

--- a/RuleDocumentation/AvoidUsingInvokeExpression.md
+++ b/RuleDocumentation/AvoidUsingInvokeExpression.md
@@ -1,22 +1,21 @@
 #AvoidUsingInvokeExpression
 **Severity Level: Warning**
 
-
 ##Description
+Care must be taken when using the ```Invoke-Expression``` command. The ```Invoke-Expression``` executes the specified string and returns the results. 
 
-The Invoke-Expression cmdlet evaluates or runs a specified string as a command and returns the results of the expression or command. It can be extraordinarily powerful so it is not that you want to never use it but you need to be very careful about using it.  In particular, you are probably on safe ground if the data only comes from the program itself.  If you include any data provided from the user - you need to protect yourself from Code Injection. 
-
+Code injection into your application or script can occur if the expression passed as a string includes any data provided from the user.
 
 ##How to Fix
-
-To fix a violation of this rule, please remove Invoke-Expression from script and find other options instead.
+Remove the use of ```Invoke-Expression```.
 
 ##Example
+###Wrong： 
+``` PowerShell
+Invoke-Expression "Get-Process"
+```
 
-Wrong： 
-
-	Invoke-Expression "Get-Process"
-
-Correct: 
-
-	Get-Process
+###Correct: 
+``` PowerShell
+Get-Process
+```

--- a/RuleDocumentation/AvoidUsingPlainTextForPassword.md
+++ b/RuleDocumentation/AvoidUsingPlainTextForPassword.md
@@ -1,61 +1,48 @@
 #AvoidUsingPlainTextForPassword 
 **Severity Level: Warning**
 
-
 ##Description
+Password parameters that take in plaintext will expose passwords and compromise the security of your system. Passwords should be stored in the 
+```SecureString``` type.
 
-Password parameters that take in plaintext will expose passwords and compromise the security of your system.
+The following parameters are considered password parameters (this is not case sensitive):
+    - Password
+    - Pass
+    - Passwords
+    - Passphrase
+    - Passphrases
+    - PasswordParam
+
+If a parameter is defined with a name in the above list, it should be declared with type ```SecureString```
 
 ##How to Fix
-
-To fix a violation of this rule, please use SecureString as the type of password parameter.
+Change the type to ```SecureString```.
 
 ##Example
-
-Wrong： 
-```
-    function Test-Script
-    {
-        [CmdletBinding()]
-        [Alias()]
-        [OutputType([int])]
-        Param
-        (
-            [string]
-            $Password,
-            [string]
-            $Pass,
-            [string[]]
-            $Passwords,
-            $Passphrases,
-            $Passwordparam
-        )
-        ...
-    }
+###Wrong： 
+``` PowerShell
+function Test-Script
+{
+    [CmdletBinding()]
+    Param
+    (
+        [string]
+        $Password
+    )
+    ...
+}
 ```
 
-Correct: 
-
-```
-    function Test-Script
-    {
-        [CmdletBinding()]
-        [Alias()]
-        [OutputType([Int])]
-        Param
-        (
-            [SecureString]
-            $Password,
-            [System.Security.SecureString]
-            $Pass,
-            [SecureString[]]
-            $Passwords,
-            [SecureString]
-            $Passphrases,
-            [SecureString]
-            $PasswordParam
-        )
-        ...
-    }
-
+###Correct: 
+``` PowerShell
+function Test-Script
+{
+    [CmdletBinding()]
+    Param
+    (
+        [SecureString]
+        $Password
+    )
+    ...
+}
 ```

--- a/RuleDocumentation/AvoidUsingPlainTextForPassword.md
+++ b/RuleDocumentation/AvoidUsingPlainTextForPassword.md
@@ -6,12 +6,12 @@ Password parameters that take in plaintext will expose passwords and compromise 
 ```SecureString``` type.
 
 The following parameters are considered password parameters (this is not case sensitive):
-    - Password
-    - Pass
-    - Passwords
-    - Passphrase
-    - Passphrases
-    - PasswordParam
+* Password
+* Pass
+* Passwords
+* Passphrase
+* Passphrases
+* PasswordParam
 
 If a parameter is defined with a name in the above list, it should be declared with type ```SecureString```
 

--- a/RuleDocumentation/AvoidUsingPositionalParameters.md
+++ b/RuleDocumentation/AvoidUsingPositionalParameters.md
@@ -2,18 +2,20 @@
 **Severity Level: Warning**
 
 ##Description
+When developing PowerShell content that will potentially need to be maintained over time, either by the original author or others, you should use full command names and parameter names.
 
-To fix a violation of this rule, please use named parameters instead of positional parameters when calling a command.
+The use of positional parameters can reduce the readability of code and potentially introduce errors.
 
 ##How to Fix
-
-To fix a violation of this rule, please use named parameters instead of positional parameters when calling a command.
+Use full parameter names when calling commands.
 
 ##Example
-Wrong:
+###Wrong:
+``` PowerShell
+Get-ChildItem *.txt
+```
 
-	Get-ChildItem *.txt
-
-Correct:
-
-	Get-Content -Path *.txt
+###Correct:
+``` PowerShell
+Get-Content -Path *.txt
+```

--- a/RuleDocumentation/AvoidUsingUsernameAndPasswordParams.md
+++ b/RuleDocumentation/AvoidUsingUsernameAndPasswordParams.md
@@ -1,30 +1,39 @@
 #AvoidUsingUsernameAndPasswordParams
 **Severity Level: Error**
 
-
 ##Description
-
-Functions should only take in a credential parameter of type PSCredential instead of username and password parameters.
+To standardize command parameters, credentials should be accept as objects of type ```PSCredential```. Functions should not make use of username or password parameters.
 
 ##How to Fix
-
-To fix a violation of this rule, please pass username and password as a PSCredential type parameter.
+Change the parameter to type ```PSCredential```.
 
 ##Example
+###Wrong：    
+``` PowerShell
+function Test-Script
+{
+    [CmdletBinding()]
+    Param
+    (
+        [String]
+        $Username,
+        [SecureString]
+        $Password
+    )
+    ...
+}
+```
 
-Wrong：    
-```
-    [int]
-    $Param2,
-    [SecureString]
-    $Password,
-    [string]
-    $Username
-```
-
-Correct:   
-```
-    function MyFunction3 ([PSCredential]$Username, $Passwords)
-    {
-    }
+###Correct:   
+``` PowerShell
+function Test-Script
+{
+    [CmdletBinding()]
+    Param
+    (
+        [PSCredential]
+        $Credential
+    )
+    ...
+}
 ```

--- a/RuleDocumentation/AvoidUsingWMICmdlet.md
+++ b/RuleDocumentation/AvoidUsingWMICmdlet.md
@@ -5,28 +5,28 @@
 As of PowerShell 3.0, the CIM CMDLets should be used over the WMI CMDLets.
 
 The following CMDLets should not be used:
-    - ```Get-WmiObject```
-    - ```Remove-WmiObject```
-    - ```Invoke-WmiObject```
-    - ```Register-WmiEvent```
-    - ```Set-WmiInstance```
+* ```Get-WmiObject```
+* ```Remove-WmiObject```
+* ```Invoke-WmiObject```
+* ```Register-WmiEvent```
+* ```Set-WmiInstance```
 
 Use the following CMDLets instead:
-    - ```Get-CimInstance```
-    - ```Remove-CimInstance```
-    - ```Invoke-CimMethod```
-    - ```Register-CimIndicationEvent```
-    - ```Set-CimInstance```
+* ```Get-CimInstance```
+* ```Remove-CimInstance```
+* ```Invoke-CimMethod```
+* ```Register-CimIndicationEvent```
+* ```Set-CimInstance```
 
 The CIM CMDLets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, allowing for the management of Windows and non-Windows operating systems.
 
 ##How to Fix
 Change to the equivalent CIM based CMDLet.
-    - ```Get-WmiObject``` -> ```Get-CimInstance```
-    - ```Remove-WmiObject``` -> ```Remove-CimInstance```
-    - ```Invoke-WmiObject``` -> ```Invoke-CimMethod```
-    - ```Register-WmiEvent``` -> ```Register-CimIndicationEvent```
-    - ```Set-WmiInstance``` -> ```Set-CimInstance```
+* ```Get-WmiObject``` -> ```Get-CimInstance```
+* ```Remove-WmiObject``` -> ```Remove-CimInstance```
+* ```Invoke-WmiObject``` -> ```Invoke-CimMethod```
+* ```Register-WmiEvent``` -> ```Register-CimIndicationEvent```
+* ```Set-WmiInstance``` -> ```Set-CimInstance```
 
 ##Example
 ###Wrong:

--- a/RuleDocumentation/AvoidUsingWMICmdlet.md
+++ b/RuleDocumentation/AvoidUsingWMICmdlet.md
@@ -1,26 +1,42 @@
 #AvoidUsingWMICmdlet
 **Severity Level: Warning**
 
-
 ##Description
+As of PowerShell 3.0, the CIM CMDLets should be used over the WMI CMDLets.
 
-Avoid Using Get-WMIObject, Remove-WMIObject, Invoke-WmiMethod, Register-WmiEvent, Set-WmiInstance
+The following CMDLets should not be used:
+    - ```Get-WmiObject```
+    - ```Remove-WmiObject```
+    - ```Invoke-WmiObject```
+    - ```Register-WmiEvent```
+    - ```Set-WmiInstance```
 
-For PowerShell 3.0 and above, use CIM cmdlet which perform the same tasks as the WMI cmdlets. The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, which enables the cmdlets to use the same techniques to manage Windows computers and those running other operating systems.
+Use the following CMDLets instead:
+    - ```Get-CimInstance```
+    - ```Remove-CimInstance```
+    - ```Invoke-CimMethod```
+    - ```Register-CimIndicationEvent```
+    - ```Set-CimInstance```
+
+The CIM CMDLets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, allowing for the management of Windows and non-Windows operating systems.
 
 ##How to Fix
-
-Use corresponding CIM cmdlets such as Get-CIMInstance, Remove-CIMInstance, Invoke-CIMMethod, Register-CimIndicationEvent, Set-CimInstance 
+Change to the equivalent CIM based CMDLet.
+    - ```Get-WmiObject``` -> ```Get-CimInstance```
+    - ```Remove-WmiObject``` -> ```Remove-CimInstance```
+    - ```Invoke-WmiObject``` -> ```Invoke-CimMethod```
+    - ```Register-WmiEvent``` -> ```Register-CimIndicationEvent```
+    - ```Set-WmiInstance``` -> ```Set-CimInstance```
 
 ##Example
-
-Wrong:
-```
+###Wrong:
+``` PowerShell
 Get-WmiObject -Query 'Select * from Win32_Process where name LIKE "myprocess%"' | Remove-WmiObject
 Invoke-WmiMethod –Class Win32_Process –Name "Create" –ArgumentList @{ CommandLine = "notepad.exe" }
 ```
-Correct:
-```
+
+###Correct:
+``` PowerShell
 Get-CimInstance -Query 'Select * from Win32_Process where name LIKE "myprocess%"' | Remove-CIMInstance
 Invoke-CimMethod –ClassName Win32_Process –MethodName "Create" –Arguments @{ CommandLine = "notepad.exe" }
 ```

--- a/RuleDocumentation/AvoidUsingWriteHost.md
+++ b/RuleDocumentation/AvoidUsingWriteHost.md
@@ -1,34 +1,33 @@
 #AvoidUsingWriteHost 
 **Severity Level: Warning**
 
-
 ##Description
+The use of ```Write-Host``` is greatly discouraged unless in the use of commands with the ```Show``` verb. The ```Show``` verb explicitly means "show on the screen, with no 
+other possibilities".
 
-It is generally accepted that you should never use Write-Host to create any script output whatsoever, unless your script (or function, or whatever) uses the Show verb (as in, Show-Performance). That verb explicitly means “show on the screen, with no other possibilities.” Like Show-Command.
+Commands with the ```Show``` verb do not have this check applied.
 
 ##How to Fix
-
-PTo fix a violation of this rule, please replace Write-Host with Write-Output.
+Replace ```Write-Host``` with ```Write-Output``` or ```Write-Verbose```.
 
 ##Example
-
-Wrong： 
-
-```
+###Wrong： 
+``` PowerShell
 function Test
 {
 	...
 	Write-Host "Executing.."
+	...
 }
 ```
 
-Correct: 
-
-```
+###Correct: 
+``` PowerShell
 function Test
 {
 	...
 	Write-Output "Executing.."
+	...
 }
 
 function Show-Something

--- a/RuleDocumentation/DscExamplesPresent.md
+++ b/RuleDocumentation/DscExamplesPresent.md
@@ -1,13 +1,10 @@
 #DscExamplesPresent
 **Severity Level: Information**
 
-
 ##Description
-
 Checks that DSC examples for given resource are present.
 
 ##How to Fix
-
 To fix a violation of this rule, please make sure Examples directory is present:
 * For non-class based resources it should exist at the same folder level as DSCResources folder.
 * For class based resources it should be present at the same folder level as resource psm1 file. 
@@ -15,11 +12,8 @@ To fix a violation of this rule, please make sure Examples directory is present:
 Examples folder should contain sample configuration for given resource - file name should contain resource's name.
 
 ##Example
-
 ### Non-class based resource
-
 Let's assume we have non-class based resource with a following file structure:
-
 * xAzure
   * DSCResources
     * MSFT_xAzureSubscription
@@ -27,7 +21,6 @@ Let's assume we have non-class based resource with a following file structure:
       * MSFT_xAzureSubscription.schema.mof
 
 In this case, to fix this warning, we should add examples in a following way:
-
 * xAzure
   * DSCResources
     * MSFT_xAzureSubscription
@@ -38,15 +31,12 @@ In this case, to fix this warning, we should add examples in a following way:
     * MSFT_xAzureSubscription_RemoveSubscriptionExample.ps1
 
 ### Class based resource
-
 Let's assume we have class based resource with a following file structure:
-
 * MyDscResource
     * MyDscResource.psm1
     * MyDscResource.psd1
 
 In this case, to fix this warning, we should add examples in a following way:
-
 * MyDscResource
     * MyDscResource.psm1
     * MyDscResource.psd1

--- a/RuleDocumentation/DscTestsPresent.md
+++ b/RuleDocumentation/DscTestsPresent.md
@@ -33,7 +33,7 @@ In this case, to fix this warning, we should add tests in a following way:
 Let's assume we have class based resource with a following file structure:
 * MyDscResource
     * MyDscResource.psm1
-    * MyDscresource.psd1
+    * MyDscResource.psd1
 
 In this case, to fix this warning, we should add tests in a following way:
 * MyDscResource

--- a/RuleDocumentation/DscTestsPresent.md
+++ b/RuleDocumentation/DscTestsPresent.md
@@ -1,13 +1,10 @@
 #DscTestsPresent
 **Severity Level: Information**
 
-
 ##Description
-
 Checks that DSC tests for given resource are present.
 
 ##How to Fix
-
 To fix a violation of this rule, please make sure Tests directory is present:
 * For non-class based resources it should exist at the same folder level as DSCResources folder.
 * For class based resources it should be present at the same folder level as resource psm1 file. 
@@ -15,11 +12,8 @@ To fix a violation of this rule, please make sure Tests directory is present:
 Tests folder should contain test script for given resource - file name should contain resource's name.
 
 ##Example
-
 ### Non-class based resource
-
 Let's assume we have non-class based resource with a following file structure:
-
 * xAzure
   * DSCResources
     * MSFT_xAzureSubscription
@@ -27,7 +21,6 @@ Let's assume we have non-class based resource with a following file structure:
       * MSFT_xAzureSubscription.schema.mof
 
 In this case, to fix this warning, we should add tests in a following way:
-
 * xAzure
   * DSCResources
     * MSFT_xAzureSubscription
@@ -37,18 +30,15 @@ In this case, to fix this warning, we should add tests in a following way:
     * MSFT_xAzureSubscription_Tests.ps1
 
 ### Class based resource
-
 Let's assume we have class based resource with a following file structure:
-
 * MyDscResource
     * MyDscResource.psm1
     * MyDscresource.psd1
 
 In this case, to fix this warning, we should add tests in a following way:
-
 * MyDscResource
     * MyDscResource.psm1
-    * MyDscresource.psd1
+    * MyDscResource.psd1
     * Tests
       * MyDscResource_Tests.ps1
 

--- a/RuleDocumentation/MissingModuleManifestField.md
+++ b/RuleDocumentation/MissingModuleManifestField.md
@@ -1,14 +1,38 @@
 #MissingModuleManifestField 
 **Severity Level: Warning**
 
-
 ##Description
+A module manifest is a ```.psd1``` file that contains a hash table. The keys and values in the hash table describe the contents and attributes of the module, define the
+prerequisites, and determine how the components are processed. 
 
-Some fields of the module manifest (such as ModuleVersion) are required.
+Module manifests must contain the following keys (and a corresponding value) to be considered valid:
+    - ```ModuleVersion```
+
+All other keys are optional. The order of the entries is not important.
 
 ##How to Fix
-
 Please consider adding the missing fields to the manifest.
 
 ##Example
+###Wrong:
+``` PowerShell
+@{
+    Author              = 'PowerShell Author'
+    NestedModules       = @('.\mymodule.psm1')
+    FunctionsToExport   = '*'
+    CmdletsToExport     = '*'
+    VariablesToExport   = '*'
+}
+```
 
+###Correct:
+``` PowerShell
+@{
+    ModuleVersion       = '1.0'
+    Author              = 'PowerShell Author'
+    NestedModules       = @('.\mymodule.psm1')
+    FunctionsToExport   = '*'
+    CmdletsToExport     = '*'
+    VariablesToExport   = '*'
+}
+```

--- a/RuleDocumentation/MissingModuleManifestField.md
+++ b/RuleDocumentation/MissingModuleManifestField.md
@@ -6,7 +6,7 @@ A module manifest is a ```.psd1``` file that contains a hash table. The keys and
 prerequisites, and determine how the components are processed. 
 
 Module manifests must contain the following keys (and a corresponding value) to be considered valid:
-    - ```ModuleVersion```
+* ```ModuleVersion```
 
 All other keys are optional. The order of the entries is not important.
 

--- a/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
+++ b/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
@@ -5,7 +5,7 @@
 To ensure that PowerShell performs comparisons correctly, the ```$null``` element should be on the left side of the operator.
 
 There are a number of reasons why this should occur:
-* When there is an array on the left side of a null equality comparison, PowerShell will check for a $null IN the array rather than if the array is null.
+* When there is an array on the left side of a null equality comparison, PowerShell will check for a ```$null``` IN the array rather than if the array is null.
 * PowerShell will perform type casting left to right, resulting in incorrect comparisons when ```$null``` is cast to other types.
 
 ##How to Fix

--- a/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
+++ b/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
@@ -5,8 +5,8 @@
 To ensure that PowerShell performs comparisons correctly, the ```$null``` element should be on the left side of the operator.
 
 There are a number of reasons why this should occur:
-	- When there is an array on the left side of a null equality comparison, PowerShell will check for a $null IN the array rather than if the array is null.
-	- PowerShell will perform type casting left to right, resulting in incorrect comparisons when ```$null``` is cast to other types.
+* When there is an array on the left side of a null equality comparison, PowerShell will check for a $null IN the array rather than if the array is null.
+* PowerShell will perform type casting left to right, resulting in incorrect comparisons when ```$null``` is cast to other types.
 
 ##How to Fix
 Move ```$null``` to the left side of the comparison.

--- a/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
+++ b/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
@@ -1,30 +1,33 @@
 #PossibleIncorrectComparisonWithNull 
 **Severity Level: Warning**
 
-
 ##Description
+To ensure that PowerShell performs comparisons correctly, the ```$null``` element should be on the left side of the operator.
 
-Checks that $null is on the left side of any equaltiy comparisons (eq, ne, ceq, cne, ieq, ine). When there is an array on the left side of a null equality comparison, PowerShell will check for a $null IN the array rather than if the array is null. If the two sides of the comaprision are switched this is fixed. Therefore, $null should always be on the left side of equality comparisons just in case.
+There are a number of reasons why this should occur:
+	- When there is an array on the left side of a null equality comparison, PowerShell will check for a $null IN the array rather than if the array is null.
+	- PowerShell will perform type casting left to right, resulting in incorrect comparisons when ```$null``` is cast to other types.
 
 ##How to Fix
+Move ```$null``` to the left side of the comparison.
 
-Please consider moving null on the left side of the comparison.
 ##Example
-
-Wrong： 
-
-	function CompareWithNull
+### Wrong： 
+``` PowerShell
+function Test-CompareWithNull
+{
+	if ($DebugPreference -eq $null) 
 	{
-	    if ($DebugPreference -eq $null) 
-	    {
-	    }
 	}
+}
+```
 
-Correct: 
-
-	function CompareWithNull
+###Correct: 
+``` PowerShell
+function Test-CompareWithNull
+{
+	if ($null -eq $DebugPreference) 
 	{
-	    if ($null -eq $DebugPreference) 
-	    {
-	    }
 	}
+}
+```

--- a/RuleDocumentation/ProvideCommentHelp.md
+++ b/RuleDocumentation/ProvideCommentHelp.md
@@ -1,71 +1,59 @@
 #ProvideCommentHelp 
 **Severity Level: Info**
 
-
 ##Description
+Comment based help should be provided for all PowerShell commands. This test only checks for the presence of comment based help and not on the validity or format.
 
-Checks that all cmdlets have a help comment. This rule only checks existence. It does not check the content of the comment.
-
+For assistance on comment based help, use the command ```Get-Help about_comment_based_help``` or the article, "How to Write Cmdlet Help" (http://go.microsoft.com/fwlink/?LinkID=123415).
 
 ##How to Fix
-
-Please consider adding help comment for each cmdlet.
+Include comment based help for each command identified.
 
 ##Example
+###Wrong:
+``` PowerShell
+function Get-File
+{
+    [CmdletBinding()]
+    Param
+    (
+        ...
+    )
+    
+}
+```
 
-Wrong:
-
-    function Verb-Files
-    {
-        [CmdletBinding(DefaultParameterSetName='Parameter Set 1', 
-                      SupportsShouldProcess=$true, 
-                      PositionalBinding=$false,
-                      HelpUri = 'http://www.microsoft.com/',
-                      ConfirmImpact='Medium')]
-        [Alias()]
-        [OutputType([string])]
-        Param
-        (
-            ...
-        )
-       
-    }
-
-Right:
-
-    <#
-    .Synopsis
-       Short description
-    .DESCRIPTION
-       Long description
-    .EXAMPLE
-       Example of how to use this cmdlet
-    .EXAMPLE
-       Another example of how to use this cmdlet
-    .INPUTS
-       Inputs to this cmdlet (if any)
-    .OUTPUTS
-       Output from this cmdlet (if any)
-    .NOTES
-       General notes
-    .COMPONENT
-       The component this cmdlet belongs to
-    .ROLE
-       The role this cmdlet belongs to
-    .FUNCTIONALITY
-       The functionality that best describes this cmdlet
-    #>
-    function Get-File
-    {
-        [CmdletBinding(DefaultParameterSetName='Parameter Set 1', 
-                      SupportsShouldProcess=$true, 
-                      PositionalBinding=$false,
-                      HelpUri = 'http://www.microsoft.com/',
-                      ConfirmImpact='Medium')]
-        [Alias()]
-        [OutputType([string])]
-        Param
-        (
-            ...
-        )
-    }
+###Correct:
+``` PowerShell
+<#
+.Synopsis
+    Short description
+.DESCRIPTION
+    Long description
+.EXAMPLE
+    Example of how to use this cmdlet
+.EXAMPLE
+    Another example of how to use this cmdlet
+.INPUTS
+    Inputs to this cmdlet (if any)
+.OUTPUTS
+    Output from this cmdlet (if any)
+.NOTES
+    General notes
+.COMPONENT
+    The component this cmdlet belongs to
+.ROLE
+    The role this cmdlet belongs to
+.FUNCTIONALITY
+    The functionality that best describes this cmdlet
+#>
+function Get-File
+{
+    [CmdletBinding()]
+    Param
+    (
+        ...
+    )
+    
+}
+```

--- a/RuleDocumentation/ProvideDefaultParameterValue.md
+++ b/RuleDocumentation/ProvideDefaultParameterValue.md
@@ -1,28 +1,24 @@
 #ProvideDefaultParameterValue
 **Severity Level: Warning**
 
-
 ##Description
-Parameters must have a default value as uninitialized parameters will lead to potential bugs in the scripts.
+Just like non-global scoped variables, parameters must have a default value if they are not mandatory, i.e ```Mandatory=$false```. 
+Having optional parameters without default values leads to uninitialized variables leading to potential bugs.
 
 ##How to Fix
-
-To fix a violation of this rule, please specify a default value for all parameters.
+Specify a default value for all parameters that are not mandatory.
 
 ##Example
-
-Wrong： 
-
-```
+###Wrong： 
+``` PowerShell
 function Test($Param1)
 {
 	$Param1
 }
 ```
 
-Correct: 
-
-```
+###Correct: 
+``` PowerShell
 function Test($Param1 = $null)
 {
 	$Param1

--- a/RuleDocumentation/ProvideVerboseMessage.md
+++ b/RuleDocumentation/ProvideVerboseMessage.md
@@ -1,30 +1,30 @@
 #ProvideVerboseMessage 
 **Severity Level: Information**
 
-
 ##Description
-
-Checks that Write-Verbose is called at least once in every cmdlet or script. This is in line with the PowerShell best practices.
-
+Best practice recommends that additional user information is provided within commands, functions and scripts using ```Write-Verbose```.
+ 
 ##How to Fix
-
-Please consider adding Write-Verbose in each cmdlet.
+Make use of the ```Write-Verbose``` command.
 
 ##Example
-Correct
-```
-Function TestFunction1
+###Wrong： 
+``` PowerShell
+Function Test-Function
 {
-    [cmdletbinding()]
+    [CmdletBinding()]
+    Param()
+    ...
+}
+```
+
+###Correct:
+``` PowerShell
+Function Test-Function
+{
+    [CmdletBinding()]
     Param()
     Write-Verbose "Verbose output"
-
-}
-
-Function TestFunction2
-{
-    [cmdletbinding()]
-    Param(）
-    Write-Verbose "Verbose output"
+    ...
 }
 ```

--- a/RuleDocumentation/ReturnCorrectTypeDSCFunctions.md
+++ b/RuleDocumentation/ReturnCorrectTypeDSCFunctions.md
@@ -5,14 +5,14 @@
 The functions in DSC resources have specific return objects.
 
 For non-class based resources:
-    - ```Set-TargetResource``` must not return any value.
-    - ```Test-TargetResource``` must return a boolean.
-    - ```Get-TargetResource``` must return a hash table.
+* ```Set-TargetResource``` must not return any value.
+* ```Test-TargetResource``` must return a boolean.
+* ```Get-TargetResource``` must return a hash table.
 
 For class based resources:
-    - ```Set``` must not return any value.
-    - ```Test``` must return a boolean.
-    - ```Get``` must return an instance of the DSC class.
+* ```Set``` must not return any value.
+* ```Test``` must return a boolean.
+* ```Get``` must return an instance of the DSC class.
 
 ##How to Fix
 Ensure that each function returns the correct type.

--- a/RuleDocumentation/ReturnCorrectTypeDSCFunctions.md
+++ b/RuleDocumentation/ReturnCorrectTypeDSCFunctions.md
@@ -1,17 +1,146 @@
 #ReturnCorrectTypeDSCFunctions 
 **Severity Level: Information**
 
-
 ##Description
+The functions in DSC resources have specific return objects.
 
-Set function in DSC class and Set-TargetResource in DSC resource must not return anything. Get function in DSC class must return an instance of the DSC class and Get-TargetResource function in DSC resource must return a hashtable. Test function in DSC class and Get-TargetResource function in DSC resource must return a boolean.
+For non-class based resources:
+    - ```Set-TargetResource``` must not return any value.
+    - ```Test-TargetResource``` must return a boolean.
+    - ```Get-TargetResource``` must return a hash table.
 
+For class based resources:
+    - ```Set``` must not return any value.
+    - ```Test``` must return a boolean.
+    - ```Get``` must return an instance of the DSC class.
 
 ##How to Fix
+Ensure that each function returns the correct type.
 
-To fix a violation of this rule, please correct the return type of the Get/Set/Test-TargetResource functions in DSC resource.
+##Example Non Class Based
+###Wrong:
+``` PowerShell
+function Get-TargetResource
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
 
+function Set-TargetResource
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
 
-##Example
+function Test-TargetResource
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+```
+
+###Correct:
+``` PowerShell
+function Get-TargetResource
+{
+    [OutputType([Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+
+function Set-TargetResource
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+
+function Test-TargetResource
+{
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+```
+
+##Example Class Based
+###Wrong:
+``` PowerShell
+[DscResource()]
+class MyDSCResource
+{
+    [DscProperty(Key)]
+    [string] $Name
+
+    [String] Get() 
+    {
+        ...
+    }
+
+    [String] Set() 
+    {
+        ...
+    }
+
+    [bool] Test() 
+    {
+        ...
+    }
+}
+```
+
+###Correct:
+``` PowerShell
+[DscResource()]
+class MyDSCResource
+{
+    [DscProperty(Key)]
+    [string] $Name
+
+    [MyDSCResource] Get() 
+    {
+        ...
+    }
+
+    [void] Set() 
+    {
+        ...
+    }
+
+    [bool] Test() 
+    {
+        ...
+    }
+}
+```
 
 

--- a/RuleDocumentation/UseApprovedVerbs.md
+++ b/RuleDocumentation/UseApprovedVerbs.md
@@ -1,28 +1,27 @@
 #UseApprovedVerbs 
 **Severity Level: Warning**
 
-
 ##Description
+All CMDLets must used approved verbs.
 
-All defined cmdlets must use approved verbs. This is in line with PowerShell's best practices.
+Approved verbs can be found by running the command ```Get-Verb```.
 
 ##How to Fix
-
-Please consider using full cmdlet name instead of alias. 
+Change the verb in the CMDLet's name to an approved verb. 
 
 ##Example
+###Wrong： 
+``` PowerShell
+function Change-Item
+{
+    ...
+}
+````
 
-Wrong： 
-
-    function Change-Item
-    {
-        ...
-    }
-
-Correct: 
-    
-    function Update-Item
-    {
-        ...
-    }
-
+###Correct: 
+``` PowerShell    
+function Update-Item
+{
+    ...
+}
+```

--- a/RuleDocumentation/UseBOMForUnicodeEncodedFile.md
+++ b/RuleDocumentation/UseBOMForUnicodeEncodedFile.md
@@ -2,5 +2,7 @@
 **Severity Level: Warning**
 
 ##Description
+For a file encoded with a format other than ASCII, ensure Byte Order Mark (BOM) is present to ensure that any application consuming this file can interpret it correctly.
 
-For a file encoded with a format other than ASCII, ensure BOM is present to ensure that any application consuming this file can interpret it correctly.
+##How to Fix
+Ensure that the file is encoded with BOM present.

--- a/RuleDocumentation/UseCmdletCorrectly.md
+++ b/RuleDocumentation/UseCmdletCorrectly.md
@@ -1,22 +1,28 @@
 #UseCmdletCorrectly 
 **Severity Level: Warning**
 
-
 ##Description
-
-Cmdlets must be invoked with the correct syntax and parameters. For example, calling Set-Date with no parameters would be triggered by this rule since it has a required date parameter. 
+Whenever we call a command, care should be taken that it is invoked with the correct syntax and parameters.
 
 ##How to Fix
-
-To fix a violation of this rule, please use mandatory parameters when calling cmdlets.
+Specify all mandatory parameters when calling commands.
 
 ##Example
-
-Wrong： 
-
+###Wrong： 
+``` PowerShell
+Function Set-TodaysDate ()
+{
 	Set-Date
+	...
+}
+```
 
-Correct: 
-
+###Correct:
+``` PowerShell
+Function Set-TodaysDate ()
+{
 	$date = Get-Date
 	Set-Date -Date $t
+	...
+}
+```

--- a/RuleDocumentation/UseDeclaredVarsMoreThanAssignments.md
+++ b/RuleDocumentation/UseDeclaredVarsMoreThanAssignments.md
@@ -1,31 +1,28 @@
 #UseDeclaredVarsMoreThanAssignments 
 **Severity Level: Warning**
 
-
 ##Description
-
-Checks that variables are used in more than just their assignment. Generally this is a red flag that a variable is not needed. This rule does not check if the assignment and usage are in the same function.
-
+Generally variables that are not used more than their assignments are considered wasteful and not needed.
 
 ##How to Fix
-
-Please consider remove the variables that are declared but not used outside of the function.
-
+Remove the variables that are declared but not used outside of the function.
 
 ##Example
-Wrong： 
-    
-    function Test
-    {
-        $declaredVar = "Declared"
-        $declaredVar2 = "Not used"
-    }
+###Wrong： 
+``` PowerShell
+function Test
+{
+    $declaredVar = "Declared just for fun"
+    $declaredVar2 = "Not used"
+    Write-Output $declaredVar
+}
+```
 
-Correct: 
-
-    function Test
-    {
-        $declaredVar = "Declared just for fun"
-        Write-Output $declaredVar
-    }
-
+###Correct: 
+``` PowerShell
+function Test
+{
+    $declaredVar = "Declared just for fun"
+    Write-Output $declaredVar
+}
+```

--- a/RuleDocumentation/UseIdenticalMandatoryParametersDSC.md
+++ b/RuleDocumentation/UseIdenticalMandatoryParametersDSC.md
@@ -1,17 +1,85 @@
 #UseIdenticalMandatoryParametersDSC 
 **Severity Level: Error**
 
-
 ##Description
-
-The Get/Test/Set TargetResource functions of DSC Resource must have the same mandatory parameters
-
+The ```Get-TargetResource```, ```Test-TargetResource``` and ```Set-TargetResource``` functions of DSC Resource must have the same mandatory parameters.
 
 ##How to Fix
+Correct the mandatory parameters for the functions in DSC resource.
 
-To fix a violation of this rule, please correct the mandatory parameters for Get/Set/Test functions in DSC resource.
+##Example Non Class Based
+###Wrong:
+``` PowerShell
+function Get-TargetResource
+{
+    [OutputType([Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
 
+function Set-TargetResource
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $TargetName
+    )
+    ...
+}
 
-##Example
+function Test-TargetResource
+{
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+```
 
+###Correct:
+``` PowerShell
+function Get-TargetResource
+{
+    [OutputType([Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
 
+function Set-TargetResource
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+
+function Test-TargetResource
+{
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+```

--- a/RuleDocumentation/UseIdenticalParametersDSC.md
+++ b/RuleDocumentation/UseIdenticalParametersDSC.md
@@ -1,17 +1,97 @@
 #UseIdenticalParametersDSC 
 **Severity Level: Error**
 
-
 ##Description
-
-The Test and Set-TargetResource functions of DSC Resource must have the same parameters.
-
+The ```Get-TargetResource```, ```Test-TargetResource``` and ```Set-TargetResource``` functions of DSC Resource must have the same parameters.
 
 ##How to Fix
+Correct the parameters for the functions in DSC resource.
 
-To fix a violation of this rule, please correct the mandatory parameters for Test and Set-TargetResource functions in DSC resource.
+##Example Non Class Based
+###Wrong:
+``` PowerShell
+function Get-TargetResource
+{
+    [OutputType([Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name,
 
+        [String]
+        $TargetResource
+    )
+    ...
+}
 
-##Example
+function Set-TargetResource
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
 
+function Test-TargetResource
+{
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+```
 
+###Correct:
+``` PowerShell
+function Get-TargetResource
+{
+    [OutputType([Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name,
+
+        [String]
+        $TargetResource
+    )
+    ...
+}
+
+function Set-TargetResource
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name,
+
+        [String]
+        $TargetResource
+    )
+    ...
+}
+
+function Test-TargetResource
+{
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name,
+
+        [String]
+        $TargetResource
+    )
+    ...
+}
+```

--- a/RuleDocumentation/UseOutputTypeCorrectly.md
+++ b/RuleDocumentation/UseOutputTypeCorrectly.md
@@ -31,6 +31,6 @@ function Get-Foo
         Param(
         )
 
-        return "bar"
+        return "four"
 }
 ```

--- a/RuleDocumentation/UseOutputTypeCorrectly.md
+++ b/RuleDocumentation/UseOutputTypeCorrectly.md
@@ -1,37 +1,36 @@
 ﻿#UseOutputTypeCorrectly 
 **Severity Level: Information**
 
-
 ##Description
+A command should return the same type as declared in ```OutputType```.
 
-If a return type is declared, the cmdlet must return that type. If a type is returned, a return type must be declared.
+You can get more details by running ```Get-Help about_Functions_OutputTypeAttribute``` command in Windows PowerShell.
 
 ##How to Fix
-
-To fix a violation of this rule, please check the OuputType attribute lists and the types that are returned in your code. You can get more details by running “Get-Help about_Functions_OutputTypeAttribute” command in Windows PowerShell. 
-
-##Example
+Specify that the OutputType attribute lists and the types returned in the CMDLet match.
 
 ##Example
-Wrong:
+###Wrong:
+``` PowerShell
+function Get-Foo
+{
+        [CmdletBinding()]
+        [OutputType([String])]
+        Param(
+        )
+        return 4
+}
+```
 
-	function Get-Foo
-	{
-            [CmdletBinding()]
-            [OutputType([String])]
-            Param(
-            )
-            return "4
-	}
+###Correct:
+``` PowerShell
+function Get-Foo
+{
+        [CmdletBinding()]
+        [OutputType([String])]
+        Param(
+        )
 
-Correct:
-
-	function Get-Foo
-	{
-            [CmdletBinding()]
-            [OutputType([String])]
-            Param(
-            )
-
-            return "bar"
-	}
+        return "bar"
+}
+```

--- a/RuleDocumentation/UsePSCredentialType.md
+++ b/RuleDocumentation/UsePSCredentialType.md
@@ -1,27 +1,25 @@
 #UsePSCredentialType
 **Severity Level: Warning**
 
-
 ##Description
-
-Checks that cmdlets that have a Credential parameter accept PSCredential. This comes from the PowerShell teams best practices.
+If the CMDLet or function has a Credential parameter, the parameter must accept the ```PSCredential``` type.
 
 ##How to Fix
-
-Please change the parameter type to be PSCredential.
+Change the Credential parameter's type to be ```PSCredential```.
 
 ##Example
+###Wrong:
+``` PowerShell
+function Credential([String]$Credential) 
+{
+	...
+}
+```
 
-Wrong:
-
-	function Credential([String]$Credential) 
-	{
-		...
-	}
-
-Correct:
-
-	function Credential([PSCredential]$Credential) 
-	{
-		...
-	}
+###Correct:
+``` PowerShell
+function Credential([PSCredential]$Credential) 
+{
+	...
+}
+```

--- a/RuleDocumentation/UsePSCredentialType.md
+++ b/RuleDocumentation/UsePSCredentialType.md
@@ -2,10 +2,10 @@
 **Severity Level: Warning**
 
 ##Description
-If the CMDLet or function has a Credential parameter, the parameter must accept the ```PSCredential``` type.
+If the CMDLet or function has a ```Credential``` parameter, the parameter must accept the ```PSCredential``` type.
 
 ##How to Fix
-Change the Credential parameter's type to be ```PSCredential```.
+Change the ```Credential``` parameter's type to be ```PSCredential```.
 
 ##Example
 ###Wrong:

--- a/RuleDocumentation/UseShouldProcessCorrectly.md
+++ b/RuleDocumentation/UseShouldProcessCorrectly.md
@@ -5,13 +5,13 @@
 Checks that if the ```SupportsShouldProcess``` is present, i.e, ```[CmdletBinding(SupportsShouldProcess = $true)]```, and then tests if the function or CMDLet calls 
 ShouldProcess or ShouldContinue; i.e ```$PSCmdlet.ShouldProcess``` or ```$PSCmdlet.ShouldContinue```.
 
-A violation is any function where ```SupportsShouldProcess``` that makes no calls to ShouldProcess or ShouldContinue.
+A violation is any function where ```SupportsShouldProcess``` that makes no calls to ```ShouldProcess``` or ```ShouldContinue```.
 
 Scripts with one or the other but not both will generally run into an error or unexpected behavior.
 
 ##How to Fix
-To fix a violation of this rule, please call ShouldProcess method in advanced functions when SupportsShouldProcess argument is present. 
-Or please add SupportsShouldProcess argument when calling ShouldProcess.
+To fix a violation of this rule, please call ```ShouldProcess``` method in advanced functions when ```SupportsShouldProcess``` argument is present. 
+Or please add ```SupportsShouldProcess``` argument when calling ```ShouldProcess```.
 You can get more details by running ```Get-Help about_Functions_CmdletBindingAttribute``` and ```Get-Help about_Functions_Advanced_Methods``` command in Windows PowerShell.
 
 ##Example

--- a/RuleDocumentation/UseShouldProcessCorrectly.md
+++ b/RuleDocumentation/UseShouldProcessCorrectly.md
@@ -1,53 +1,30 @@
 #UseShouldProcessCorrectly 
 **Severity Level: Warning**
 
-
 ##Description
+Checks that if the ```SupportsShouldProcess``` is present, i.e, ```[CmdletBinding(SupportsShouldProcess = $true)]```, and then tests if the function or CMDLet calls 
+ShouldProcess or ShouldContinue; i.e ```$PSCmdlet.ShouldProcess``` or ```$PSCmdlet.ShouldContinue```.
 
-Checks that if the SupportsShouldProcess is present, the function calls ShouldProcess/ShouldContinue and vice versa. Scripts with one or the other but not both will generally run into an error or unexpected behavior.
+A violation is any function where ```SupportsShouldProcess``` that makes no calls to ShouldProcess or ShouldContinue.
 
+Scripts with one or the other but not both will generally run into an error or unexpected behavior.
 
 ##How to Fix
-
-To fix a violation of this rule, please call ShouldProcess method in advanced functions when SupportsShouldProcess argument is present. Or please add SupportsShouldProcess argument when calling ShouldProcess.You can get more details by running “Get-Help about_Functions_CmdletBindingAttribute” and “Get-Help about_Functions_Advanced_Methods” command in Windows PowerShell.
+To fix a violation of this rule, please call ShouldProcess method in advanced functions when SupportsShouldProcess argument is present. 
+Or please add SupportsShouldProcess argument when calling ShouldProcess.
+You can get more details by running ```Get-Help about_Functions_CmdletBindingAttribute``` and ```Get-Help about_Functions_Advanced_Methods``` command in Windows PowerShell.
 
 ##Example
-
-Wrong： 
-
-	function Verb-Files
+###Wrong： 
+``` PowerShell
+	function Set-File
 	{
-	    [CmdletBinding(DefaultParameterSetName='Parameter Set 1', 
-	                  SupportsShouldProcess=$true, 
-	                  PositionalBinding=$false,
-	                  HelpUri = 'http://www.microsoft.com/',
-	                  ConfirmImpact='Medium')]
-	    [Alias()]
-	    [OutputType([String])]
+	    [CmdletBinding(SupportsShouldProcess=$true)]
 	    Param
 	    (
-	        # Param1 help description
-	        [Parameter(Mandatory=$true, 
-	                   ValueFromPipeline=$true,
-	                   ValueFromPipelineByPropertyName=$true, 
-	                   ValueFromRemainingArguments=$false, 
-	                   Position=0,
-	                   ParameterSetName='Parameter Set 1')]
-	        [ValidateNotNull()]
-	        [ValidateNotNullOrEmpty()]
-	        [ValidateCount(0,5)]
-	        [ValidateSet("sun", "moon", "earth")]
-	        [Alias("p1")] 
-	        $Param1,
-	        # Param2 help description
-	        [Parameter(ParameterSetName='Parameter Set 1')]
-	        [AllowNull()]
-	        [AllowEmptyCollection()]
-	        [AllowEmptyString()]
-	        [ValidateScript({$true})]
-	        [ValidateRange(0,5)]
-	        [int]
-	        $Verbose,
+	        # Path to file
+			[Parameter(Mandatory=$true)] 
+	        $Path
 	    )
 
 	    Begin
@@ -55,57 +32,24 @@ Wrong：
 	    }
 	    Process
 	    {
+			"String" | Out-File -FilePath $FilePath
 	    }
 	    End
 	    {
 	    }
 	}
+```
 
-Correct:
-
-	function Get-File
+###Correct:
+``` PowerShell
+	function Set-File
 	{
-	    [CmdletBinding(DefaultParameterSetName='Parameter Set 1', 
-	                  SupportsShouldProcess=$true, 
-	                  PositionalBinding=$false,
-	                  HelpUri = 'http://www.microsoft.com/',
-	                  ConfirmImpact='Medium')]
-	    [Alias()]
-	    [OutputType([String])]
+	    [CmdletBinding(SupportsShouldProcess=$true)]
 	    Param
 	    (
-	        # Param1 help description
-	        [Parameter(Mandatory=$true, 
-	                   ValueFromPipeline=$true,
-	                   ValueFromPipelineByPropertyName=$true, 
-	                   ValueFromRemainingArguments=$false, 
-	                   Position=0,
-	                   ParameterSetName='Parameter Set 1')]
-	        [ValidateNotNull()]
-	        [ValidateNotNullOrEmpty()]
-	        [ValidateCount(0,5)]
-	        [ValidateSet("sun", "moon", "earth")]
-	        [Alias("p1")] 
-	        $Param1,
-
-	        # Param2 help description
-	        [Parameter(ParameterSetName='Parameter Set 1')]
-	        [AllowNull()]
-	        [AllowEmptyCollection()]
-	        [AllowEmptyString()]
-	        [ValidateScript({$true})]
-	        [ValidateRange(0,5)]
-	        [int]
-	        $Param2,
-
-	        # Param3 help description
-	        [Parameter(ParameterSetName='Another Parameter Set')]
-	        [ValidatePattern("[a-z]*")]
-	        [ValidateLength(0,15)]
-	        [String]
-	        $Param3,
-	        [bool]
-	        $Force
+	        # Path to file
+			[Parameter(Mandatory=$true)] 
+	        $Path
 	    )
 
 	    Begin
@@ -113,15 +57,17 @@ Correct:
 	    }
 	    Process
 	    {
-	        if ($pscmdlet.ShouldProcess("Target", "Operation"))
+			if ($PSCmdlet.ShouldProcess("Target", "Operation"))
 	        {
-	            Write-Verbose "Write Verbose"
-	            Get-Process
-	        }
+				"String" | Out-File -FilePath $FilePath
+			}
 	    }
 	    End
 	    {
-	        if ($pscmdlet.ShouldContinue("Yes", "No")) {
-	        }
+			if ($pscmdlet.ShouldContinue("Yes", "No")) 
+			{
+				...
+        	}
 	    }
 	}
+```

--- a/RuleDocumentation/UseShouldProcessForStateChangingFunctions.md
+++ b/RuleDocumentation/UseShouldProcessForStateChangingFunctions.md
@@ -2,29 +2,44 @@
 **Severity Level: Warning**
 
 ##Description
+Functions whose verbs change system state should support ```ShouldProcess```.
 
-Functions that have verbs like New, Start, Stop, Set, Reset and Restart that change system state should support 'ShouldProcess'
+Verbs that should support ```ShouldProcess```:
+	- ```New```
+	- ```Reset```
+	- ```Restart```
+	- ```Set```
+	- ```Start```
+	- ```Stop```
 
 ##How to Fix
-
-To fix a violation of this rule, please add attribute SupportsShouldProcess. eg: [CmdletBinding(SupportsShouldProcess = $true)] to the function.
+Include the attribute ```SupportsShouldProcess```, in the ```CmdletBindingBinding```.
 
 ##Example
-
-Wrong:
-```
+###Wrong:
+``` PowerShell
 	function Set-ServiceObject
 	{
 	    [CmdletBinding()]
-    	    param ([string]$c)
+		param 
+		(
+			[string]
+			$Parameter1
+		)
+		...
 	}
 ```
 
-Correct: 
-```
+###Correct: 
+``` PowerShell
 	function Set-ServiceObject
 	{
 	    [CmdletBinding(SupportsShouldProcess = $true)]
-	    param ([string]$c)
+	    param 
+		(
+			[string]
+			$Parameter1
+		)
+		...
 	}
 ```

--- a/RuleDocumentation/UseShouldProcessForStateChangingFunctions.md
+++ b/RuleDocumentation/UseShouldProcessForStateChangingFunctions.md
@@ -5,12 +5,12 @@
 Functions whose verbs change system state should support ```ShouldProcess```.
 
 Verbs that should support ```ShouldProcess```:
-	- ```New```
-	- ```Reset```
-	- ```Restart```
-	- ```Set```
-	- ```Start```
-	- ```Stop```
+* ```New```
+* ```Reset```
+* ```Restart```
+* ```Set```
+* ```Start```
+* ```Stop```
 
 ##How to Fix
 Include the attribute ```SupportsShouldProcess```, in the ```CmdletBindingBinding```.

--- a/RuleDocumentation/UseSingularNouns.md
+++ b/RuleDocumentation/UseSingularNouns.md
@@ -2,25 +2,24 @@
 **Severity Level: Warning**
 
 ##Description
-
-Cmdlet should use singular instead of plural nouns. This comes from the PowerShell teams best practices.
+PowerShell team best practices state CMDLets should use singular nouns and not plurals.
 
 ##How to Fix
-
-Please correct the plural nouns to be singluar.
+Change plurals to singular.
 
 ##Example
+###Wrong：
+``` PowerShell
+function Get-Files
+{
+	...
+}
+```
 
-Wrong：
-
-	function Get-Files
-	{
-		...
-	}
-
-Correct: 
-
-	function Get-File
-	{
-		...
-	}
+###Correct: 
+``` PowerShell
+function Get-File
+{
+	...
+}
+```

--- a/RuleDocumentation/UseStandardDSCFunctionsInResource.md
+++ b/RuleDocumentation/UseStandardDSCFunctionsInResource.md
@@ -5,14 +5,14 @@
 All DSC resources are required to implement the correct functions.
 
 For non-class based resources:
-    - ```Set-TargetResource``` 
-    - ```Test-TargetResource```
-    - ```Get-TargetResource```
+* ```Set-TargetResource``` 
+* ```Test-TargetResource```
+* ```Get-TargetResource```
 
 For class based resources:
-    - ```Set```
-    - ```Test```
-    - ```Get```
+* ```Set```
+* ```Test```
+* ```Get```
 
 ##How to Fix
 Add the missing functions to the resource.

--- a/RuleDocumentation/UseStandardDSCFunctionsInResource.md
+++ b/RuleDocumentation/UseStandardDSCFunctionsInResource.md
@@ -1,16 +1,133 @@
 #UseStandardDSCFunctionsInResource
 **Severity Level: Error**
 
-
 ##Description
+All DSC resources are required to implement the correct functions.
 
-DSC Resource must implement Get, Set and Test-TargetResource functions. DSC Class must implement Get, Set and Test functions.
+For non-class based resources:
+    - ```Set-TargetResource``` 
+    - ```Test-TargetResource```
+    - ```Get-TargetResource```
 
+For class based resources:
+    - ```Set```
+    - ```Test```
+    - ```Get```
 
 ##How to Fix
+Add the missing functions to the resource.
 
-To fix a violation of this rule, please add the missing functions to the resouce.
- 
+##Example Non Class Based
+###Wrong:
+``` PowerShell
+function Get-TargetResource
+{
+    [OutputType([Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
 
-##Example
+function Set-TargetResource
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+```
+###Correct:
+``` PowerShell
+function Get-TargetResource
+{
+    [OutputType([Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+
+function Set-TargetResource
+{
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+
+function Test-TargetResource
+{
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [String]
+        $Name
+    )
+    ...
+}
+```
+
+##Example Class Based
+###Wrong:
+``` PowerShell
+[DscResource()]
+class MyDSCResource
+{
+    [DscProperty(Key)]
+    [string] $Name
+
+    [void] Set() 
+    {
+        ...
+    }
+
+    [bool] Test() 
+    {
+        ...
+    }
+}
+
+###Correct:
+``` PowerShell
+[DscResource()]
+class MyDSCResource
+{
+    [DscProperty(Key)]
+    [string] $Name
+
+    [MyDSCResource] Get() 
+    {
+        ...
+    }
+
+    [void] Set() 
+    {
+        ...
+    }
+
+    [bool] Test() 
+    {
+        ...
+    }
+}
+```
+
+
+
+
+
 

--- a/RuleDocumentation/UseToExportFieldsInManifest.md
+++ b/RuleDocumentation/UseToExportFieldsInManifest.md
@@ -1,28 +1,40 @@
 #UseToExportFieldsInManifest 
 **Severity Level: Warning**
 
-
 ##Description
+To improve the performance of module auto-discovery, module manifests should not use wildcards (*) or null (```$null``) in the following entries:
+	- ```AliasesToExport```
+	- ```CmdletsToExport```
+	- ```FunctionsToExport```
+	- ```VariablesToExport```
 
-In a module manifest, AliasesToExport, CmdletsToExport, FunctionsToExport and VariablesToExport fields should not use wildcards or $null in their entries. During module auto-discovery, if any of these entries are missing or $null or wildcard, PowerShell does some potentially expensive work to analyze the rest of the module.
+The use of wildcards or null has the potential to cause PowerShell to perform expensive work to analyse a module during module auto-discovery.
 
 ##How to Fix
-
-Please consider using an explicit list. 
+Use an explicit list in the entries.
 
 ##Example 1
+Suppose there are no functions in your module to export. Then,
 
-Wrong： 
- 	FunctionsToExport = $null
+###Wrong： 
+``` PowerShell
+FunctionsToExport = $null
+```
 
-Correct: 
-	FunctionToExport = @()
+###Correct:
+``` PowerShell 
+FunctionToExport = @()
+```
 
 ##Example 2
 Suppose there are only two functions in your module, Get-Foo and Set-Foo that you want to export. Then,
 
-Wrong:	
-	FunctionsToExport = '*'
+###Wrong:
+``` PowerShell	
+FunctionsToExport = '*'
+```
 
-Correct:
-	FunctionToExport = @(Get-Foo, Set-Foo)	
+###Correct:
+``` PowerShell
+FunctionToExport = @(Get-Foo, Set-Foo)
+```

--- a/RuleDocumentation/UseToExportFieldsInManifest.md
+++ b/RuleDocumentation/UseToExportFieldsInManifest.md
@@ -3,10 +3,10 @@
 
 ##Description
 To improve the performance of module auto-discovery, module manifests should not use wildcards (*) or null (```$null``) in the following entries:
-	- ```AliasesToExport```
-	- ```CmdletsToExport```
-	- ```FunctionsToExport```
-	- ```VariablesToExport```
+* ```AliasesToExport```
+* ```CmdletsToExport```
+* ```FunctionsToExport```
+* ```VariablesToExport```
 
 The use of wildcards or null has the potential to cause PowerShell to perform expensive work to analyse a module during module auto-discovery.
 

--- a/RuleDocumentation/UseToExportFieldsInManifest.md
+++ b/RuleDocumentation/UseToExportFieldsInManifest.md
@@ -2,7 +2,7 @@
 **Severity Level: Warning**
 
 ##Description
-To improve the performance of module auto-discovery, module manifests should not use wildcards (*) or null (```$null``) in the following entries:
+To improve the performance of module auto-discovery, module manifests should not use wildcards (```'*'```) or null (```$null```) in the following entries:
 * ```AliasesToExport```
 * ```CmdletsToExport```
 * ```FunctionsToExport```
@@ -27,7 +27,7 @@ FunctionToExport = @()
 ```
 
 ##Example 2
-Suppose there are only two functions in your module, Get-Foo and Set-Foo that you want to export. Then,
+Suppose there are only two functions in your module, ```Get-Foo``` and ```Set-Foo``` that you want to export. Then,
 
 ###Wrong:
 ``` PowerShell	

--- a/ScriptRuleDocumentation.md
+++ b/ScriptRuleDocumentation.md
@@ -54,21 +54,21 @@ Export-ModuleMember -Function (FunctionName)
 ###Example
 ``` PowerShell
 <#
-.SYNOPSIS
-    Uses #Requires -RunAsAdministrator instead of your own methods.
-.DESCRIPTION
-    The #Requires statement prevents a script from running unless the Windows PowerShell version, modules, snap-ins, and module and snap-in version prerequisites are met. 
-    From Windows PowerShell 4.0, the #Requires statement let script developers require that sessions be run with elevated user rights (run as Administrator). 
-    Script developers does not need to write their own methods any more.
-    To fix a violation of this rule, please consider to use #Requires -RunAsAdministrator instead of your own methods.
-.EXAMPLE
-    Measure-RequiresRunAsAdministrator -ScriptBlockAst $ScriptBlockAst
-.INPUTS
-    [System.Management.Automation.Language.ScriptBlockAst]
-.OUTPUTS
-    [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]]
-.NOTES
-    None
+        .SYNOPSIS
+        Uses #Requires -RunAsAdministrator instead of your own methods.
+        .DESCRIPTION
+        The #Requires statement prevents a script from running unless the Windows PowerShell version, modules, snap-ins, and module and snap-in version prerequisites are met. 
+        From Windows PowerShell 4.0, the #Requires statement let script developers require that sessions be run with elevated user rights (run as Administrator). 
+        Script developers does not need to write their own methods any more.
+        To fix a violation of this rule, please consider to use #Requires -RunAsAdministrator instead of your own methods.
+        .EXAMPLE
+        Measure-RequiresRunAsAdministrator -ScriptBlockAst $ScriptBlockAst
+        .INPUTS
+        [System.Management.Automation.Language.ScriptBlockAst]
+        .OUTPUTS
+        [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]]
+        .NOTES
+        None
 #>
 function Measure-RequiresRunAsAdministrator
 {
@@ -94,13 +94,13 @@ function Measure-RequiresRunAsAdministrator
                 [bool]$returnValue = $false
                 if ($Ast -is [System.Management.Automation.Language.MemberExpressionAst])
                 {
-                    [System.Management.Automation.Language.MemberExpressionAst]$meAst = $ast;
+                    [System.Management.Automation.Language.MemberExpressionAst]$meAst = $Ast
                     if ($meAst.Member -is [System.Management.Automation.Language.StringConstantExpressionAst])
                     {
-                        [System.Management.Automation.Language.StringConstantExpressionAst]$sceAst = $meAst.Member;
-                        if ($sceAst.Value -eq "isinrole")
+                        [System.Management.Automation.Language.StringConstantExpressionAst]$sceAst = $meAst.Member
+                        if ($sceAst.Value -eq 'isinrole')
                         {
-                            $returnValue = $true;
+                            $returnValue = $true
                         }
                     }
                 }
@@ -111,10 +111,10 @@ function Measure-RequiresRunAsAdministrator
             [ScriptBlock]$predicate2 = {
                 param ([System.Management.Automation.Language.Ast]$Ast)
                 [bool]$returnValue = $false
-                if ($ast -is [System.Management.Automation.Language.AssignmentStatementAst])
+                if ($Ast -is [System.Management.Automation.Language.AssignmentStatementAst])
                 {
-                    [System.Management.Automation.Language.AssignmentStatementAst]$asAst = $Ast;
-                    if ($asAst.Right.ToString().ToLower() -eq "[system.security.principal.windowsbuiltinrole]::administrator")
+                    [System.Management.Automation.Language.AssignmentStatementAst]$asAst = $Ast
+                    if ($asAst.Right.ToString().ToLower() -eq '[system.security.principal.windowsbuiltinrole]::administrator')
                     {
                         $returnValue = $true
                     }
@@ -129,12 +129,14 @@ function Measure-RequiresRunAsAdministrator
             if ($null -ne $ScriptBlockAst.ScriptRequirements)
             {
                 if ((!$ScriptBlockAst.ScriptRequirements.IsElevationRequired) -and 
-                    ($methodAst.Count -ne 0) -and ($assignmentAst.Count -ne 0))
+                ($methodAst.Count -ne 0) -and ($assignmentAst.Count -ne 0))
                 {
-                    $result = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{"Message"  = $Messages.MeasureRequiresRunAsAdministrator; 
-                                                "Extent"   = $assignmentAst.Extent;
-                                                "RuleName" = $PSCmdlet.MyInvocation.InvocationName;
-                                                "Severity" = "Information"}
+                    $result = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
+                        'Message' = $Messages.MeasureRequiresRunAsAdministrator
+                        'Extent' = $assignmentAst.Extent
+                        'RuleName' = $PSCmdlet.MyInvocation.InvocationName
+                        'Severity' = 'Information'
+                    }
                     $results += $result               
                 }
             }
@@ -142,10 +144,12 @@ function Measure-RequiresRunAsAdministrator
             {
                 if (($methodAst.Count -ne 0) -and ($assignmentAst.Count -ne 0))
                 {
-                    $result = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{"Message"  = $Messages.MeasureRequiresRunAsAdministrator; 
-                                                "Extent"   = $assignmentAst.Extent;
-                                                "RuleName" = $PSCmdlet.MyInvocation.InvocationName;
-                                                "Severity" = "Information"}
+                    $result = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
+                        'Message' = $Messages.MeasureRequiresRunAsAdministrator
+                        'Extent' = $assignmentAst.Extent
+                        'RuleName' = $PSCmdlet.MyInvocation.InvocationName
+                        'Severity' = 'Information'
+                    }
                     $results += $result               
                 }        
             }

--- a/ScriptRuleDocumentation.md
+++ b/ScriptRuleDocumentation.md
@@ -1,11 +1,13 @@
 ##Documentation for Customized Rules in PowerShell Scripts
-PSScriptAnalyzer uses MEF(Managed Extensibility Framework) to import all rules defined in the assembly. It can also consume rules written in PowerShell scripts. When calling Invoke-ScriptAnalyzer, users can pass customized rules using parameter -CustomizedRulePath to apply rule checkings on the scripts. 
+PSScriptAnalyzer uses MEF(Managed Extensibility Framework) to import all rules defined in the assembly. It can also consume rules written in PowerShell scripts. 
 
-This documentation serves as a basic guideline on how to define customized rules.
+When calling Invoke-ScriptAnalyzer, users can specify custom rules using the parameter ```CustomizedRulePath```.
+
+The purpose of this documentation is to server as a basic guide on creating your own customized rules.
 
 ###Basics
 - Functions should have comment-based help. Make sure .DESCRIPTION field is there, as it will be consumed as rule description for the customized rule.
-```
+``` PowerShell
 <#
 .SYNOPSIS
     Name of your rule.
@@ -19,36 +21,38 @@ This documentation serves as a basic guideline on how to define customized rules
 ```
 
 - Output type should be DiagnosticRecord:
-```
+``` PowerShell
 [OutputType([Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]])]
 ```
 
 - Make sure each function takes either a Token or an Ast as a parameter
-```
+``` PowerShell
 Param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.Management.Automation.Language.ScriptBlockAst]
-        $testAst
-    )
+(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [System.Management.Automation.Language.ScriptBlockAst]
+    $testAst
+)
 ```
 
 - DiagnosticRecord should have four properties: Message, Extent, RuleName and Severity
-```
-$result = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]]@{"Message"  = "This is a sample rule"; 
-     "Extent"   = $ast.Extent;
-     "RuleName" = $PSCmdlet.MyInvocation.InvocationName;
-     "Severity" = "Warning"}
+``` PowerShell
+$result = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord[]]@{
+    "Message"  = "This is a sample rule"
+    "Extent"   = $ast.Extent
+    "RuleName" = $PSCmdlet.MyInvocation.InvocationName
+    "Severity" = "Warning"
+}
 ```
 
 - Make sure you export the function(s) at the end of the script using Export-ModuleMember
-```
+``` PowerShell
 Export-ModuleMember -Function (FunctionName)
 ```
 
 ###Example
-```
+``` PowerShell
 <#
 .SYNOPSIS
     Uses #Requires -RunAsAdministrator instead of your own methods.
@@ -155,4 +159,5 @@ function Measure-RequiresRunAsAdministrator
     }
 }
 ```
+
 More examples can be found in *Tests\Engine\CommunityRules*


### PR DESCRIPTION
This is a considerable commit, based up a considerable about of work. This should address #594.

The following things should now, hopefully, be in the documentation:
1. Code blocks correctly marked as PowerShell or C# to ensure GitHub provides the right syntax highlighting.
2. Descriptions, How to Fix statements and Examples should correctly refect the check.
3. Examples have been expanded and improved.  Examples now in the majority of cases follow the best practices.

Outstanding issues (as I see it) with the documentation:
1. DSC rules need more clarity if they apply to class/non-class based resources.
2. AvoidShouldContinueWithoutForce needs more clarity.
3. All examples should make use of verb-noun and other good/best practices
4. MissingModuleManifestField, only lists one mandatory field based upon my research, need to confirm no others are.
5. Do the checks match what is listed in PowerShellBestPractices.md ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/597)
<!-- Reviewable:end -->
