### PR TITLE
Fix UseDeclaredVarsMoreThanAssignment rule

### DIFF
--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -27,6 +27,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 #endif
     public class UseDeclaredVarsMoreThanAssignments : IScriptRule
     {
+// TODO arrange private and public functions
+// TODO Code formatting
+// TODO inline documentation
+        private Dictionary<ScriptBlockAst, Dictionary<string, AssignmentStatementAst>> scriptBlockAssignmentMap;
+        private Dictionary<ScriptBlockAst, Dictionary<string, bool>> scriptblockVariableUsageMap;
+        private Dictionary<ScriptBlockAst, ScriptBlockAst> scriptBlockAstParentMap;
+
+        private Ast ast;
+        private string fileName;
+
         /// <summary>
         /// AnalyzeScript: Analyzes the ast to check that variables are used in more than just there assignment.
         /// </summary>
@@ -46,14 +56,67 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 yield break;
             }
 
+            scriptBlockAssignmentMap = new Dictionary<ScriptBlockAst, Dictionary<string, AssignmentStatementAst>>();
+            scriptblockVariableUsageMap = new Dictionary<ScriptBlockAst, Dictionary<string, bool>>();
+            scriptBlockAstParentMap = new Dictionary<ScriptBlockAst, ScriptBlockAst>();
+            this.ast = ast;
+            this.fileName = fileName;
             foreach (var scriptBlockAst in scriptBlockAsts)
             {
                 var sbAst = scriptBlockAst as ScriptBlockAst;
-                foreach (var diagnosticRecord in AnalyzeScriptBlockAst(sbAst, fileName))
+                AnalyzeScriptBlockAst(sbAst, fileName);
+            }
+
+            foreach (var diagnosticRecord in GetViolations())
+            {
+                yield return diagnosticRecord;
+            }
+        }
+
+        private IEnumerable<DiagnosticRecord> GetViolations()
+        {
+            // throw violation if
+            // if a variable in a scope is unused
+            // AND
+            // if it is unused in the parent scopes
+
+            foreach (var sbAst in scriptblockVariableUsageMap.Keys)
+            {
+                foreach (var variable in scriptblockVariableUsageMap[sbAst].Keys)
                 {
-                    yield return diagnosticRecord;
+                    if (!DoesScriptBlockUseVariable(sbAst, variable))
+                    {
+                        yield return new DiagnosticRecord(
+                            string.Format(CultureInfo.CurrentCulture, Strings.UseDeclaredVarsMoreThanAssignmentsError, variable),
+                            scriptBlockAssignmentMap[sbAst][variable].Left.Extent,
+                            GetName(),
+                            DiagnosticSeverity.Warning,
+                            fileName,
+                            variable);
+
+                    }
                 }
             }
+        }
+
+        private bool DoesScriptBlockUseVariable(ScriptBlockAst scriptBlockAst, string variable)
+        {
+            if (scriptblockVariableUsageMap[scriptBlockAst].ContainsKey(variable))
+            {
+                if (!scriptblockVariableUsageMap[scriptBlockAst][variable])
+                {
+                        if (scriptBlockAstParentMap[scriptBlockAst] == null)
+                        {
+                            return false;
+                        }
+
+                        return DoesScriptBlockUseVariable(scriptBlockAstParentMap[scriptBlockAst], variable);
+                }
+
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -114,22 +177,24 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <param name="scriptBlockAst">Ast of type ScriptBlock</param>
         /// <param name="fileName">Name of file containing the ast</param>
         /// <returns>An enumerable containing diagnostic records</returns>
-        private IEnumerable<DiagnosticRecord> AnalyzeScriptBlockAst(ScriptBlockAst scriptBlockAst, string fileName)
+        private void AnalyzeScriptBlockAst(ScriptBlockAst scriptBlockAst, string fileName)
         {
             IEnumerable<Ast> assignmentAsts = scriptBlockAst.FindAll(testAst => testAst is AssignmentStatementAst, false);
             IEnumerable<Ast> varAsts = scriptBlockAst.FindAll(testAst => testAst is VariableExpressionAst, true);
             IEnumerable<Ast> varsInAssignment;
 
             Dictionary<string, AssignmentStatementAst> assignments = new Dictionary<string, AssignmentStatementAst>(StringComparer.OrdinalIgnoreCase);
+            Dictionary<string, bool> isVariableUsed = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
 
             string varKey;
             bool inAssignment;
 
             if (assignmentAsts == null)
             {
-                yield break;
+                return;
             }
 
+            // TODO Remove key removal
             foreach (AssignmentStatementAst assignmentAst in assignmentAsts)
             {
                 // Only checks for the case where lhs is a variable. Ignore things like $foo.property
@@ -147,6 +212,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         if (!assignments.ContainsKey(variableName))
                         {
                             assignments.Add(variableName, assignmentAst);
+                            isVariableUsed.Add(variableName, false);
                         }
                     }
                 }
@@ -163,35 +229,45 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     {
                         varsInAssignment = assignments[varKey].Left.FindAll(testAst => testAst is VariableExpressionAst, true);
 
-                        // Checks if this variableAst is part of the logged assignment
+
                         foreach (VariableExpressionAst varInAssignment in varsInAssignment)
                         {
                             inAssignment |= varInAssignment.Equals(varAst);
                         }
 
-                        if (!inAssignment)
-                        {
-                            assignments.Remove(varKey);
-                        }
-
                         // Check if variable belongs to PowerShell built-in variables
-                        if (Helper.Instance.HasSpecialVars(varKey))
+                        // Checks if this variableAst is part of the logged assignment
+                        if (!inAssignment || Helper.Instance.HasSpecialVars(varKey))
                         {
                             assignments.Remove(varKey);
+                            isVariableUsed[varKey] = true;
                         }
                     }
                 }
             }
 
-            foreach (string key in assignments.Keys)
+            scriptBlockAssignmentMap[scriptBlockAst] = assignments;
+            scriptblockVariableUsageMap[scriptBlockAst] = isVariableUsed;
+            scriptBlockAstParentMap[scriptBlockAst] = GetScriptBlockAstParent(scriptBlockAst);
+        }
+
+        private ScriptBlockAst GetScriptBlockAstParent(Ast scriptBlockAst)
+        {
+            if (scriptBlockAst == this.ast)
             {
-                yield return new DiagnosticRecord(
-                    string.Format(CultureInfo.CurrentCulture, Strings.UseDeclaredVarsMoreThanAssignmentsError, key),
-                    assignments[key].Left.Extent,
-                    GetName(),
-                    DiagnosticSeverity.Warning,
-                    fileName,
-                    key);
+                return null;
+            }
+            else
+            {
+                var parent = scriptBlockAst.Parent as ScriptBlockAst;
+                if (parent == null)
+                {
+                    return GetScriptBlockAstParent(scriptBlockAst.Parent);
+                }
+                else
+                {
+                    return parent;
+                }
             }
         }
     }

--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 #endif
     public class UseDeclaredVarsMoreThanAssignments : IScriptRule
     {
-// TODO Code formatting
         private Dictionary<ScriptBlockAst, Dictionary<string, AssignmentStatementAst>> scriptBlockAssignmentMap;
         private Dictionary<ScriptBlockAst, Dictionary<string, bool>> scriptblockVariableUsageMap;
         private Dictionary<ScriptBlockAst, ScriptBlockAst> scriptBlockAstParentMap;

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -9,6 +9,17 @@ $violationName = "PSUseDeclaredVarsMoreThanAssignments"
 $violations = Invoke-ScriptAnalyzer $directory\UseDeclaredVarsMoreThanAssignments.ps1 | Where-Object {$_.RuleName -eq $violationName}
 $noViolations = Invoke-ScriptAnalyzer $directory\UseDeclaredVarsMoreThanAssignmentsNoViolations.ps1 | Where-Object {$_.RuleName -eq $violationName}
 
+Function Test-UseDeclaredVarsMoreThanAssignments
+{
+    param(
+        [string] $targetScript,
+        [int] $expectedNumViolations
+    )
+            Invoke-ScriptAnalyzer -ScriptDefinition $targetScript -IncludeRule $violationName | `
+            Get-Count | `
+            Should Be $expectedNumViolations
+}
+
 Describe "UseDeclaredVarsMoreThanAssignments" {
     Context "When there are violations" {
         It "has 2 use declared vars more than assignments violations" {
@@ -33,21 +44,46 @@ function MyFunc2() {
     $a + $a
 }
 '@
-            Invoke-ScriptAnalyzer -ScriptDefinition $target -IncludeRule $violationName | `
-            Get-Count | `
-            Should Be 1
+            Test-UseDeclaredVarsMoreThanAssignments $target 1
+        }
+
+        It "flags variables assigned in downstream scopes" {
+$target = @'
+function Get-Directory() {
+    $a = 1
+    1..10 | ForEach-Object { $a = $_ }
+}
+'@
+            Test-UseDeclaredVarsMoreThanAssignments $target 2
         }
 
         It "does not flag `$InformationPreference variable" {
-            Invoke-ScriptAnalyzer -ScriptDefinition '$InformationPreference=Stop' -IncludeRule $violationName  | `
-            Get-Count | `
-            Should Be 0
+            Test-UseDeclaredVarsMoreThanAssignments '$InformationPreference=Stop' 0
         }
 
         It "does not flag `$PSModuleAutoLoadingPreference variable" {
-            Invoke-ScriptAnalyzer -ScriptDefinition '$PSModuleAutoLoadingPreference=None' -IncludeRule $violationName | `
-            Get-Count | `
-            Should Be 0
+            Test-UseDeclaredVarsMoreThanAssignments '$PSModuleAutoLoadingPreference=None' 0
+        }
+
+        It "does not flags variables used in downstream scopes" {
+$target = @'
+function Get-Directory() {
+    $a = 1
+    1..10 | ForEach-Object { Write-Output $a }
+}
+'@
+            Test-UseDeclaredVarsMoreThanAssignments $target 0
+        }
+
+        It "does not flag variables assigned in downstream scope but used in parent scope" {
+$target = @'
+function Get-Directory() {
+    $a = 1
+    1..10 | ForEach-Object { $a = $_ }
+    $a
+}
+'@
+            Test-UseDeclaredVarsMoreThanAssignments $target 0
         }
     }
 

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -56,6 +56,12 @@ function Get-Directory() {
 '@
             Test-UseDeclaredVarsMoreThanAssignments $target 2
         }
+    }
+
+    Context "When there are no violations" {
+        It "returns no violations" {
+            $noViolations.Count | Should Be 0
+        }
 
         It "does not flag `$InformationPreference variable" {
             Test-UseDeclaredVarsMoreThanAssignments '$InformationPreference=Stop' 0
@@ -84,12 +90,6 @@ function Get-Directory() {
 }
 '@
             Test-UseDeclaredVarsMoreThanAssignments $target 0
-        }
-    }
-
-    Context "When there are no violations" {
-        It "returns no violations" {
-            $noViolations.Count | Should Be 0
         }
     }
 }


### PR DESCRIPTION
Consider the following case:
```powershell
$a = 1
1..5 | ForEach-Object {$a = 2}
$a
```

In this case, the rule would flag the assignment in the `ForEach-Object` block. This commit fixes this issue.

Resolves #636

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/655)
<!-- Reviewable:end -->
