### PR TITLE
Fix markdown headings in rule documentation

### DIFF
--- a/RuleDocumentation/AvoidAlias.md
+++ b/RuleDocumentation/AvoidAlias.md
@@ -1,7 +1,9 @@
-﻿# AvoidAlias
+# AvoidAlias
+
 **Severity Level: Warning**
 
 ## Description
+
 An alias is an alternate name or nickname for a CMDLet or for a command element, such as a function, script, file, or executable file.
 You can use the alias instead of the command name in any Windows PowerShell commands.
 
@@ -13,13 +15,16 @@ When developing PowerShell content that will potentially need to be maintained o
 The use of full command names also allows for syntax highlighting in sites and applications like GitHub and Visual Studio Code.
 
 ## How to Fix
+
 Use the full cmdlet name and not an alias.
 
 ## Alias Whitelist
+
 To prevent `PSScriptAnalyzer` from flagging your preferred aliases, create a whitelist of the aliases in your settings file and point `PSScriptAnalyzer` to use the settings file. For example, to disable `PSScriptAnalyzer` from flagging `cd`, which is an alias of `Set-Location`, set the settings file content to the following.
 
 ```PowerShell
 # PSScriptAnalyzerSettings.psd1
+
 @{
     'Rules' = @{
         'PSAvoidUsingCmdletAliases' = @{
@@ -30,12 +35,15 @@ To prevent `PSScriptAnalyzer` from flagging your preferred aliases, create a whi
 ```
 
 ## Example
-### Wrong：
+
+### Wrong?
+
 ``` PowerShell
 gps | Where-Object {$_.WorkingSet -gt 20000000}
 ```
 
 ### Correct:
+
 ``` PowerShell
 Get-Process | Where-Object {$_.WorkingSet -gt 20000000}
 ```

--- a/RuleDocumentation/AvoidDefaultTrueValueSwitchParameter.md
+++ b/RuleDocumentation/AvoidDefaultTrueValueSwitchParameter.md
@@ -1,14 +1,19 @@
 # AvoidDefaultTrueValueSwitchParameter
+
 **Severity Level: Warning**
 
 ## Description
+
 Switch parameters for commands should default to false.
 
 ## How
+
 Change the default value of the switch parameter to be false.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Test-Script
 {
@@ -26,6 +31,7 @@ function Test-Script
 ```
 
 ### Correct
+
 ``` PowerShell
 function Test-Script
 {

--- a/RuleDocumentation/AvoidDefaultTrueValueSwitchParameter.md
+++ b/RuleDocumentation/AvoidDefaultTrueValueSwitchParameter.md
@@ -1,14 +1,14 @@
-﻿#AvoidDefaultTrueValueSwitchParameter
+# AvoidDefaultTrueValueSwitchParameter
 **Severity Level: Warning**
 
-##Description
+## Description
 Switch parameters for commands should default to false.
 
-##How to Fix
+## How
 Change the default value of the switch parameter to be false.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function Test-Script
 {
@@ -25,7 +25,7 @@ function Test-Script
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Test-Script
 {

--- a/RuleDocumentation/AvoidEmptyCatchBlock.md
+++ b/RuleDocumentation/AvoidEmptyCatchBlock.md
@@ -1,16 +1,16 @@
-﻿#AvoidEmptyCatchBlock
+# AvoidEmptyCatchBlock
 **Severity Level: Warning**
 
-##Description
+## Description
 Empty catch blocks are considered a poor design choice as they result in the errors occurring in a `try` block not being acted upon.
 
 While this does not inherently lead to issues, they should be avoided wherever possible.
 
-##How to Fix
+## How
 Use ```Write-Error``` or ```throw``` statements within the catch block.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 try
 {
@@ -21,7 +21,7 @@ catch [DivideByZeroException]
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 try
 {

--- a/RuleDocumentation/AvoidEmptyCatchBlock.md
+++ b/RuleDocumentation/AvoidEmptyCatchBlock.md
@@ -1,16 +1,21 @@
 # AvoidEmptyCatchBlock
+
 **Severity Level: Warning**
 
 ## Description
+
 Empty catch blocks are considered a poor design choice as they result in the errors occurring in a `try` block not being acted upon.
 
 While this does not inherently lead to issues, they should be avoided wherever possible.
 
 ## How
+
 Use ```Write-Error``` or ```throw``` statements within the catch block.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 try
 {
@@ -22,6 +27,7 @@ catch [DivideByZeroException]
 ```
 
 ### Correct
+
 ``` PowerShell
 try
 {

--- a/RuleDocumentation/AvoidGlobalAliases.md
+++ b/RuleDocumentation/AvoidGlobalAliases.md
@@ -1,22 +1,28 @@
 # AvoidGlobalAliases
+
 **Severity Level: Warning**
 
 ## Description
+
 Globally scoped aliases override existing aliases within the sessions with matching names. This name collision can cause difficult to debug issues for consumers of modules and scripts.  
 
 
 To understand more about scoping, see ```Get-Help about_Scopes```.
 
 ## How
+
 Use other scope modifiers for new aliases.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 New-Alias -Name Name -Value Value -Scope "Global"
 ```
 
 ### Correct
+
 ``` PowerShell
 New-Alias -Name Name1 -Value Value
 ```

--- a/RuleDocumentation/AvoidGlobalAliases.md
+++ b/RuleDocumentation/AvoidGlobalAliases.md
@@ -1,22 +1,22 @@
-#AvoidGlobalAliases
+# AvoidGlobalAliases
 **Severity Level: Warning**
 
-##Description
+## Description
 Globally scoped aliases override existing aliases within the sessions with matching names. This name collision can cause difficult to debug issues for consumers of modules and scripts.  
 
 
 To understand more about scoping, see ```Get-Help about_Scopes```.
 
-##How to Fix
+## How
 Use other scope modifiers for new aliases.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 New-Alias -Name Name -Value Value -Scope "Global"
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 New-Alias -Name Name1 -Value Value
 ```

--- a/RuleDocumentation/AvoidGlobalFunctions.md
+++ b/RuleDocumentation/AvoidGlobalFunctions.md
@@ -1,22 +1,28 @@
 # AvoidGlobalFunctions
+
 **Severity Level: Warning**
 
 ## Description
+
 Globally scoped functions override existing functions within the sessions with matching names. This name collision can cause difficult to debug issues for consumers of modules.  
 
 
 To understand more about scoping, see ```Get-Help about_Scopes```.
 
 ## How
+
 Use other scope modifiers for functions.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function global:functionName {}
 ```
 
 ### Correct
+
 ``` PowerShell
 function functionName {} 
 ```

--- a/RuleDocumentation/AvoidGlobalFunctions.md
+++ b/RuleDocumentation/AvoidGlobalFunctions.md
@@ -1,22 +1,22 @@
-﻿#AvoidGlobalFunctions
+# AvoidGlobalFunctions
 **Severity Level: Warning**
 
-##Description
+## Description
 Globally scoped functions override existing functions within the sessions with matching names. This name collision can cause difficult to debug issues for consumers of modules.  
 
 
 To understand more about scoping, see ```Get-Help about_Scopes```.
 
-##How to Fix
+## How
 Use other scope modifiers for functions.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 function global:functionName {}
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function functionName {} 
 ```

--- a/RuleDocumentation/AvoidGlobalVars.md
+++ b/RuleDocumentation/AvoidGlobalVars.md
@@ -1,7 +1,7 @@
-﻿#AvoidGlobalVars
+# AvoidGlobalVars
 **Severity Level: Warning**
 
-##Description
+## Description
 A variable is a unit of memory in which values are stored. Windows PowerShell controls access to variables, functions, aliases, and drives through a mechanism known as scoping.
 Variables and functions that are present when Windows PowerShell starts have been created in the global scope.
 
@@ -12,11 +12,11 @@ Globally scoped variables include:
 
 To understand more about scoping, see ```Get-Help about_Scopes```.
 
-##How to Fix
+## How
 Use other scope modifiers for variables.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 $Global:var1 = $null
 function Test-NotGlobal ($var)
@@ -25,7 +25,7 @@ function Test-NotGlobal ($var)
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 $var1 = $null
 function Test-NotGlobal ($var1, $var2)

--- a/RuleDocumentation/AvoidGlobalVars.md
+++ b/RuleDocumentation/AvoidGlobalVars.md
@@ -1,7 +1,9 @@
 # AvoidGlobalVars
+
 **Severity Level: Warning**
 
 ## Description
+
 A variable is a unit of memory in which values are stored. Windows PowerShell controls access to variables, functions, aliases, and drives through a mechanism known as scoping.
 Variables and functions that are present when Windows PowerShell starts have been created in the global scope.
 
@@ -13,10 +15,13 @@ Globally scoped variables include:
 To understand more about scoping, see ```Get-Help about_Scopes```.
 
 ## How
+
 Use other scope modifiers for variables.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 $Global:var1 = $null
 function Test-NotGlobal ($var)
@@ -26,6 +31,7 @@ function Test-NotGlobal ($var)
 ```
 
 ### Correct
+
 ``` PowerShell
 $var1 = $null
 function Test-NotGlobal ($var1, $var2)

--- a/RuleDocumentation/AvoidInvokingEmptyMembers.md
+++ b/RuleDocumentation/AvoidInvokingEmptyMembers.md
@@ -1,20 +1,20 @@
-﻿#AvoidInvokingEmptyMembers
+# AvoidInvokingEmptyMembers
 **Severity Level: Warning**
 
-##Description
+## Description
 Invoking non-constant members can cause potential bugs. Please double check the syntax to make sure that invoked members are constants.
 
-##How to Fix
+## How
 Provide the requested members for a given type or class.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 $MyString = "abc"
 $MyString.('len'+'gth')
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 $MyString = "abc"
 $MyString.('length')

--- a/RuleDocumentation/AvoidInvokingEmptyMembers.md
+++ b/RuleDocumentation/AvoidInvokingEmptyMembers.md
@@ -1,20 +1,26 @@
 # AvoidInvokingEmptyMembers
+
 **Severity Level: Warning**
 
 ## Description
+
 Invoking non-constant members can cause potential bugs. Please double check the syntax to make sure that invoked members are constants.
 
 ## How
+
 Provide the requested members for a given type or class.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 $MyString = "abc"
 $MyString.('len'+'gth')
 ```
 
 ### Correct
+
 ``` PowerShell
 $MyString = "abc"
 $MyString.('length')

--- a/RuleDocumentation/AvoidNullOrEmptyHelpMessageAttribute.md
+++ b/RuleDocumentation/AvoidNullOrEmptyHelpMessageAttribute.md
@@ -1,15 +1,15 @@
-﻿#AvoidNullOrEmtpyHelpMessageAttribute
+# AvoidNullOrEmtpyHelpMessageAttribute
 **Severity Level: Warning**
 
-##Description
+## Description
 The value of the `HelpMessage` attribute should not be an empty string or a null value as this causes PowerShell's interpreter to throw an mirror when executing the
 function or cmdlet.
 
-##How to Fix
+## How
 Specify a value for the `HelpMessage` attribute.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 Function BadFuncEmptyHelpMessageEmpty
 {
@@ -45,7 +45,7 @@ Function BadFuncEmptyHelpMessageNoAssignment
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 Function GoodFuncHelpMessage
 {

--- a/RuleDocumentation/AvoidNullOrEmptyHelpMessageAttribute.md
+++ b/RuleDocumentation/AvoidNullOrEmptyHelpMessageAttribute.md
@@ -1,15 +1,20 @@
 # AvoidNullOrEmtpyHelpMessageAttribute
+
 **Severity Level: Warning**
 
 ## Description
+
 The value of the `HelpMessage` attribute should not be an empty string or a null value as this causes PowerShell's interpreter to throw an mirror when executing the
 function or cmdlet.
 
 ## How
+
 Specify a value for the `HelpMessage` attribute.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 Function BadFuncEmptyHelpMessageEmpty
 {
@@ -46,6 +51,7 @@ Function BadFuncEmptyHelpMessageNoAssignment
 ```
 
 ### Correct
+
 ``` PowerShell
 Function GoodFuncHelpMessage
 {

--- a/RuleDocumentation/AvoidReservedCharInCmdlet.md
+++ b/RuleDocumentation/AvoidReservedCharInCmdlet.md
@@ -1,22 +1,28 @@
 # AvoidReservedCharInCmdlet
+
 **Severity Level: Error**
 
 ## Description
+
 You cannot use following reserved characters in a function or cmdlet name as these can cause parsing or runtime errors.
 
 Reserved Characters include: `#,(){}[]&/\\$^;:\"'<>|?@`*%+=~`
 
 ## How
+
 Remove reserved characters from names.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function MyFunction[1]
 {...}
 ```
 
 ### Correct
+
 ``` PowerShell
 function MyFunction
 {...}

--- a/RuleDocumentation/AvoidReservedCharInCmdlet.md
+++ b/RuleDocumentation/AvoidReservedCharInCmdlet.md
@@ -1,22 +1,22 @@
-﻿#AvoidReservedCharInCmdlet
+# AvoidReservedCharInCmdlet
 **Severity Level: Error**
 
-##Description
+## Description
 You cannot use following reserved characters in a function or cmdlet name as these can cause parsing or runtime errors.
 
 Reserved Characters include: `#,(){}[]&/\\$^;:\"'<>|?@`*%+=~`
 
-##How to Fix
+## How
 Remove reserved characters from names.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function MyFunction[1]
 {...}
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function MyFunction
 {...}

--- a/RuleDocumentation/AvoidReservedParams.md
+++ b/RuleDocumentation/AvoidReservedParams.md
@@ -1,14 +1,14 @@
-﻿#AvoidReservedParams
+# AvoidReservedParams
 **Severity Level: Error**
 
-##Description
+## Description
 You cannot use reserved common parameters in an advanced function.
 
-##How to Fix
+## How
 Change the name of the parameter.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function Test
 {
@@ -21,7 +21,7 @@ function Test
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Test
 {

--- a/RuleDocumentation/AvoidReservedParams.md
+++ b/RuleDocumentation/AvoidReservedParams.md
@@ -1,14 +1,19 @@
 # AvoidReservedParams
+
 **Severity Level: Error**
 
 ## Description
+
 You cannot use reserved common parameters in an advanced function.
 
 ## How
+
 Change the name of the parameter.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Test
 {
@@ -22,6 +27,7 @@ function Test
 ```
 
 ### Correct
+
 ``` PowerShell
 function Test
 {

--- a/RuleDocumentation/AvoidShouldContinueWithoutForce.md
+++ b/RuleDocumentation/AvoidShouldContinueWithoutForce.md
@@ -1,16 +1,21 @@
 # AvoidShouldContinueWithoutForce
+
 **Severity Level: Warning**
 
 ## Description
+
 Functions that use ShouldContinue should have a boolean force parameter to allow user to bypass it.
 
 You can get more details by running `Get-Help about_Functions_CmdletBindingAttribute` and `Get-Help about_Functions_Advanced_Methods` command in Windows PowerShell.
 
 ## How
+
 Call the `ShouldContinue` method in advanced functions when `ShouldProcess` method returns `$true`.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 Function Test-ShouldContinue
 {
@@ -28,6 +33,7 @@ Function Test-ShouldContinue
 ```
 
 ### Correct
+
 ``` PowerShell
 Function Test-ShouldContinue
 {

--- a/RuleDocumentation/AvoidShouldContinueWithoutForce.md
+++ b/RuleDocumentation/AvoidShouldContinueWithoutForce.md
@@ -1,16 +1,16 @@
-﻿#AvoidShouldContinueWithoutForce
+# AvoidShouldContinueWithoutForce
 **Severity Level: Warning**
 
-##Description
+## Description
 Functions that use ShouldContinue should have a boolean force parameter to allow user to bypass it.
 
 You can get more details by running `Get-Help about_Functions_CmdletBindingAttribute` and `Get-Help about_Functions_Advanced_Methods` command in Windows PowerShell.
 
-##How to Fix
+## How
 Call the `ShouldContinue` method in advanced functions when `ShouldProcess` method returns `$true`.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 Function Test-ShouldContinue
 {
@@ -27,7 +27,7 @@ Function Test-ShouldContinue
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 Function Test-ShouldContinue
 {

--- a/RuleDocumentation/AvoidTrapStatement.md
+++ b/RuleDocumentation/AvoidTrapStatement.md
@@ -1,7 +1,9 @@
 # AvoidTrapStatement
+
 **Severity Level: Warning**
 
 ## Description
+
 The `Trap` keyword specifies a list of statements to run when a terminating error occurs.
 
 Trap statements handle the terminating errors and allow execution of the script or function to continue instead of stopping.
@@ -10,10 +12,13 @@ Traps are intended for the use of administrators and not for script and cmdlet d
 of `try{} catch{} finally{}` statements.
 
 ## How
+
 Replace `Trap` statements with `try{} catch{} finally{}` statements.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Test-Trap
 {
@@ -22,6 +27,7 @@ function Test-Trap
 ```
 
 ### Correct
+
 ``` PowerShell
 function Test-Trap
 {

--- a/RuleDocumentation/AvoidTrapStatement.md
+++ b/RuleDocumentation/AvoidTrapStatement.md
@@ -1,7 +1,7 @@
-﻿#AvoidTrapStatement
+# AvoidTrapStatement
 **Severity Level: Warning**
 
-##Description
+## Description
 The `Trap` keyword specifies a list of statements to run when a terminating error occurs.
 
 Trap statements handle the terminating errors and allow execution of the script or function to continue instead of stopping.
@@ -9,11 +9,11 @@ Trap statements handle the terminating errors and allow execution of the script 
 Traps are intended for the use of administrators and not for script and cmdlet developers. PowerShell scripts and cmdlets should make use
 of `try{} catch{} finally{}` statements.
 
-##How to Fix
+## How
 Replace `Trap` statements with `try{} catch{} finally{}` statements.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function Test-Trap
 {
@@ -21,7 +21,7 @@ function Test-Trap
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Test-Trap
 {

--- a/RuleDocumentation/AvoidUninitializedVariable.md
+++ b/RuleDocumentation/AvoidUninitializedVariable.md
@@ -1,20 +1,20 @@
-#AvoidUninitializedVariable
+# AvoidUninitializedVariable
 
 **Severity Level: Warning**
 
-##Description
+## Description
 
 A variable is a unit of memory in which values are stored. Windows PowerShell controls access to variables, functions, aliases, and drives through a mechanism known as scoping.
 
 All non-global variables must be initialized, otherwise potential bugs could be introduced.
 
-##How to Fix
+## How
 
 Initialize non-global variables.
 
-##Example
+## Example
 
-###Wrong：
+### Wrong
 
 ``` PowerShell
 function NotGlobal {
@@ -24,7 +24,7 @@ function NotGlobal {
 }
 ```
 
-###Correct:
+### Correct
 
 ``` PowerShell
 function NotGlobal {

--- a/RuleDocumentation/AvoidUsingComputerNameHardcoded.md
+++ b/RuleDocumentation/AvoidUsingComputerNameHardcoded.md
@@ -1,14 +1,14 @@
-﻿#AvoidUsingComputerNameHardcoded
+# AvoidUsingComputerNameHardcoded
 **Severity Level: Error**
 
-##Description
+## Description
 The names of computers should never be hard coded as this will expose sensitive information. The `ComputerName` parameter should never have a hard coded value.
 
-##How to Fix
+## How
 Remove hard coded computer names.
 
-##Example 1
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 Function Invoke-MyRemoteCommand ()
 {
@@ -16,7 +16,7 @@ Function Invoke-MyRemoteCommand ()
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 Function Invoke-MyCommand ($ComputerName)
 {
@@ -24,8 +24,8 @@ Function Invoke-MyCommand ($ComputerName)
 }
 ```
 
-##Example 2
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 Function Invoke-MyLocalCommand ()
 {
@@ -33,7 +33,7 @@ Function Invoke-MyLocalCommand ()
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 Function Invoke-MyLocalCommand ()
 {

--- a/RuleDocumentation/AvoidUsingComputerNameHardcoded.md
+++ b/RuleDocumentation/AvoidUsingComputerNameHardcoded.md
@@ -1,14 +1,19 @@
 # AvoidUsingComputerNameHardcoded
+
 **Severity Level: Error**
 
 ## Description
+
 The names of computers should never be hard coded as this will expose sensitive information. The `ComputerName` parameter should never have a hard coded value.
 
 ## How
+
 Remove hard coded computer names.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 Function Invoke-MyRemoteCommand ()
 {
@@ -17,6 +22,7 @@ Function Invoke-MyRemoteCommand ()
 ```
 
 ### Correct
+
 ``` PowerShell
 Function Invoke-MyCommand ($ComputerName)
 {
@@ -25,7 +31,9 @@ Function Invoke-MyCommand ($ComputerName)
 ```
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 Function Invoke-MyLocalCommand ()
 {
@@ -34,6 +42,7 @@ Function Invoke-MyLocalCommand ()
 ```
 
 ### Correct
+
 ``` PowerShell
 Function Invoke-MyLocalCommand ()
 {

--- a/RuleDocumentation/AvoidUsingConvertToSecureStringWithPlainText.md
+++ b/RuleDocumentation/AvoidUsingConvertToSecureStringWithPlainText.md
@@ -1,20 +1,26 @@
 # AvoidUsingConvertToSecureStringWithPlainText
+
 **Severity Level: Error**
 
 ## Description
+
 The use of the `AsPlainText` parameter with the `ConvertTo-SecureString` command can expose secure information.
 
 ## How
+
 Use a standard encrypted variable to perform any SecureString conversions.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 $UserInput = Read-Host "Please enter your secure code"
 $EncryptedInput = ConvertTo-SecureString -String $UserInput -AsPlainText -Force
 ```
 
 ### Correct
+
 ``` PowerShell
 $SecureUserInput = Read-Host "Please enter your secure code" -AsSecureString
 $EncryptedInput = ConvertFrom-SecureString -String $SecureUserInput

--- a/RuleDocumentation/AvoidUsingConvertToSecureStringWithPlainText.md
+++ b/RuleDocumentation/AvoidUsingConvertToSecureStringWithPlainText.md
@@ -1,20 +1,20 @@
-﻿#AvoidUsingConvertToSecureStringWithPlainText
+# AvoidUsingConvertToSecureStringWithPlainText
 **Severity Level: Error**
 
-##Description
+## Description
 The use of the `AsPlainText` parameter with the `ConvertTo-SecureString` command can expose secure information.
 
-##How to Fix
+## How
 Use a standard encrypted variable to perform any SecureString conversions.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 $UserInput = Read-Host "Please enter your secure code"
 $EncryptedInput = ConvertTo-SecureString -String $UserInput -AsPlainText -Force
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 $SecureUserInput = Read-Host "Please enter your secure code" -AsSecureString
 $EncryptedInput = ConvertFrom-SecureString -String $SecureUserInput

--- a/RuleDocumentation/AvoidUsingDeprecatedManifestFields.md
+++ b/RuleDocumentation/AvoidUsingDeprecatedManifestFields.md
@@ -1,16 +1,21 @@
 # AvoidUsingDeprecatedManifestFields
+
 **Severity Level: Warning**
 
 ## Description
+
 In PowerShell 5.0, a number of fields in module manifest files (.psd1) have been changed.
 
 The field `ModuleToProcess` has been replaced with the `RootModule` field.
 
 ## How
+
 Replace `ModuleToProcess` with `RootModule` in the module manifest.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 ModuleToProcess ='psscriptanalyzer'
 
@@ -18,6 +23,7 @@ ModuleVersion = '1.0'
 ```
 
 ### Correct
+
 ``` PowerShell
 RootModule ='psscriptanalyzer'
 

--- a/RuleDocumentation/AvoidUsingDeprecatedManifestFields.md
+++ b/RuleDocumentation/AvoidUsingDeprecatedManifestFields.md
@@ -1,23 +1,23 @@
-﻿#AvoidUsingDeprecatedManifestFields
+# AvoidUsingDeprecatedManifestFields
 **Severity Level: Warning**
 
-##Description
+## Description
 In PowerShell 5.0, a number of fields in module manifest files (.psd1) have been changed.
 
 The field `ModuleToProcess` has been replaced with the `RootModule` field.
 
-##How to Fix
+## How
 Replace `ModuleToProcess` with `RootModule` in the module manifest.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 ModuleToProcess ='psscriptanalyzer'
 
 ModuleVersion = '1.0'
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 RootModule ='psscriptanalyzer'
 

--- a/RuleDocumentation/AvoidUsingFilePath.md
+++ b/RuleDocumentation/AvoidUsingFilePath.md
@@ -1,16 +1,21 @@
 # AvoidUsingFilePath
+
 **Severity Level: Error**
 
 ## Description
+
 If a file path is used in a script that refers to a file on the computer or on the shared network, this could expose sensitive information or result in availability issues.
 
 Care should be taken to ensure that no computer or network paths are hard coded, instead non-rooted paths should be used.
 
 ## How
+
 Ensure that no network paths are hard coded and that file paths are non-rooted.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 Function Get-MyCSVFile
 {
@@ -26,6 +31,7 @@ Function Write-Documentation
 ```
 
 ### Correct
+
 ``` PowerShell
 Function Get-MyCSVFile ($NetworkPath)
 {

--- a/RuleDocumentation/AvoidUsingFilePath.md
+++ b/RuleDocumentation/AvoidUsingFilePath.md
@@ -1,16 +1,16 @@
-﻿#AvoidUsingFilePath
+# AvoidUsingFilePath
 **Severity Level: Error**
 
-##Description
+## Description
 If a file path is used in a script that refers to a file on the computer or on the shared network, this could expose sensitive information or result in availability issues.
 
 Care should be taken to ensure that no computer or network paths are hard coded, instead non-rooted paths should be used.
 
-##How to Fix
+## How
 Ensure that no network paths are hard coded and that file paths are non-rooted.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 Function Get-MyCSVFile
 {
@@ -25,7 +25,7 @@ Function Write-Documentation
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 Function Get-MyCSVFile ($NetworkPath)
 {

--- a/RuleDocumentation/AvoidUsingInvokeExpression.md
+++ b/RuleDocumentation/AvoidUsingInvokeExpression.md
@@ -1,21 +1,21 @@
-﻿#AvoidUsingInvokeExpression
+# AvoidUsingInvokeExpression
 **Severity Level: Warning**
 
-##Description
+## Description
 Care must be taken when using the `Invoke-Expression` command. The `Invoke-Expression` executes the specified string and returns the results.
 
 Code injection into your application or script can occur if the expression passed as a string includes any data provided from the user.
 
-##How to Fix
+## How
 Remove the use of `Invoke-Expression`.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 Invoke-Expression "Get-Process"
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 Get-Process
 ```

--- a/RuleDocumentation/AvoidUsingInvokeExpression.md
+++ b/RuleDocumentation/AvoidUsingInvokeExpression.md
@@ -1,21 +1,27 @@
 # AvoidUsingInvokeExpression
+
 **Severity Level: Warning**
 
 ## Description
+
 Care must be taken when using the `Invoke-Expression` command. The `Invoke-Expression` executes the specified string and returns the results.
 
 Code injection into your application or script can occur if the expression passed as a string includes any data provided from the user.
 
 ## How
+
 Remove the use of `Invoke-Expression`.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 Invoke-Expression "Get-Process"
 ```
 
 ### Correct
+
 ``` PowerShell
 Get-Process
 ```

--- a/RuleDocumentation/AvoidUsingPlainTextForPassword.md
+++ b/RuleDocumentation/AvoidUsingPlainTextForPassword.md
@@ -1,7 +1,9 @@
 # AvoidUsingPlainTextForPassword
+
 **Severity Level: Warning**
 
 ## Description
+
 Password parameters that take in plaintext will expose passwords and compromise the security of your system. Passwords should be stored in the
 ```SecureString``` type.
 
@@ -16,10 +18,13 @@ The following parameters are considered password parameters (this is not case se
 If a parameter is defined with a name in the above list, it should be declared with type ```SecureString```
 
 ## How
+
 Change the type to ```SecureString```.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Test-Script
 {
@@ -34,6 +39,7 @@ function Test-Script
 ```
 
 ### Correct
+
 ``` PowerShell
 function Test-Script
 {

--- a/RuleDocumentation/AvoidUsingPlainTextForPassword.md
+++ b/RuleDocumentation/AvoidUsingPlainTextForPassword.md
@@ -1,7 +1,7 @@
-﻿#AvoidUsingPlainTextForPassword
+# AvoidUsingPlainTextForPassword
 **Severity Level: Warning**
 
-##Description
+## Description
 Password parameters that take in plaintext will expose passwords and compromise the security of your system. Passwords should be stored in the
 ```SecureString``` type.
 
@@ -15,11 +15,11 @@ The following parameters are considered password parameters (this is not case se
 
 If a parameter is defined with a name in the above list, it should be declared with type ```SecureString```
 
-##How to Fix
+## How
 Change the type to ```SecureString```.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function Test-Script
 {
@@ -33,7 +33,7 @@ function Test-Script
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Test-Script
 {

--- a/RuleDocumentation/AvoidUsingPositionalParameters.md
+++ b/RuleDocumentation/AvoidUsingPositionalParameters.md
@@ -1,21 +1,21 @@
-﻿#AvoidUsingPositionalParameters
+# AvoidUsingPositionalParameters
 **Severity Level: Warning**
 
-##Description
+## Description
 When developing PowerShell content that will potentially need to be maintained over time, either by the original author or others, you should use full command names and parameter names.
 
 The use of positional parameters can reduce the readability of code and potentially introduce errors.
 
-##How to Fix
+## How
 Use full parameter names when calling commands.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 Get-ChildItem *.txt
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 Get-Content -Path *.txt
 ```

--- a/RuleDocumentation/AvoidUsingPositionalParameters.md
+++ b/RuleDocumentation/AvoidUsingPositionalParameters.md
@@ -1,21 +1,27 @@
 # AvoidUsingPositionalParameters
+
 **Severity Level: Warning**
 
 ## Description
+
 When developing PowerShell content that will potentially need to be maintained over time, either by the original author or others, you should use full command names and parameter names.
 
 The use of positional parameters can reduce the readability of code and potentially introduce errors.
 
 ## How
+
 Use full parameter names when calling commands.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 Get-ChildItem *.txt
 ```
 
 ### Correct
+
 ``` PowerShell
 Get-Content -Path *.txt
 ```

--- a/RuleDocumentation/AvoidUsingUsernameAndPasswordParams.md
+++ b/RuleDocumentation/AvoidUsingUsernameAndPasswordParams.md
@@ -1,14 +1,19 @@
 # AvoidUsingUsernameAndPasswordParams
+
 **Severity Level: Error**
 
 ## Description
+
 To standardize command parameters, credentials should be accepted as objects of type ```PSCredential```. Functions should not make use of username or password parameters.
 
 ## How
+
 Change the parameter to type ```PSCredential```.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Test-Script
 {
@@ -25,6 +30,7 @@ function Test-Script
 ```
 
 ### Correct
+
 ``` PowerShell
 function Test-Script
 {

--- a/RuleDocumentation/AvoidUsingUsernameAndPasswordParams.md
+++ b/RuleDocumentation/AvoidUsingUsernameAndPasswordParams.md
@@ -1,14 +1,14 @@
-﻿#AvoidUsingUsernameAndPasswordParams
+# AvoidUsingUsernameAndPasswordParams
 **Severity Level: Error**
 
-##Description
+## Description
 To standardize command parameters, credentials should be accepted as objects of type ```PSCredential```. Functions should not make use of username or password parameters.
 
-##How to Fix
+## How
 Change the parameter to type ```PSCredential```.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function Test-Script
 {
@@ -24,7 +24,7 @@ function Test-Script
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Test-Script
 {

--- a/RuleDocumentation/AvoidUsingWMICmdlet.md
+++ b/RuleDocumentation/AvoidUsingWMICmdlet.md
@@ -1,7 +1,9 @@
 # AvoidUsingWMICmdlet
+
 **Severity Level: Warning**
 
 ## Description
+
 As of PowerShell 3.0, the CIM cmdlets should be used over the WMI cmdlets.
 
 The following cmdlets should not be used:
@@ -21,6 +23,7 @@ Use the following cmdlets instead:
 The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, allowing for the management of Windows and non-Windows operating systems.
 
 ## How
+
 Change to the equivalent CIM based cmdlet.
 * `Get-WmiObject` -> `Get-CimInstance`
 * `Remove-WmiObject` -> `Remove-CimInstance`
@@ -29,13 +32,16 @@ Change to the equivalent CIM based cmdlet.
 * `Set-WmiInstance` -> `Set-CimInstance`
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 Get-WmiObject -Query 'Select * from Win32_Process where name LIKE "myprocess%"' | Remove-WmiObject
 Invoke-WmiMethod ?Class Win32_Process ?Name "Create" ?ArgumentList @{ CommandLine = "notepad.exe" }
 ```
 
 ### Correct
+
 ``` PowerShell
 Get-CimInstance -Query 'Select * from Win32_Process where name LIKE "myprocess%"' | Remove-CIMInstance
 Invoke-CimMethod ?ClassName Win32_Process ?MethodName "Create" ?Arguments @{ CommandLine = "notepad.exe" }

--- a/RuleDocumentation/AvoidUsingWMICmdlet.md
+++ b/RuleDocumentation/AvoidUsingWMICmdlet.md
@@ -1,7 +1,7 @@
-﻿#AvoidUsingWMICmdlet
+# AvoidUsingWMICmdlet
 **Severity Level: Warning**
 
-##Description
+## Description
 As of PowerShell 3.0, the CIM cmdlets should be used over the WMI cmdlets.
 
 The following cmdlets should not be used:
@@ -20,7 +20,7 @@ Use the following cmdlets instead:
 
 The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, allowing for the management of Windows and non-Windows operating systems.
 
-##How to Fix
+## How
 Change to the equivalent CIM based cmdlet.
 * `Get-WmiObject` -> `Get-CimInstance`
 * `Remove-WmiObject` -> `Remove-CimInstance`
@@ -28,15 +28,15 @@ Change to the equivalent CIM based cmdlet.
 * `Register-WmiEvent` -> `Register-CimIndicationEvent`
 * `Set-WmiInstance` -> `Set-CimInstance`
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 Get-WmiObject -Query 'Select * from Win32_Process where name LIKE "myprocess%"' | Remove-WmiObject
-Invoke-WmiMethod –Class Win32_Process –Name "Create" –ArgumentList @{ CommandLine = "notepad.exe" }
+Invoke-WmiMethod ?Class Win32_Process ?Name "Create" ?ArgumentList @{ CommandLine = "notepad.exe" }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 Get-CimInstance -Query 'Select * from Win32_Process where name LIKE "myprocess%"' | Remove-CIMInstance
-Invoke-CimMethod –ClassName Win32_Process –MethodName "Create" –Arguments @{ CommandLine = "notepad.exe" }
+Invoke-CimMethod ?ClassName Win32_Process ?MethodName "Create" ?Arguments @{ CommandLine = "notepad.exe" }
 ```

--- a/RuleDocumentation/AvoidUsingWriteHost.md
+++ b/RuleDocumentation/AvoidUsingWriteHost.md
@@ -1,17 +1,22 @@
 # AvoidUsingWriteHost
+
 **Severity Level: Warning**
 
 ## Description
+
 The use of `Write-Host` is greatly discouraged unless in the use of commands with the `Show` verb. The `Show` verb explicitly means "show on the screen, with no
 other possibilities".
 
 Commands with the `Show` verb do not have this check applied.
 
 ## How
+
 Replace `Write-Host` with `Write-Output` or `Write-Verbose`.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Test
 {
@@ -22,6 +27,7 @@ function Test
 ```
 
 ### Correct
+
 ``` PowerShell
 function Test
 {

--- a/RuleDocumentation/AvoidUsingWriteHost.md
+++ b/RuleDocumentation/AvoidUsingWriteHost.md
@@ -1,17 +1,17 @@
-﻿#AvoidUsingWriteHost
+# AvoidUsingWriteHost
 **Severity Level: Warning**
 
-##Description
+## Description
 The use of `Write-Host` is greatly discouraged unless in the use of commands with the `Show` verb. The `Show` verb explicitly means "show on the screen, with no
 other possibilities".
 
 Commands with the `Show` verb do not have this check applied.
 
-##How to Fix
+## How
 Replace `Write-Host` with `Write-Output` or `Write-Verbose`.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function Test
 {
@@ -21,7 +21,7 @@ function Test
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Test
 {

--- a/RuleDocumentation/DscExamplesPresent.md
+++ b/RuleDocumentation/DscExamplesPresent.md
@@ -1,10 +1,13 @@
 # DscExamplesPresent
+
 **Severity Level: Information**
 
 ## Description
+
 Checks that DSC examples for given resource are present.
 
 ## How
+
 To fix a violation of this rule, please make sure Examples directory is present:
 * For non-class based resources it should exist at the same folder level as DSCResources folder.
 * For class based resources it should be present at the same folder level as resource psm1 file.
@@ -12,7 +15,9 @@ To fix a violation of this rule, please make sure Examples directory is present:
 Examples folder should contain sample configuration for given resource - file name should contain resource's name.
 
 ## Example
+
 ### Non-class based resource
+
 Let's assume we have non-class based resource with a following file structure:
 * xAzure
   * DSCResources
@@ -31,6 +36,7 @@ In this case, to fix this warning, we should add examples in a following way:
     * MSFT_xAzureSubscription_RemoveSubscriptionExample.ps1
 
 ### Class based resource
+
 Let's assume we have class based resource with a following file structure:
 * MyDscResource
     * MyDscResource.psm1

--- a/RuleDocumentation/DscExamplesPresent.md
+++ b/RuleDocumentation/DscExamplesPresent.md
@@ -1,17 +1,17 @@
-﻿#DscExamplesPresent
+# DscExamplesPresent
 **Severity Level: Information**
 
-##Description
+## Description
 Checks that DSC examples for given resource are present.
 
-##How to Fix
+## How
 To fix a violation of this rule, please make sure Examples directory is present:
 * For non-class based resources it should exist at the same folder level as DSCResources folder.
 * For class based resources it should be present at the same folder level as resource psm1 file.
 
 Examples folder should contain sample configuration for given resource - file name should contain resource's name.
 
-##Example
+## Example
 ### Non-class based resource
 Let's assume we have non-class based resource with a following file structure:
 * xAzure

--- a/RuleDocumentation/DscTestsPresent.md
+++ b/RuleDocumentation/DscTestsPresent.md
@@ -1,17 +1,17 @@
-﻿#DscTestsPresent
+# DscTestsPresent
 **Severity Level: Information**
 
-##Description
+## Description
 Checks that DSC tests for given resource are present.
 
-##How to Fix
+## How
 To fix a violation of this rule, please make sure Tests directory is present:
 * For non-class based resources it should exist at the same folder level as DSCResources folder.
 * For class based resources it should be present at the same folder level as resource psm1 file.
 
 Tests folder should contain test script for given resource - file name should contain resource's name.
 
-##Example
+## Example
 ### Non-class based resource
 Let's assume we have non-class based resource with a following file structure:
 * xAzure

--- a/RuleDocumentation/DscTestsPresent.md
+++ b/RuleDocumentation/DscTestsPresent.md
@@ -1,10 +1,13 @@
 # DscTestsPresent
+
 **Severity Level: Information**
 
 ## Description
+
 Checks that DSC tests for given resource are present.
 
 ## How
+
 To fix a violation of this rule, please make sure Tests directory is present:
 * For non-class based resources it should exist at the same folder level as DSCResources folder.
 * For class based resources it should be present at the same folder level as resource psm1 file.
@@ -12,7 +15,9 @@ To fix a violation of this rule, please make sure Tests directory is present:
 Tests folder should contain test script for given resource - file name should contain resource's name.
 
 ## Example
+
 ### Non-class based resource
+
 Let's assume we have non-class based resource with a following file structure:
 * xAzure
   * DSCResources
@@ -30,6 +35,7 @@ In this case, to fix this warning, we should add tests in a following way:
     * MSFT_xAzureSubscription_Tests.ps1
 
 ### Class based resource
+
 Let's assume we have class based resource with a following file structure:
 * MyDscResource
     * MyDscResource.psm1

--- a/RuleDocumentation/MissingModuleManifestField.md
+++ b/RuleDocumentation/MissingModuleManifestField.md
@@ -1,7 +1,7 @@
-﻿#MissingModuleManifestField
+# MissingModuleManifestField
 **Severity Level: Warning**
 
-##Description
+## Description
 A module manifest is a `.psd1` file that contains a hash table. The keys and values in the hash table describe the contents and attributes of the module, define the
 prerequisites, and determine how the components are processed.
 
@@ -10,11 +10,11 @@ Module manifests must contain the following keys (and a corresponding value) to 
 
 All other keys are optional. The order of the entries is not important.
 
-##How to Fix
+## How
 Please consider adding the missing fields to the manifest.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 @{
     Author              = 'PowerShell Author'
@@ -25,7 +25,7 @@ Please consider adding the missing fields to the manifest.
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 @{
     ModuleVersion       = '1.0'

--- a/RuleDocumentation/MissingModuleManifestField.md
+++ b/RuleDocumentation/MissingModuleManifestField.md
@@ -1,7 +1,9 @@
 # MissingModuleManifestField
+
 **Severity Level: Warning**
 
 ## Description
+
 A module manifest is a `.psd1` file that contains a hash table. The keys and values in the hash table describe the contents and attributes of the module, define the
 prerequisites, and determine how the components are processed.
 
@@ -11,10 +13,13 @@ Module manifests must contain the following keys (and a corresponding value) to 
 All other keys are optional. The order of the entries is not important.
 
 ## How
+
 Please consider adding the missing fields to the manifest.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 @{
     Author              = 'PowerShell Author'
@@ -26,6 +31,7 @@ Please consider adding the missing fields to the manifest.
 ```
 
 ### Correct
+
 ``` PowerShell
 @{
     ModuleVersion       = '1.0'

--- a/RuleDocumentation/PlaceCloseBrace.md
+++ b/RuleDocumentation/PlaceCloseBrace.md
@@ -1,12 +1,15 @@
-﻿# PlaceCloseBrace
+# PlaceCloseBrace
+
 **Severity Level: Warning**
 
 ## Description
+
 Close brace placement should follow a consistent style. It should be on a new line by itself and should not be followed by an empty line.
 
 **Note**: This rule is not enabled by default. The user needs to enable it through settings.
 
 ## Configuration
+
 ```powershell
     Rules = @{
         PSPlaceCloseBrace = @{
@@ -21,15 +24,19 @@ Close brace placement should follow a consistent style. It should be on a new li
 ### Parameters
 
 #### Enable: bool (Default value is `$false`)
+
 Enable or disable the rule during ScriptAnalyzer invocation.
 
 #### NoEmptyLineBefore: bool (Default value is `$false`)
+
 Create violation if there is an empty line before a close brace.
 
 #### IgnoreOneLineBlock: bool (Default value is `$true`)
+
 Indicates if close braces in a one line block should be ignored or not.
 E.g. $x = if ($true) { "blah" } else { "blah blah" }
 In the above example, if the property is set to true then the rule will not fire a violation.
 
 #### NewLineAfter: bool (Default value is `$true`)
+
 Indicates if a new line should follow a close brace. If set to true a close brace should be followed by a new line.

--- a/RuleDocumentation/PlaceOpenBrace.md
+++ b/RuleDocumentation/PlaceOpenBrace.md
@@ -1,12 +1,15 @@
 # PlaceOpenBrace
+
 **Severity Level: Warning**
 
 ## Description
+
 Open brace placement should follow a consistent style. It can either follow KR style (on same line) or the Allman style (not on same line).
 
 **Note**: This rule is not enabled by default. The user needs to enable it through settings.
 
 ## Configuration
+
 ```powershell
     Rules = @{
         PSPlaceOpenBrace = @{
@@ -21,15 +24,19 @@ Open brace placement should follow a consistent style. It can either follow KR s
 ### Parameters
 
 #### Enable: bool (Default value is `$false`)
+
 Enable or disable the rule during ScriptAnalyzer invocation.
 
 #### OnSameLine: bool (Default value is `$true`)
+
 # true
 
 #### NewLineAfter: bool (Default value is `$true`)
+
 Enforce a new line character after an open brace. The default value is true.
 
 #### IgnoreOneLineBlock: bool (Default value is `$true`)
+
 Indicates if open braces in a one line block should be ignored or not.
 E.g. $x = if ($true) { "blah" } else { "blah blah" }
 In the above example, if the property is set to true then the rule will not fire a violation.

--- a/RuleDocumentation/PlaceOpenBrace.md
+++ b/RuleDocumentation/PlaceOpenBrace.md
@@ -1,4 +1,4 @@
-﻿# PlaceOpenBrace
+# PlaceOpenBrace
 **Severity Level: Warning**
 
 ## Description
@@ -24,7 +24,7 @@ Open brace placement should follow a consistent style. It can either follow KR s
 Enable or disable the rule during ScriptAnalyzer invocation.
 
 #### OnSameLine: bool (Default value is `$true`)
-Provide an option to enforce the open brace to be on the same line as preceding keyword (KR style) or on the next line (Allman style). The default value is `#true.
+# true
 
 #### NewLineAfter: bool (Default value is `$true`)
 Enforce a new line character after an open brace. The default value is true.

--- a/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
+++ b/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
@@ -1,7 +1,9 @@
 # PossibleIncorrectComparisonWithNull
+
 **Severity Level: Warning**
 
 ## Description
+
 To ensure that PowerShell performs comparisons correctly, the `$null` element should be on the left side of the operator.
 
 There are a number of reasons why this should occur:
@@ -9,10 +11,13 @@ There are a number of reasons why this should occur:
 * PowerShell will perform type casting left to right, resulting in incorrect comparisons when `$null` is cast to other types.
 
 ## How
+
 Move `$null` to the left side of the comparison.
 
 ## Example
+
 ### Wrong?
+
 ``` PowerShell
 function Test-CompareWithNull
 {
@@ -23,6 +28,7 @@ function Test-CompareWithNull
 ```
 
 ### Correct
+
 ``` PowerShell
 function Test-CompareWithNull
 {

--- a/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
+++ b/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
@@ -1,18 +1,18 @@
-﻿#PossibleIncorrectComparisonWithNull
+# PossibleIncorrectComparisonWithNull
 **Severity Level: Warning**
 
-##Description
+## Description
 To ensure that PowerShell performs comparisons correctly, the `$null` element should be on the left side of the operator.
 
 There are a number of reasons why this should occur:
 * When there is an array on the left side of a null equality comparison, PowerShell will check for a `$null` IN the array rather than if the array is null.
 * PowerShell will perform type casting left to right, resulting in incorrect comparisons when `$null` is cast to other types.
 
-##How to Fix
+## How
 Move `$null` to the left side of the comparison.
 
-##Example
-### Wrong：
+## Example
+### Wrong?
 ``` PowerShell
 function Test-CompareWithNull
 {
@@ -22,7 +22,7 @@ function Test-CompareWithNull
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Test-CompareWithNull
 {

--- a/RuleDocumentation/ProvideCommentHelp.md
+++ b/RuleDocumentation/ProvideCommentHelp.md
@@ -1,16 +1,16 @@
-﻿#ProvideCommentHelp
+# ProvideCommentHelp
 **Severity Level: Info**
 
-##Description
+## Description
 Comment based help should be provided for all PowerShell commands. This test only checks for the presence of comment based help and not on the validity or format.
 
 For assistance on comment based help, use the command ```Get-Help about_comment_based_help``` or the article, "How to Write Cmdlet Help" (http://go.microsoft.com/fwlink/?LinkID=123415).
 
-##How to Fix
+## How
 Include comment based help for each command identified.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 function Get-File
 {
@@ -23,7 +23,7 @@ function Get-File
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 <#
 .Synopsis

--- a/RuleDocumentation/ProvideCommentHelp.md
+++ b/RuleDocumentation/ProvideCommentHelp.md
@@ -1,16 +1,21 @@
 # ProvideCommentHelp
+
 **Severity Level: Info**
 
 ## Description
+
 Comment based help should be provided for all PowerShell commands. This test only checks for the presence of comment based help and not on the validity or format.
 
 For assistance on comment based help, use the command ```Get-Help about_comment_based_help``` or the article, "How to Write Cmdlet Help" (http://go.microsoft.com/fwlink/?LinkID=123415).
 
 ## How
+
 Include comment based help for each command identified.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Get-File
 {
@@ -24,6 +29,7 @@ function Get-File
 ```
 
 ### Correct
+
 ``` PowerShell
 <#
 .Synopsis
@@ -47,6 +53,7 @@ function Get-File
 .FUNCTIONALITY
     The functionality that best describes this cmdlet
 #>
+
 function Get-File
 {
     [CmdletBinding()]

--- a/RuleDocumentation/ProvideDefaultParameterValue.md
+++ b/RuleDocumentation/ProvideDefaultParameterValue.md
@@ -1,15 +1,20 @@
 # ProvideDefaultParameterValue
+
 **Severity Level: Warning**
 
 ## Description
+
 Just like non-global scoped variables, parameters must have a default value if they are not mandatory, i.e `Mandatory=$false`.
 Having optional parameters without default values leads to uninitialized variables leading to potential bugs.
 
 ## How
+
 Specify a default value for all parameters that are not mandatory.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Test($Param1)
 {
@@ -18,6 +23,7 @@ function Test($Param1)
 ```
 
 ### Correct
+
 ``` PowerShell
 function Test($Param1 = $null)
 {

--- a/RuleDocumentation/ProvideDefaultParameterValue.md
+++ b/RuleDocumentation/ProvideDefaultParameterValue.md
@@ -1,15 +1,15 @@
-﻿#ProvideDefaultParameterValue
+# ProvideDefaultParameterValue
 **Severity Level: Warning**
 
-##Description
+## Description
 Just like non-global scoped variables, parameters must have a default value if they are not mandatory, i.e `Mandatory=$false`.
 Having optional parameters without default values leads to uninitialized variables leading to potential bugs.
 
-##How to Fix
+## How
 Specify a default value for all parameters that are not mandatory.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function Test($Param1)
 {
@@ -17,7 +17,7 @@ function Test($Param1)
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Test($Param1 = $null)
 {

--- a/RuleDocumentation/ProvideVerboseMessage.md
+++ b/RuleDocumentation/ProvideVerboseMessage.md
@@ -1,14 +1,19 @@
 # ProvideVerboseMessage
+
 **Severity Level: Information**
 
 ## Description
+
 Best practice recommends that additional user information is provided within commands, functions and scripts using `Write-Verbose`.
 
 ## How
+
 Make use of the `Write-Verbose` command.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 Function Test-Function
 {
@@ -19,6 +24,7 @@ Function Test-Function
 ```
 
 ### Correct
+
 ``` PowerShell
 Function Test-Function
 {

--- a/RuleDocumentation/ProvideVerboseMessage.md
+++ b/RuleDocumentation/ProvideVerboseMessage.md
@@ -1,14 +1,14 @@
-﻿#ProvideVerboseMessage
+# ProvideVerboseMessage
 **Severity Level: Information**
 
-##Description
+## Description
 Best practice recommends that additional user information is provided within commands, functions and scripts using `Write-Verbose`.
 
-##How to Fix
+## How
 Make use of the `Write-Verbose` command.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 Function Test-Function
 {
@@ -18,7 +18,7 @@ Function Test-Function
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 Function Test-Function
 {

--- a/RuleDocumentation/README.md
+++ b/RuleDocumentation/README.md
@@ -1,4 +1,5 @@
 # PowerShell Script Analyzer Rules
+
 ## Table of Contents
 
 | Rule | Severity |

--- a/RuleDocumentation/ReturnCorrectTypeDSCFunctions.md
+++ b/RuleDocumentation/ReturnCorrectTypeDSCFunctions.md
@@ -1,7 +1,9 @@
 # ReturnCorrectTypeDSCFunctions
+
 **Severity Level: Information**
 
 ## Description
+
 The functions in DSC resources have specific return objects.
 
 For non-class based resources:
@@ -15,10 +17,13 @@ For class based resources:
 * `Get` must return an instance of the DSC class.
 
 ## How
+
 Ensure that each function returns the correct type.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Get-TargetResource
 {
@@ -55,6 +60,7 @@ function Test-TargetResource
 ```
 
 ### Correct
+
 ``` PowerShell
 function Get-TargetResource
 {
@@ -93,7 +99,9 @@ function Test-TargetResource
 ```
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 [DscResource()]
 class MyDSCResource
@@ -119,6 +127,7 @@ class MyDSCResource
 ```
 
 ### Correct
+
 ``` PowerShell
 [DscResource()]
 class MyDSCResource

--- a/RuleDocumentation/ReturnCorrectTypeDSCFunctions.md
+++ b/RuleDocumentation/ReturnCorrectTypeDSCFunctions.md
@@ -1,7 +1,7 @@
-﻿#ReturnCorrectTypeDSCFunctions
+# ReturnCorrectTypeDSCFunctions
 **Severity Level: Information**
 
-##Description
+## Description
 The functions in DSC resources have specific return objects.
 
 For non-class based resources:
@@ -14,11 +14,11 @@ For class based resources:
 * `Test` must return a boolean.
 * `Get` must return an instance of the DSC class.
 
-##How to Fix
+## How
 Ensure that each function returns the correct type.
 
-##Example Non Class Based
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 function Get-TargetResource
 {
@@ -54,7 +54,7 @@ function Test-TargetResource
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Get-TargetResource
 {
@@ -92,8 +92,8 @@ function Test-TargetResource
 }
 ```
 
-##Example Class Based
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 [DscResource()]
 class MyDSCResource
@@ -118,7 +118,7 @@ class MyDSCResource
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 [DscResource()]
 class MyDSCResource

--- a/RuleDocumentation/UseApprovedVerbs.md
+++ b/RuleDocumentation/UseApprovedVerbs.md
@@ -1,16 +1,21 @@
 # UseApprovedVerbs
+
 **Severity Level: Warning**
 
 ## Description
+
 All CMDLets must used approved verbs.
 
 Approved verbs can be found by running the command `Get-Verb`.
 
 ## How
+
 Change the verb in the cmdlet's name to an approved verb.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Change-Item
 {
@@ -19,6 +24,7 @@ function Change-Item
 ````
 
 ### Correct
+
 ``` PowerShell
 function Update-Item
 {

--- a/RuleDocumentation/UseApprovedVerbs.md
+++ b/RuleDocumentation/UseApprovedVerbs.md
@@ -1,16 +1,16 @@
-﻿#UseApprovedVerbs
+# UseApprovedVerbs
 **Severity Level: Warning**
 
-##Description
+## Description
 All CMDLets must used approved verbs.
 
 Approved verbs can be found by running the command `Get-Verb`.
 
-##How to Fix
+## How
 Change the verb in the cmdlet's name to an approved verb.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function Change-Item
 {
@@ -18,7 +18,7 @@ function Change-Item
 }
 ````
 
-###Correct:
+### Correct
 ``` PowerShell
 function Update-Item
 {

--- a/RuleDocumentation/UseBOMForUnicodeEncodedFile.md
+++ b/RuleDocumentation/UseBOMForUnicodeEncodedFile.md
@@ -1,8 +1,8 @@
-﻿#UseBOMForUnicodeEncodedFile
+# UseBOMForUnicodeEncodedFile
 **Severity Level: Warning**
 
-##Description
+## Description
 For a file encoded with a format other than ASCII, ensure Byte Order Mark (BOM) is present to ensure that any application consuming this file can interpret it correctly.
 
-##How to Fix
+## How
 Ensure that the file is encoded with BOM present.

--- a/RuleDocumentation/UseBOMForUnicodeEncodedFile.md
+++ b/RuleDocumentation/UseBOMForUnicodeEncodedFile.md
@@ -1,8 +1,11 @@
 # UseBOMForUnicodeEncodedFile
+
 **Severity Level: Warning**
 
 ## Description
+
 For a file encoded with a format other than ASCII, ensure Byte Order Mark (BOM) is present to ensure that any application consuming this file can interpret it correctly.
 
 ## How
+
 Ensure that the file is encoded with BOM present.

--- a/RuleDocumentation/UseCmdletCorrectly.md
+++ b/RuleDocumentation/UseCmdletCorrectly.md
@@ -1,14 +1,14 @@
-﻿#UseCmdletCorrectly
+# UseCmdletCorrectly
 **Severity Level: Warning**
 
-##Description
+## Description
 Whenever we call a command, care should be taken that it is invoked with the correct syntax and parameters.
 
-##How to Fix
+## How
 Specify all mandatory parameters when calling commands.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 Function Set-TodaysDate ()
 {
@@ -17,7 +17,7 @@ Function Set-TodaysDate ()
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 Function Set-TodaysDate ()
 {

--- a/RuleDocumentation/UseCmdletCorrectly.md
+++ b/RuleDocumentation/UseCmdletCorrectly.md
@@ -1,14 +1,19 @@
 # UseCmdletCorrectly
+
 **Severity Level: Warning**
 
 ## Description
+
 Whenever we call a command, care should be taken that it is invoked with the correct syntax and parameters.
 
 ## How
+
 Specify all mandatory parameters when calling commands.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 Function Set-TodaysDate ()
 {
@@ -18,6 +23,7 @@ Function Set-TodaysDate ()
 ```
 
 ### Correct
+
 ``` PowerShell
 Function Set-TodaysDate ()
 {

--- a/RuleDocumentation/UseCompatibleCmdlets.md
+++ b/RuleDocumentation/UseCompatibleCmdlets.md
@@ -1,7 +1,9 @@
-﻿# UseCompatibleCmdlets
+# UseCompatibleCmdlets
+
 **Severity Level: Warning**
 
 ## Description
+
 This rule flags cmdlets that are not available in a given Edition/Version of PowerShell on a given Operating System. It works by comparing a cmdlet against a set of whitelists which ship with PSScriptAnalyzer. They can be found at `/path/to/PSScriptAnalyzerModule/Settings`. These files are of the form, `PSEDITION-PSVERSION-OS.json` where `PSEDITION` can be either `core` or `desktop`, `OS` can be either `windows`, `linux` or `osx`, and `version` is the PowerShell version. To enable the rule to check if your script is compatible on PowerShell Core on windows, put the following your settings file:
 ```PowerShell
 @{

--- a/RuleDocumentation/UseConsistentIndentation.md
+++ b/RuleDocumentation/UseConsistentIndentation.md
@@ -1,12 +1,15 @@
-﻿# UseConsistentIndentation
+# UseConsistentIndentation
+
 **Severity Level: Warning**
 
 ## Description
+
 Indentation should be consistent throughout the source file.
 
 **Note**: This rule is not enabled by default. The user needs to enable it through settings.
 
 ## Configuration
+
 ```powershell
     Rules = @{
         PSUseConsistentIndentation = @{
@@ -19,7 +22,9 @@ Indentation should be consistent throughout the source file.
 ### Parameters
 
 #### Enable: bool (Default value is `$false`)
+
 Enable or disable the rule during ScriptAnalyzer invocation.
 
 #### IndentationSize: bool (Default value is `4`)
+
 Indentation size in the number of space characters.

--- a/RuleDocumentation/UseConsistentWhitespace.md
+++ b/RuleDocumentation/UseConsistentWhitespace.md
@@ -1,8 +1,8 @@
-﻿# UseConsistentWhitespace
+# UseConsistentWhitespace
 **Severity Level: Warning**
 
 ## Description
-This rule enforces consistent brace, parenthesis, binary operator, assignment operator and separator styles. For more information please see the [Parameters](#parameters) section.
+# parameters
 
 **Note**: This rule is not enabled by default. The user needs to enable it through settings.
 

--- a/RuleDocumentation/UseConsistentWhitespace.md
+++ b/RuleDocumentation/UseConsistentWhitespace.md
@@ -1,12 +1,15 @@
 # UseConsistentWhitespace
+
 **Severity Level: Warning**
 
 ## Description
+
 # parameters
 
 **Note**: This rule is not enabled by default. The user needs to enable it through settings.
 
 ## Configuration
+
 ```powershell
     Rules = @{
         PSUseConsistentWhitespace = @{
@@ -22,16 +25,21 @@
 ### Parameters
 
 #### Enable: bool (Default value is `$false`)
+
 Enable or disable the rule during ScriptAnalyzer invocation.
 
 #### CheckOpenBrace: bool (Default value is `$true`)
+
 Checks if there is a space between a keyword and its corresponding open brace. E.g. `foo { }`.
 
 #### CheckOpenParen: bool (Default value is `$true`)
+
 Checks if there is space between a keyword and its corresponding open parenthesis. E.g. `if (true)`.
 
 #### CheckOperator: bool (Default value is `$true`)
+
 Checks if a binary operator is surrounded on both sides by a space. E.g. `$x = 1`.
 
 #### CheckSeparator: bool (Default value is `$true`)
+
 Checks if a comma or a semicolon is followed by a space. E.g. `@(1, 2, 3)` or `@{a = 1; b = 2}`.

--- a/RuleDocumentation/UseDeclaredVarsMoreThanAssignments.md
+++ b/RuleDocumentation/UseDeclaredVarsMoreThanAssignments.md
@@ -1,14 +1,14 @@
-﻿#UseDeclaredVarsMoreThanAssignments
+# UseDeclaredVarsMoreThanAssignments
 **Severity Level: Warning**
 
-##Description
+## Description
 Generally variables that are not used more than their assignments are considered wasteful and not needed.
 
-##How to Fix
+## How
 Remove the variables that are declared but not used.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function Test
 {
@@ -18,7 +18,7 @@ function Test
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Test
 {

--- a/RuleDocumentation/UseDeclaredVarsMoreThanAssignments.md
+++ b/RuleDocumentation/UseDeclaredVarsMoreThanAssignments.md
@@ -1,14 +1,19 @@
 # UseDeclaredVarsMoreThanAssignments
+
 **Severity Level: Warning**
 
 ## Description
+
 Generally variables that are not used more than their assignments are considered wasteful and not needed.
 
 ## How
+
 Remove the variables that are declared but not used.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Test
 {
@@ -19,6 +24,7 @@ function Test
 ```
 
 ### Correct
+
 ``` PowerShell
 function Test
 {

--- a/RuleDocumentation/UseIdenticalMandatoryParametersDSC.md
+++ b/RuleDocumentation/UseIdenticalMandatoryParametersDSC.md
@@ -1,14 +1,19 @@
 # UseIdenticalMandatoryParametersDSC
+
 **Severity Level: Error**
 
 ## Description
+
 The `Get-TargetResource`, `Test-TargetResource` and `Set-TargetResource` functions of DSC Resource must have the same mandatory parameters.
 
 ## How
+
 Correct the mandatory parameters for the functions in DSC resource.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Get-TargetResource
 {
@@ -47,6 +52,7 @@ function Test-TargetResource
 ```
 
 ### Correct
+
 ``` PowerShell
 function Get-TargetResource
 {

--- a/RuleDocumentation/UseIdenticalMandatoryParametersDSC.md
+++ b/RuleDocumentation/UseIdenticalMandatoryParametersDSC.md
@@ -1,14 +1,14 @@
-﻿#UseIdenticalMandatoryParametersDSC
+# UseIdenticalMandatoryParametersDSC
 **Severity Level: Error**
 
-##Description
+## Description
 The `Get-TargetResource`, `Test-TargetResource` and `Set-TargetResource` functions of DSC Resource must have the same mandatory parameters.
 
-##How to Fix
+## How
 Correct the mandatory parameters for the functions in DSC resource.
 
-##Example Non Class Based
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 function Get-TargetResource
 {
@@ -46,7 +46,7 @@ function Test-TargetResource
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Get-TargetResource
 {

--- a/RuleDocumentation/UseIdenticalParametersDSC.md
+++ b/RuleDocumentation/UseIdenticalParametersDSC.md
@@ -1,14 +1,19 @@
 # UseIdenticalParametersDSC
+
 **Severity Level: Error**
 
 ## Description
+
 The `Get-TargetResource`, `Test-TargetResource` and `Set-TargetResource` functions of DSC Resource must have the same parameters.
 
 ## How
+
 Correct the parameters for the functions in DSC resource.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Get-TargetResource
 {
@@ -50,6 +55,7 @@ function Test-TargetResource
 ```
 
 ### Correct
+
 ``` PowerShell
 function Get-TargetResource
 {

--- a/RuleDocumentation/UseIdenticalParametersDSC.md
+++ b/RuleDocumentation/UseIdenticalParametersDSC.md
@@ -1,14 +1,14 @@
-﻿#UseIdenticalParametersDSC
+# UseIdenticalParametersDSC
 **Severity Level: Error**
 
-##Description
+## Description
 The `Get-TargetResource`, `Test-TargetResource` and `Set-TargetResource` functions of DSC Resource must have the same parameters.
 
-##How to Fix
+## How
 Correct the parameters for the functions in DSC resource.
 
-##Example Non Class Based
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 function Get-TargetResource
 {
@@ -49,7 +49,7 @@ function Test-TargetResource
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Get-TargetResource
 {

--- a/RuleDocumentation/UseLiteralInitializerForHashtable.md
+++ b/RuleDocumentation/UseLiteralInitializerForHashtable.md
@@ -1,24 +1,31 @@
 # UseLiteralInitializerForHashtable
+
 **Severity Level: Warning**
 
 ## Description
+
 Creating a hashtable by either `[hashtable]::new()` or `New-Object -TypeName hashtable` will create a hashtable wherein the keys are looked-up in a case-sensitive manner, unless an `IEqualityComparer` object is passed as an argument. However, PowerShell is case-insensitive in nature and it is best to create hashtables with case-insensitive key look-up. This rule is intended to warn the author of the case-sensitive nature of the hashtable if he/she creates a hashtable using the `new` member or the `New-Object` cmdlet.
 
 ## How to Fix
+
 Use the full cmdlet name and not an alias.
 
 ## Example
-### Wrong：
+
+### Wrong???
+
 ``` PowerShell
 $hashtable = [hashtable]::new()
 ```
 
-### Wrong：
+### Wrong???
+
 ``` PowerShell
 $hashtable = New-Object -TypeName hashtable
 ```
 
 ### Correct:
+
 ``` PowerShell
 $hashtable = @{}
 ```

--- a/RuleDocumentation/UseOutputTypeCorrectly.md
+++ b/RuleDocumentation/UseOutputTypeCorrectly.md
@@ -1,16 +1,21 @@
 # UseOutputTypeCorrectly
+
 **Severity Level: Information**
 
 ## Description
+
 A command should return the same type as declared in `OutputType`.
 
 You can get more details by running `Get-Help about_Functions_OutputTypeAttribute` command in Windows PowerShell.
 
 ## How
+
 Specify that the OutputType attribute lists and the types returned in the cmdlet match.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Get-Foo
 {
@@ -23,6 +28,7 @@ function Get-Foo
 ```
 
 ### Correct
+
 ``` PowerShell
 function Get-Foo
 {

--- a/RuleDocumentation/UseOutputTypeCorrectly.md
+++ b/RuleDocumentation/UseOutputTypeCorrectly.md
@@ -1,16 +1,16 @@
-﻿#UseOutputTypeCorrectly
+# UseOutputTypeCorrectly
 **Severity Level: Information**
 
-##Description
+## Description
 A command should return the same type as declared in `OutputType`.
 
 You can get more details by running `Get-Help about_Functions_OutputTypeAttribute` command in Windows PowerShell.
 
-##How to Fix
+## How
 Specify that the OutputType attribute lists and the types returned in the cmdlet match.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 function Get-Foo
 {
@@ -22,7 +22,7 @@ function Get-Foo
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Get-Foo
 {

--- a/RuleDocumentation/UsePSCredentialType.md
+++ b/RuleDocumentation/UsePSCredentialType.md
@@ -1,14 +1,19 @@
 # UsePSCredentialType
+
 **Severity Level: Warning**
 
 ## Description
+
 If the cmdlet or function has a `Credential` parameter, the parameter must accept the `PSCredential` type.
 
 ## How
+
 Change the `Credential` parameter's type to be `PSCredential`.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Credential([String]$Credential)
 {
@@ -17,6 +22,7 @@ function Credential([String]$Credential)
 ```
 
 ### Correct
+
 ``` PowerShell
 function Credential([PSCredential]$Credential)
 {

--- a/RuleDocumentation/UsePSCredentialType.md
+++ b/RuleDocumentation/UsePSCredentialType.md
@@ -1,14 +1,14 @@
-﻿#UsePSCredentialType
+# UsePSCredentialType
 **Severity Level: Warning**
 
-##Description
+## Description
 If the cmdlet or function has a `Credential` parameter, the parameter must accept the `PSCredential` type.
 
-##How to Fix
+## How
 Change the `Credential` parameter's type to be `PSCredential`.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 function Credential([String]$Credential)
 {
@@ -16,7 +16,7 @@ function Credential([String]$Credential)
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Credential([PSCredential]$Credential)
 {

--- a/RuleDocumentation/UseShouldProcessCorrectly.md
+++ b/RuleDocumentation/UseShouldProcessCorrectly.md
@@ -1,16 +1,21 @@
 # UseShouldProcessCorrectly
+
 **Severity Level: Warning**
 
 ## Description
+
 If a cmdlet declares the `SupportsShouldProcess` attribute, then it should also call `ShouldProcess`. A violation is any function which either declares `SupportsShouldProcess` attribute but makes no calls to `ShouldProcess` or it calls `ShouldProcess` but does not does not declare `SupportsShouldProcess`
 
 For more information, please refer to `about_Functions_Advanced_Methods` and `about_Functions_CmdletBindingAttribute`
 
 ## How
+
 To fix a violation of this rule, please call `ShouldProcess` method when a cmdlet declares `SupportsShouldProcess` attribute. Or please add `SupportsShouldProcess` attribute argument when calling `ShouldProcess`
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 	function Set-File
 	{
@@ -26,6 +31,7 @@ To fix a violation of this rule, please call `ShouldProcess` method when a cmdle
 ```
 
 ### Correct
+
 ``` PowerShell
 	function Set-File
 	{

--- a/RuleDocumentation/UseShouldProcessCorrectly.md
+++ b/RuleDocumentation/UseShouldProcessCorrectly.md
@@ -1,16 +1,16 @@
-﻿#UseShouldProcessCorrectly
+# UseShouldProcessCorrectly
 **Severity Level: Warning**
 
-##Description
+## Description
 If a cmdlet declares the `SupportsShouldProcess` attribute, then it should also call `ShouldProcess`. A violation is any function which either declares `SupportsShouldProcess` attribute but makes no calls to `ShouldProcess` or it calls `ShouldProcess` but does not does not declare `SupportsShouldProcess`
 
 For more information, please refer to `about_Functions_Advanced_Methods` and `about_Functions_CmdletBindingAttribute`
 
-##How to Fix
+## How
 To fix a violation of this rule, please call `ShouldProcess` method when a cmdlet declares `SupportsShouldProcess` attribute. Or please add `SupportsShouldProcess` attribute argument when calling `ShouldProcess`
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 	function Set-File
 	{
@@ -25,7 +25,7 @@ To fix a violation of this rule, please call `ShouldProcess` method when a cmdle
 	}
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 	function Set-File
 	{

--- a/RuleDocumentation/UseShouldProcessForStateChangingFunctions.md
+++ b/RuleDocumentation/UseShouldProcessForStateChangingFunctions.md
@@ -1,7 +1,9 @@
 # UseShouldProcessForStateChangingFunctions
+
 **Severity Level: Warning**
 
 ## Description
+
 Functions whose verbs change system state should support `ShouldProcess`.
 
 Verbs that should support `ShouldProcess`:
@@ -15,10 +17,13 @@ Verbs that should support `ShouldProcess`:
 * `Update`
 
 ## How
+
 Include the attribute `SupportsShouldProcess`, in the `CmdletBindingBinding`.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 	function Set-ServiceObject
 	{
@@ -33,6 +38,7 @@ Include the attribute `SupportsShouldProcess`, in the `CmdletBindingBinding`.
 ```
 
 ### Correct
+
 ``` PowerShell
 	function Set-ServiceObject
 	{

--- a/RuleDocumentation/UseShouldProcessForStateChangingFunctions.md
+++ b/RuleDocumentation/UseShouldProcessForStateChangingFunctions.md
@@ -1,7 +1,7 @@
-﻿#UseShouldProcessForStateChangingFunctions
+# UseShouldProcessForStateChangingFunctions
 **Severity Level: Warning**
 
-##Description
+## Description
 Functions whose verbs change system state should support `ShouldProcess`.
 
 Verbs that should support `ShouldProcess`:
@@ -14,11 +14,11 @@ Verbs that should support `ShouldProcess`:
 * `Reset`
 * `Update`
 
-##How to Fix
+## How
 Include the attribute `SupportsShouldProcess`, in the `CmdletBindingBinding`.
 
-##Example
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 	function Set-ServiceObject
 	{
@@ -32,7 +32,7 @@ Include the attribute `SupportsShouldProcess`, in the `CmdletBindingBinding`.
 	}
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 	function Set-ServiceObject
 	{

--- a/RuleDocumentation/UseSingularNouns.md
+++ b/RuleDocumentation/UseSingularNouns.md
@@ -1,14 +1,14 @@
-﻿#UseSingularNouns
+# UseSingularNouns
 **Severity Level: Warning**
 
-##Description
+## Description
 PowerShell team best practices state cmdlets should use singular nouns and not plurals.
 
-##How to Fix
+## How
 Change plurals to singular.
 
-##Example
-###Wrong：
+## Example
+### Wrong
 ``` PowerShell
 function Get-Files
 {
@@ -16,7 +16,7 @@ function Get-Files
 }
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 function Get-File
 {

--- a/RuleDocumentation/UseSingularNouns.md
+++ b/RuleDocumentation/UseSingularNouns.md
@@ -1,14 +1,19 @@
 # UseSingularNouns
+
 **Severity Level: Warning**
 
 ## Description
+
 PowerShell team best practices state cmdlets should use singular nouns and not plurals.
 
 ## How
+
 Change plurals to singular.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Get-Files
 {
@@ -17,6 +22,7 @@ function Get-Files
 ```
 
 ### Correct
+
 ``` PowerShell
 function Get-File
 {

--- a/RuleDocumentation/UseStandardDSCFunctionsInResource.md
+++ b/RuleDocumentation/UseStandardDSCFunctionsInResource.md
@@ -1,7 +1,7 @@
-﻿#UseStandardDSCFunctionsInResource
+# UseStandardDSCFunctionsInResource
 **Severity Level: Error**
 
-##Description
+## Description
 All DSC resources are required to implement the correct functions.
 
 For non-class based resources:
@@ -14,11 +14,11 @@ For class based resources:
 * `Test`
 * `Get`
 
-##How to Fix
+## How
 Add the missing functions to the resource.
 
-##Example Non Class Based
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 function Get-TargetResource
 {
@@ -43,7 +43,7 @@ function Set-TargetResource
     ...
 }
 ```
-###Correct:
+### Correct
 ``` PowerShell
 function Get-TargetResource
 {
@@ -81,8 +81,8 @@ function Test-TargetResource
 }
 ```
 
-##Example Class Based
-###Wrong:
+## Example
+### Wrong
 ``` PowerShell
 [DscResource()]
 class MyDSCResource
@@ -101,7 +101,7 @@ class MyDSCResource
     }
 }
 
-###Correct:
+### Correct
 ``` PowerShell
 [DscResource()]
 class MyDSCResource

--- a/RuleDocumentation/UseStandardDSCFunctionsInResource.md
+++ b/RuleDocumentation/UseStandardDSCFunctionsInResource.md
@@ -1,7 +1,9 @@
 # UseStandardDSCFunctionsInResource
+
 **Severity Level: Error**
 
 ## Description
+
 All DSC resources are required to implement the correct functions.
 
 For non-class based resources:
@@ -15,10 +17,13 @@ For class based resources:
 * `Get`
 
 ## How
+
 Add the missing functions to the resource.
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 function Get-TargetResource
 {
@@ -44,6 +49,7 @@ function Set-TargetResource
 }
 ```
 ### Correct
+
 ``` PowerShell
 function Get-TargetResource
 {
@@ -82,7 +88,9 @@ function Test-TargetResource
 ```
 
 ## Example
+
 ### Wrong
+
 ``` PowerShell
 [DscResource()]
 class MyDSCResource
@@ -102,6 +110,7 @@ class MyDSCResource
 }
 
 ### Correct
+
 ``` PowerShell
 [DscResource()]
 class MyDSCResource

--- a/RuleDocumentation/UseToExportFieldsInManifest.md
+++ b/RuleDocumentation/UseToExportFieldsInManifest.md
@@ -1,7 +1,7 @@
-﻿#UseToExportFieldsInManifest
+# UseToExportFieldsInManifest
 **Severity Level: Warning**
 
-##Description
+## Description
 To improve the performance of module auto-discovery, module manifests should not use wildcards (`'*'`) or null (`$null`) in the following entries:
 * `AliasesToExport`
 * `CmdletsToExport`
@@ -10,31 +10,31 @@ To improve the performance of module auto-discovery, module manifests should not
 
 The use of wildcards or null has the potential to cause PowerShell to perform expensive work to analyse a module during module auto-discovery.
 
-##How to Fix
+## How
 Use an explicit list in the entries.
 
-##Example 1
+## Example
 Suppose there are no functions in your module to export. Then,
 
-###Wrong：
+### Wrong
 ``` PowerShell
 FunctionsToExport = $null
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 FunctionToExport = @()
 ```
 
-##Example 2
+## Example
 Suppose there are only two functions in your module, ```Get-Foo``` and ```Set-Foo``` that you want to export. Then,
 
-###Wrong:
+### Wrong
 ``` PowerShell
 FunctionsToExport = '*'
 ```
 
-###Correct:
+### Correct
 ``` PowerShell
 FunctionToExport = @(Get-Foo, Set-Foo)
 ```

--- a/RuleDocumentation/UseToExportFieldsInManifest.md
+++ b/RuleDocumentation/UseToExportFieldsInManifest.md
@@ -1,7 +1,9 @@
 # UseToExportFieldsInManifest
+
 **Severity Level: Warning**
 
 ## Description
+
 To improve the performance of module auto-discovery, module manifests should not use wildcards (`'*'`) or null (`$null`) in the following entries:
 * `AliasesToExport`
 * `CmdletsToExport`
@@ -11,30 +13,37 @@ To improve the performance of module auto-discovery, module manifests should not
 The use of wildcards or null has the potential to cause PowerShell to perform expensive work to analyse a module during module auto-discovery.
 
 ## How
+
 Use an explicit list in the entries.
 
 ## Example
+
 Suppose there are no functions in your module to export. Then,
 
 ### Wrong
+
 ``` PowerShell
 FunctionsToExport = $null
 ```
 
 ### Correct
+
 ``` PowerShell
 FunctionToExport = @()
 ```
 
 ## Example
+
 Suppose there are only two functions in your module, ```Get-Foo``` and ```Set-Foo``` that you want to export. Then,
 
 ### Wrong
+
 ``` PowerShell
 FunctionsToExport = '*'
 ```
 
 ### Correct
+
 ``` PowerShell
 FunctionToExport = @(Get-Foo, Set-Foo)
 ```


### PR DESCRIPTION
Most rule documentation markdown files had headers of the form '#header' or '##header'. This commit fixes those issues.

Some documentation markdown markdown files were in UTF8 and the rest in ASCII. This commit converts all markdown files to ASCII encoding.