### PR TITLE
Fix rule name error

### DIFF
--- a/Engine/Settings/CodeFormatting.psd1
+++ b/Engine/Settings/CodeFormatting.psd1
@@ -21,8 +21,8 @@
             Enable = $true
             IndentationSize = 4
         }
-
-        PSUseWhitespace = @{
+		
+		PSUseConsistentWhitespace = @{
             Enable = $true
             CheckOpenBrace = $true
             CheckOpenParen = $true


### PR DESCRIPTION
The CodeFormatting.psd1 file contains a hash table for PSUseWhitespace. There is no rule with that name. Should be PSUseConsistentWhitespace.