### PR TITLE
Reuse command info cache during a PS session

### DIFF
--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -65,7 +65,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             {
                 lock (syncRoot)
                 {
-                    instance = value;
+                    if (instance == null)
+                    {
+                        instance = value;
+                    }
                 }
             }
         }

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -150,7 +150,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             KeywordBlockDictionary = new Dictionary<String, List<Tuple<int, int>>>(StringComparer.OrdinalIgnoreCase);
             VariableAnalysisDictionary = new Dictionary<Ast, VariableAnalysis>();
             ruleArguments = new Dictionary<string, Dictionary<string, object>>(StringComparer.OrdinalIgnoreCase);
-            commandInfoCache = new Dictionary<string, CommandInfo>(StringComparer.OrdinalIgnoreCase);
+            if (commandInfoCache == null)
+            {
+                commandInfoCache = new Dictionary<string, CommandInfo>(StringComparer.OrdinalIgnoreCase);
+            }
 
             IEnumerable<CommandInfo> aliases = this.invokeCommand.GetCommands("*", CommandTypes.Alias, true);
 


### PR DESCRIPTION
## Before
```powershell
PS> 1..5 | % {measure-command {Invoke-ScriptAnalyzer ~\Source\Repos\PowerShellGet\PowerShellGet\PSModule.psm1}} | select TotalSeconds

TotalSeconds
------------
  25.9780775
   25.881099
  27.8301631
  28.9696967
  28.2952561
```

## After
```powershell
PS> 1..5 | % {measure-command {Invoke-ScriptAnalyzer ~\Source\PowerShellGet\PowerShellGet\PSModule.psm1}} | select
 TotalSeconds

TotalSeconds
------------
  28.1845615
   2.9607327
   3.1941642
   3.8798161
   3.0282973
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/695)
<!-- Reviewable:end -->
