### PR TITLE
Fix ProvideCommentHelp rule extent

### DIFF
--- a/Rules/ProvideCommentHelp.cs
+++ b/Rules/ProvideCommentHelp.cs
@@ -70,7 +70,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     DiagnosticRecords.Add(
                         new DiagnosticRecord(
                             string.Format(CultureInfo.CurrentCulture, Strings.ProvideCommentHelpError, funcAst.Name),
-                            funcAst.Extent, GetName(), DiagnosticSeverity.Information, fileName));
+                            Helper.Instance.GetScriptExtentForFunctionName(funcAst),
+                            GetName(),
+                            DiagnosticSeverity.Information,
+                            fileName));
                 }
             }
 

--- a/Tests/Rules/ProvideCommentHelp.tests.ps1
+++ b/Tests/Rules/ProvideCommentHelp.tests.ps1
@@ -22,6 +22,10 @@ Describe "ProvideCommentHelp" {
             $violations[1].Message | Should Match $violationMessage
         }
 
+        It "has extent that includes only the function name" {
+            $violations[1].Extent.Text | Should Be "Comment"
+        }
+
         if ($PSVersionTable.PSVersion -ge [Version]'5.0.0')
         {
             It "Does not count violation in DSC class" {


### PR DESCRIPTION
The violation extent only contains the function name instead of the entire function definition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/679)
<!-- Reviewable:end -->
