### PR TITLE
Handle DollarParen token kind in indentation rule

### DIFF
--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -80,6 +80,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     case TokenKind.AtParen:
                     case TokenKind.LParen:
                     case TokenKind.LCurly:
+                    case TokenKind.DollarParen:
                         AddViolation(token, indentationLevel++, diagnosticRecords, ref onNewLine);
                         break;
 

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -97,4 +97,20 @@ $param3
             $violations.Count | Should Be 4
         }
     }
+
+    Context "When a sub-expression is provided" {
+        BeforeAll {
+            $def = @'
+function foo {
+    $x = $("abc")
+    $x
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+        }
+
+        It "Should not find a violations" {
+            $violations.Count | Should Be 0
+        }
+    }
 }


### PR DESCRIPTION
Resolves PowerShell/vscode-powershell#477

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psscriptanalyzer/700)
<!-- Reviewable:end -->
