### PR TITLE
Fix AvoidGlobalAliases and AvoidGlobalFunctions rules

### DIFF
--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -1776,6 +1776,19 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         }
 
         /// <summary>
+        /// Determines if analyzing a script module.
+        /// </summary>
+        /// <returns>True is file name ends with ".psm1"</returns>
+        public static bool IsModuleScript(string filepath)
+        {
+            if (filepath == null)
+            {
+                throw new ArgumentNullException("filepath");
+            }
+            return filepath.EndsWith(".psm1");
+        }
+
+        /// <summary>
         /// Checks if a given file is a valid PowerShell module manifest
         /// </summary>
         /// <param name="filepath">Path to module manifest</param>

--- a/Rules/AvoidGlobalAliases.cs
+++ b/Rules/AvoidGlobalAliases.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             records = new List<DiagnosticRecord>();
             this.fileName = fileName;
 
-            if (IsScriptModule())
+            if (fileName != null && Helper.IsModuleScript(fileName))
             {
                 ast.Visit(this);
             }
@@ -93,15 +93,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Determines if analyzing a script module.
-        /// </summary>
-        /// <returns>True is file name ends with ".psm1"</returns>
-        private bool IsScriptModule()
-        {
-            return fileName.EndsWith(".psm1");
         }
 
         public string GetCommonName()

--- a/Rules/AvoidGlobalAliases.cs
+++ b/Rules/AvoidGlobalAliases.cs
@@ -116,7 +116,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         public string GetName()
         {
-            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidGlobalAliasesName);
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.NameSpaceFormat,
+                GetSourceName(),
+                Strings.AvoidGlobalAliasesName);
         }
 
         public RuleSeverity GetSeverity()

--- a/Rules/AvoidGlobalFunctions.cs
+++ b/Rules/AvoidGlobalFunctions.cs
@@ -87,7 +87,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         public string GetName()
         {
-            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidGlobalFunctionsName);
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.NameSpaceFormat,
+                GetSourceName(),
+                Strings.AvoidGlobalFunctionsName);
         }
 
         public RuleSeverity GetSeverity()

--- a/Rules/AvoidGlobalFunctions.cs
+++ b/Rules/AvoidGlobalFunctions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             records = new List<DiagnosticRecord>();
             this.fileName = fileName;
 
-            if (IsScriptModule())
+            if (fileName != null && Helper.IsModuleScript(fileName))
             {
                 ast.Visit(this);
             }
@@ -65,15 +65,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             return AstVisitAction.Continue;
         }
         #endregion
-
-        /// <summary>
-        /// Determines if analyzing a script module.
-        /// </summary>
-        /// <returns>True is file name ends with ".psm1"</returns>
-        private bool IsScriptModule()
-        {
-            return fileName.EndsWith(".psm1");
-        }
 
         public string GetCommonName()
         {

--- a/Tests/Rules/AvoidGlobalAliases.tests.ps1
+++ b/Tests/Rules/AvoidGlobalAliases.tests.ps1
@@ -1,7 +1,7 @@
 ﻿Import-Module PSScriptAnalyzer
 
 $AvoidGlobalAliasesError = "Avoid creating aliases with a Global scope."
-$violationName = "AvoidGlobalAliases"
+$violationName = "PSAvoidGlobalAliases"
 
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidGlobalAliases.psm1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidGlobalFunctions.tests.ps1
+++ b/Tests/Rules/AvoidGlobalFunctions.tests.ps1
@@ -1,7 +1,7 @@
 ﻿Import-Module PSScriptAnalyzer
 
 $functionErroMessage = "Avoid creating functions with a Global scope."
-$violationName = "AvoidGlobalFunctions"
+$violationName = "PSAvoidGlobalFunctions"
 
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidGlobalFunctions.psm1 | Where-Object {$_.RuleName -eq $violationName}


### PR DESCRIPTION
* Fix null reference exception caused by passing a `-ScriptDefinition` argument to `Invoke-ScriptAnalyzer`
* Add `PS` prefix to their names

Fixes #657

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/658)
<!-- Reviewable:end -->
