### PR TITLE
Fix violations for one line switch conditionals

### DIFF
--- a/Rules/PlaceOpenBrace.cs
+++ b/Rules/PlaceOpenBrace.cs
@@ -206,7 +206,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             for (int k = 2; k < tokens.Length; k++)
             {
                 if (tokens[k].Kind == TokenKind.LCurly
-                    && tokens[k - 1].Kind == TokenKind.NewLine)
+                    && tokens[k - 1].Kind == TokenKind.NewLine
+                    && !tokensToIgnore.Contains(tokens[k]))
                 {
                     yield return new DiagnosticRecord(
                         GetError(Strings.PlaceOpenBraceErrorShouldBeOnSameLine),

--- a/Tests/Rules/PlaceOpenBrace.tests.ps1
+++ b/Tests/Rules/PlaceOpenBrace.tests.ps1
@@ -35,6 +35,24 @@ function foo ($param1)
         }
     }
 
+    Context "When an open brace must be on the same line in a switch statement" {
+        BeforeAll {
+            $def = @'
+switch ($x) {
+    {"b"} {"b"; break;}
+    {"a"} {"a"; break;}
+}
+'@
+            $ruleConfiguration.'OnSameLine' = $true
+            $ruleConfiguration.'IgnoreOneLineBlock' = $true
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+        }
+
+        It "Should not find a violation" {
+            $violations.Count | Should Be 0
+        }
+    }
+
     Context "When an open brace must be on a new line" {
         BeforeAll {
             $def = @'


### PR DESCRIPTION
Consider the following expression:
```powershell
switch ($x) {
{"a" -eq $_} {"a";break}
{"b" -eq $_} {"b";break}
}
```

If OnSameLine switch is `on`, this would get formatted to:
```powershell
switch ($x) { {"a" -eq $_} {"a";break} {"b" -eq $_} {"b";break}
}
```

With this commit, it ignores these one-line conditional expression and so the output will be the same as the input in this case, i.e.,
```powershell
switch ($x) {
{"a" -eq $_} {"a";break}
{"b" -eq $_} {"b";break}
}
```