### PR TITLE
Allow the DSC test to be in a subdirectory

### DIFF
--- a/Rules/DscTestsPresent.cs
+++ b/Rules/DscTestsPresent.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             if (Directory.Exists(expectedTestsPath))
             {
                 DirectoryInfo testsFolder = new DirectoryInfo(expectedTestsPath);
-                FileInfo[] testFiles = testsFolder.GetFiles(testsQuery);
+                FileInfo[] testFiles = testsFolder.GetFiles(testsQuery, SearchOption.AllDirectories);
                 if (testFiles.Length != 0)
                 {
                     testsPresent = true;


### PR DESCRIPTION
Hi

It's common to separate Pester tests in the "Tests" folder with subfolders like Unit, Integrations and so on. Therefore, the rule DscTestsPresent needs to scan subfolders not only the Tests folder itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/682)
<!-- Reviewable:end -->
