### PR TITLE
Fix AST visitor for external rules

### DIFF
--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1164,7 +1164,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 {
                     // Find all AstTypes that appeared in rule groups.
                     IEnumerable<Ast> childAsts = ast.FindAll(new Func<Ast, bool>((testAst) =>
-                        (astRuleGroup.Key.IndexOf(testAst.GetType().FullName, StringComparison.OrdinalIgnoreCase) != -1)), false);
+                        (astRuleGroup.Key.IndexOf(testAst.GetType().FullName, StringComparison.OrdinalIgnoreCase) != -1)), true);
 
                     foreach (Ast childAst in childAsts)
                     {

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -861,10 +861,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                             "Creating Instance of {0}", type.Name));
 
                     var ruleObj = Activator.CreateInstance(type);
-                    outputWriter.WriteVerbose(
-                        string.Format(
-                            "Created Instance of {0}", type.Name));
-
                     T rule = ruleObj as T;
                     if (rule == null)
                     {

--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             get { return whiteList; }
         }
 
-        AvoidAlias()
+        public AvoidAlias()
         {
             isPropertiesSet = false;
         }

--- a/Rules/UseLiteralInitializerForHashtable.cs
+++ b/Rules/UseLiteralInitializerForHashtable.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     #if !CORECLR
     [Export(typeof(IScriptRule))]
 #endif
-    class UseLiteralInitializerForHashtable : AstVisitor, IScriptRule
+    public class UseLiteralInitializerForHashtable : AstVisitor, IScriptRule
     {
         private List<DiagnosticRecord> diagnosticRecords;
         private HashSet<string> presetTypeNameSet;

--- a/Tests/Rules/AvoidUsingAlias.tests.ps1
+++ b/Tests/Rules/AvoidUsingAlias.tests.ps1
@@ -33,7 +33,7 @@ Describe "AvoidUsingAlias" {
     }
 
     Context "Settings file provides whitelist" {
-        $whiteListTestScriptDef = 'gci; cd; iwr'
+        $whiteListTestScriptDef = 'gci; cd;'
 
         It "honors the whitelist provided as hashtable" {
             $settings = @{
@@ -44,14 +44,14 @@ Describe "AvoidUsingAlias" {
                 }
             }
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $whiteListTestScriptDef -Settings $settings -IncludeRule $violationName
-            $violations.Count | Should Be 2
+            $violations.Count | Should Be 1
         }
 
         It "honors the whitelist provided through settings file" {
             # even though join-path returns string, if we do not use tostring, then invoke-scriptanalyzer cannot cast it to string type
             $settingsFilePath = (Join-Path $directory (Join-Path 'TestSettings' 'AvoidAliasSettings.psd1')).ToString()
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $whiteListTestScriptDef -Settings $settingsFilePath -IncludeRule $violationName
-            $violations.Count | Should be 2
+            $violations.Count | Should be 1
         }
     }
 }


### PR DESCRIPTION
Only the ones in the top level *Ast type instances were being provided to external rules. This fix searches nested scriptblock for the corresponding *Ast type instances to be passed to external rules.

Fixes #609

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/616)
<!-- Reviewable:end -->
