### PR TITLE
Fix UsePSCredentialType rule

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -26,6 +26,7 @@ using System.Threading.Tasks;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Management.Automation.Runspaces;
+using System.Collections;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 {
@@ -219,6 +220,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                 SessionState.InvokeCommand,
                 this);
             Helper.Instance.Initialize();
+
+            var psVersionTable = this.SessionState.PSVariable.GetValue("PSVersionTable") as Hashtable;
+            if (psVersionTable != null)
+            {
+                Helper.Instance.SetPSVersionTable(psVersionTable);
+            }
 
             string[] rulePaths = Helper.ProcessCustomRulePaths(customRulePath,
                 this.SessionState, recurseCustomRulePath);

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -62,7 +62,7 @@ Describe "Test Name parameters" {
         It "get Rules with no parameters supplied" {
 			$defaultRules = Get-ScriptAnalyzerRule
             $expectedNumRules = 45
-            if ((Test-PSEditionCoreClr) -or (Test-PSVersionV3))
+            if ((Test-PSEditionCoreClr) -or (Test-PSVersionV3) -or (Test-PSVersionV4))
             {
                 # for PSv3 PSAvoidGlobalAliases is not shipped because
                 # it uses StaticParameterBinder.BindCommand which is

--- a/Tests/PSScriptAnalyzerTestHelper.psm1
+++ b/Tests/PSScriptAnalyzerTestHelper.psm1
@@ -43,6 +43,11 @@ Function Test-PSVersionV3
 	$PSVersionTable.PSVersion.Major -eq 3
 }
 
+Function Test-PSVersionV4
+{
+	$PSVersionTable.PSVersion.Major -eq 4
+}
+
 Function Get-Count
 {
 	Begin {$count = 0}
@@ -55,4 +60,5 @@ Export-ModuleMember -Function Test-CorrectionExtent
 Export-ModuleMember -Function Test-PSEditionCoreCLR
 Export-ModuleMember -Function Test-PSEditionCoreCLRLinux
 Export-ModuleMember -Function Test-PSVersionV3
+Export-ModuleMember -Function Test-PSVersionV4
 Export-ModuleMember -Function Get-Count

--- a/Tests/Rules/AvoidGlobalAliases.tests.ps1
+++ b/Tests/Rules/AvoidGlobalAliases.tests.ps1
@@ -1,32 +1,27 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
-if ((Test-PSVersionV3))
-{
-    return
-}
-
 Import-Module PSScriptAnalyzer
 
 $AvoidGlobalAliasesError = "Avoid creating aliases with a Global scope."
 $violationName = "PSAvoidGlobalAliases"
 $violations = Invoke-ScriptAnalyzer $directory\AvoidGlobalAliases.psm1 | Where-Object {$_.RuleName -eq $violationName}
 $noViolations = Invoke-ScriptAnalyzer $directory\AvoidGlobalAliasesNoViolations.ps1 | Where-Object {$_.RuleName -eq $violationName}
-
+$IsV3OrV4 = (Test-PSVersionV3) -or (Test-PSVersionV4)
 
 Describe "$violationName " {
     Context "When there are violations" {
-        It "Has 4 avoid global alias violations" {
+        It "Has 4 avoid global alias violations" -Skip:$IsV3OrV4 {
             $violations.Count | Should Be 4
         }
 
-        It "Has the correct description message" {
+        It "Has the correct description message" -Skip:$IsV3OrV4 {
             $violations[0].Message | Should Match $AvoidGlobalAliasesError
         }
     }
 
     Context "When there are no violations" {
-        It "Returns no violations" {
+        It "Returns no violations" -Skip:$IsV3OrV4 {
             $noViolations.Count | Should Be 0
         }
     }

--- a/Tests/Rules/PSCredentialType.tests.ps1
+++ b/Tests/Rules/PSCredentialType.tests.ps1
@@ -11,7 +11,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\PSCredentialTypeNoViolations.ps
 Describe "PSCredentialType" {
     Context "When there are violations" {
         $expectedViolations = 1
-        if (Test-PSVersionV3 -or Test-PSVersionV4) {
+        if ((Test-PSVersionV3) -or (Test-PSVersionV4)) {
             $expectedViolations = 2
         }
         It ("has {0} PSCredential type violation" -f $expectedViolations) {

--- a/Tests/Rules/PSCredentialType.tests.ps1
+++ b/Tests/Rules/PSCredentialType.tests.ps1
@@ -1,14 +1,21 @@
-﻿Import-Module PSScriptAnalyzer
+﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
+$testRootDirectory = Split-Path -Parent $directory
+Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
+Import-Module PSScriptAnalyzer
+
 $violationMessage = "The Credential parameter in 'Credential' must be of type PSCredential. For PowerShell 4.0 and earlier, please define a credential transformation attribute, e.g. [System.Management.Automation.Credential()], after the PSCredential type attribute."
 $violationName = "PSUsePSCredentialType"
-$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\PSCredentialType.ps1 | Where-Object {$_.RuleName -eq $violationName}
 $noViolations = Invoke-ScriptAnalyzer $directory\PSCredentialTypeNoViolations.ps1 | Where-Object {$_.RuleName -eq $violationName}
 
 Describe "PSCredentialType" {
     Context "When there are violations" {
-        It "has 2 PSCredential type violation" {
-            $violations.Count | Should Be 2
+        $expectedViolations = 1
+        if (Test-PSVersionV3 -or Test-PSVersionV4) {
+            $expectedViolations = 2
+        }
+        It ("has {0} PSCredential type violation" -f $expectedViolations) {
+            $violations.Count | Should Be $expectedViolations
         }
 
         It "has the correct description message" {
@@ -31,9 +38,9 @@ function Get-Credential
 
     }
 
-    Context ("When there are {0} violations" -f $expectedViolationCount) {
-        It ("returns {0} violations" -f $expectedViolationCount) {
-            $noViolations.Count | Should Be $expectedViolationCount
+    Context ("When there are no violations") {
+        It "returns no violations" {
+            $noViolations.Count | Should Be 0
         }
     }
 }

--- a/Tests/Rules/PSCredentialType.tests.ps1
+++ b/Tests/Rules/PSCredentialType.tests.ps1
@@ -31,11 +31,6 @@ function Get-Credential
 
     }
 
-    $expectedViolationCount = 0
-    if ($PSVersionTable.PSVersion -lt [Version]'5.0.0')
-    {
-        $expectedViolationCount = 1
-    }
     Context ("When there are {0} violations" -f $expectedViolationCount) {
         It ("returns {0} violations" -f $expectedViolationCount) {
             $noViolations.Count | Should Be $expectedViolationCount

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,11 @@
-os:
-    - "Visual Studio 2015"
+environment:
+  matrix:
+  - APPVEYOR_BUILD_WORKER_IMAGE: WMF 5
+    PowerShellEdition: Desktop
+    BuildConfiguration: Release
+  - APPVEYOR_BUILD_WORKER_IMAGE: WMF 4
+    PowerShellEdition: Desktop
+    BuildConfiguration: PSv3Release
 
 # clone directory
 clone_folder: c:\projects\psscriptanalyzer
@@ -15,9 +21,10 @@ install:
 
 build_script:
     - ps: |
+        $PSVersionTable
         Push-Location C:\projects\psscriptanalyzer
         dotnet restore
-        C:\projects\psscriptanalyzer\buildCoreClr.ps1 -Framework net451 -Configuration Release -Build
+        C:\projects\psscriptanalyzer\buildCoreClr.ps1 -Framework net451 -Configuration $env:BuildConfiguration -Build
         C:\projects\psscriptanalyzer\build.ps1 -BuildDocs
         Pop-Location
 


### PR DESCRIPTION
* Modify behavior to not trigger on v5 and above if credential type is provided but transformation attribute is not provided.
* Remove code duplication
* Fix extent
* Fix test cases

Resolves #659

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/683)
<!-- Reviewable:end -->
