### PR TITLE
Update special variable entries

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,7 +6,9 @@
     + to check for commands in Microsoft.PowerShell.Core snapin
     + to ignore aliases
     + to ignore custom defind commands
-
+- PSUseDeclaredVarsMoreThanAssignments rule to ignore the following special variables (#653)
+    + `$PSModuleAutoLoadingPreference`
+    + `$InformationPreference`
 
 ## [1.8.1](https://github.com/PowerShell/PSScriptAnalyzer/tree/1.8.1) - 2016-10-13
 ### Added

--- a/Engine/SpecialVars.cs
+++ b/Engine/SpecialVars.cs
@@ -159,6 +159,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         internal const string PathExt = "env:PATHEXT";
         internal const string PSEmailServer = "PSEmailServer";
         internal const string PSDefaultParameterValues = "PSDefaultParameterValues";
+        internal const string PSModuleAutoLoadingPreference = "PSModuleAutoLoadingPreference";
         internal const string pwd = "PWD";
         internal const string Null = "null";
         internal const string True = "true";
@@ -179,6 +180,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                                                                     PathExt,
                                                                     PSEmailServer,
                                                                     PSDefaultParameterValues,
+                                                                    PSModuleAutoLoadingPreference,
                                                                     pwd,
                                                                     Null,
                                                                     True,

--- a/Engine/SpecialVars.cs
+++ b/Engine/SpecialVars.cs
@@ -96,27 +96,30 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         internal const string WarningPreference = "WarningPreference";
         internal const string ConfirmPreference = "ConfirmPreference";
         internal const string ProgressPreference = "ProgressPreference";
+        internal const string InformationPreference = "InformationPreference";
 
-        internal static readonly string[] PreferenceVariables = new string[]  
-                                                                {  
-                                                                    DebugPreference,  
-                                                                    VerbosePreference,  
-                                                                    ErrorActionPreference,  
-                                                                    WhatIfPreference,  
-                                                                    WarningPreference,  
+        internal static readonly string[] PreferenceVariables = new string[]
+                                                                {
+                                                                    DebugPreference,
+                                                                    VerbosePreference,
+                                                                    ErrorActionPreference,
+                                                                    WhatIfPreference,
+                                                                    WarningPreference,
                                                                     ConfirmPreference,
-                                                                    ProgressPreference
+                                                                    ProgressPreference,
+                                                                    InformationPreference
                                                                 };
 
-        internal static readonly Type[] PreferenceVariableTypes = new Type[]  
-                                                                {  
-                                                                    /* DebugPreference */   typeof(ActionPreference),  
-                                                                    /* VerbosePreference */ typeof(ActionPreference),  
-                                                                    /* ErrorPreference */   typeof(ActionPreference),  
-                                                                    /* WhatIfPreference */  typeof(SwitchParameter),  
-                                                                    /* WarningPreference */ typeof(ActionPreference),  
-                                                                    /* ConfirmPreference */ typeof(ConfirmImpact), 
+        internal static readonly Type[] PreferenceVariableTypes = new Type[]
+                                                                {
+                                                                    /* DebugPreference */   typeof(ActionPreference),
+                                                                    /* VerbosePreference */ typeof(ActionPreference),
+                                                                    /* ErrorPreference */   typeof(ActionPreference),
+                                                                    /* WhatIfPreference */  typeof(SwitchParameter),
+                                                                    /* WarningPreference */ typeof(ActionPreference),
+                                                                    /* ConfirmPreference */ typeof(ConfirmImpact),
                                                                     /* ProgressPreference */ typeof(Enum),
+                                                                    /* InformationPreference */ typeof(ActionPreference),
                                                                 };
 
         internal enum AutomaticVariable


### PR DESCRIPTION
Updates `PSUseDeclaredVarsMoreThanAssignments` rule to ignore `$PSModuleAutoLoadingPreference` and `$InformationPreference` variables.

Fixes #651

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/653)
<!-- Reviewable:end -->
