### PR TITLE
Limit AvoidAlias rule's extent

### DIFF
--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -116,12 +116,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     continue;
                 }
+
                 string cmdletName = Helper.Instance.GetCmdletNameFromAlias(aliasName);
                 if (!String.IsNullOrEmpty(cmdletName))
                 {
                     yield return new DiagnosticRecord(
                         string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingCmdletAliasesError, aliasName, cmdletName),
-                        cmdAst.Extent,
+                        GetCommandExtent(cmdAst),
                         GetName(),
                         DiagnosticSeverity.Warning,
                         fileName,
@@ -129,6 +130,26 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         suggestedCorrections: GetCorrectionExtent(cmdAst, cmdletName));
                 }
             }
+        }
+
+        /// <summary>
+        /// For a command like "gci -path c:", returns the extent of "gci" in the command
+        /// </summary>
+        private IScriptExtent GetCommandExtent(CommandAst commandAst)
+        {
+            var cmdName = commandAst.GetCommandName();
+            foreach (var cmdElement in commandAst.CommandElements)
+            {
+                var stringConstExpressinAst = cmdElement as StringConstantExpressionAst;
+                if (stringConstExpressinAst != null)
+                {
+                    if (stringConstExpressinAst.Value.Equals(cmdName))
+                    {
+                        return stringConstExpressinAst.Extent;
+                    }
+                }
+            }
+            return commandAst.Extent;
         }
 
         /// <summary>

--- a/Tests/Rules/AvoidUsingAlias.tests.ps1
+++ b/Tests/Rules/AvoidUsingAlias.tests.ps1
@@ -17,13 +17,23 @@ Describe "AvoidUsingAlias" {
             $violations[1].Message | Should Match $violationMessage
         }
 
-	It "suggests correction" {
-	   Test-CorrectionExtent $violationFilepath $violations[0] 1 'iex' 'Invoke-Expression'
-	   $violations[0].SuggestedCorrections[0].Description | Should Be 'Replace iex with Invoke-Expression'
+        It "suggests correction" {
+            Test-CorrectionExtent $violationFilepath $violations[0] 1 'iex' 'Invoke-Expression'
+            $violations[0].SuggestedCorrections[0].Description | Should Be 'Replace iex with Invoke-Expression'
 
-	   Test-CorrectionExtent $violationFilepath $violations[1] 1 'cls' 'Clear-Host'
-	   $violations[1].SuggestedCorrections[0].Description | Should Be 'Replace cls with Clear-Host'
-	}
+            Test-CorrectionExtent $violationFilepath $violations[1] 1 'cls' 'Clear-Host'
+            $violations[1].SuggestedCorrections[0].Description | Should Be 'Replace cls with Clear-Host'
+        }
+    }
+
+    Context "Violation Extent" {
+        It "should return only the cmdlet extent" {
+            $target = @'
+gci -Path C:\
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $target -IncludeRule $violationName
+            $violations[0].Extent.Text | Should Be "gci"
+        }
     }
 
     Context "When there are no violations" {


### PR DESCRIPTION
For a violation of the rule, the extent will only include the command name and not the entire command statement. For example, Invoke-ScriptAnalyzer -ScriptDefinition "gci -path c:\" with return only the extent of "gci".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/667)
<!-- Reviewable:end -->
