### PR TITLE
Fix PSAvoidUsingAliases correction extent

### DIFF
--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -184,21 +184,21 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <returns>Retruns a list of suggested corrections</returns>
         private List<CorrectionExtent> GetCorrectionExtent(CommandAst cmdAst, string cmdletName)
         {
-            var ext = cmdAst.Extent;
             var corrections = new List<CorrectionExtent>();
             var alias = cmdAst.GetCommandName();
-            string description = string.Format(
+            var description = string.Format(
                 CultureInfo.CurrentCulture,
                 Strings.AvoidUsingCmdletAliasesCorrectionDescription,
                 alias,
                 cmdletName);
+            var cmdExtent = GetCommandExtent(cmdAst);
             corrections.Add(new CorrectionExtent(
-                ext.StartLineNumber,
-                ext.EndLineNumber,
-                cmdAst.CommandElements[0].Extent.StartColumnNumber,
-                cmdAst.CommandElements[0].Extent.EndColumnNumber,
+                cmdExtent.StartLineNumber,
+                cmdExtent.EndLineNumber,
+                cmdExtent.StartColumnNumber,
+                cmdExtent.EndColumnNumber,
                 cmdletName,
-                ext.File,
+                cmdAst.Extent.File,
                 description));
             return corrections;
         }


### PR DESCRIPTION
Previously, the correction extent would include the entire command ast. This would lead to erroneous This sets the extent to mark only the first command element i.e. the command name. 

Resolves PowerShell/vscode-powershell#395

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/685)
<!-- Reviewable:end -->
