### PR TITLE
Set SuggestedCorrections property for ScriptDefinition

### DIFF
--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -140,10 +140,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         private List<CorrectionExtent> GetCorrectionExtent(CommandAst cmdAst, string cmdletName)
         {
             var ext = cmdAst.Extent;
-            if (ext.File == null)
-            {
-                return null;
-            }
             var corrections = new List<CorrectionExtent>();
             var alias = cmdAst.GetCommandName();
             string description = string.Format(

--- a/Rules/AvoidUsingPlainTextForPassword.cs
+++ b/Rules/AvoidUsingPlainTextForPassword.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 Type paramType = paramAst.StaticType;
                 bool hasPwd = false;
                 String paramName = paramAst.Name.VariablePath.ToString();
-                                
+
                 foreach (String password in passwords)
                 {
                     if (paramName.IndexOf(password, StringComparison.OrdinalIgnoreCase) != -1)
@@ -65,12 +65,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     yield return new DiagnosticRecord(
                         String.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPlainTextForPasswordError, paramAst.Name),
-                        paramAst.Extent, 
-                        GetName(), 
-                        DiagnosticSeverity.Warning, 
+                        paramAst.Extent,
+                        GetName(),
+                        DiagnosticSeverity.Warning,
                         fileName,
                         paramName,
-                        suggestedCorrections: fileName == null ? null : GetCorrectionExtent(paramAst));
+                        suggestedCorrections: GetCorrectionExtent(paramAst));
                 }
             }
         }

--- a/Rules/MisleadingBacktick.cs
+++ b/Rules/MisleadingBacktick.cs
@@ -64,11 +64,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     var extent = new ScriptExtent(start, end);
                     yield return new DiagnosticRecord(
                         string.Format(CultureInfo.CurrentCulture, Strings.MisleadingBacktickError),
-                            extent, 
-                            GetName(), 
-                            DiagnosticSeverity.Warning, 
+                            extent,
+                            GetName(),
+                            DiagnosticSeverity.Warning,
                             fileName,
-                            suggestedCorrections: fileName == null ? null : GetCorrectionExtent(extent));
+                            suggestedCorrections: GetCorrectionExtent(extent));
                 }
             }
         }
@@ -79,10 +79,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <param name="cmdAst"></param>
         /// <returns>Returns a list of suggested corrections</returns>
         private List<CorrectionExtent> GetCorrectionExtent(IScriptExtent violationExtent)
-        {            
+        {
             var corrections = new List<CorrectionExtent>();
             string description = "Remove trailing whilespace";
-            corrections.Add(new CorrectionExtent(                
+            corrections.Add(new CorrectionExtent(
                 violationExtent.StartLineNumber ,
                 violationExtent.EndLineNumber,
                 violationExtent.StartColumnNumber + 1,


### PR DESCRIPTION
SuggestedCorrections used to be populated only if Invoke-ScriptAnalyzer
is provided Path paramter. This commit removes the requirement. So now,
SuggestedCorrections is non-null even if ScriptDefinition parameter is
used to pass PowerShell script to Invoke-ScriptAnalyzer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/665)
<!-- Reviewable:end -->
