### PR TITLE
Update PossibleIncorrectComparisonWithNull.md

### DIFF
--- a/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
+++ b/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
@@ -7,8 +7,8 @@
 To ensure that PowerShell performs comparisons correctly, the `$null` element should be on the left side of the operator.
 
 There are a number of reasons why this should occur:
-* When there is an array on the left side of a null equality comparison, PowerShell will create a new array containing one `$null` item for each `$null` in the original array rather than check if the array is null.
-* PowerShell will perform type casting left to right, resulting in incorrect comparisons when `$null` is cast to other types.
+* `$null` is a scalar. When the input (left side) to an operator is a scalar value, comparison operators return a Boolean value. When the input is a collection of values, the comparison operators return any matching values, or an empty array if there are no matches in the collection. The only way to reliably check if a value is `$null` is to place `$null` on the left side of the operator so that a scalar comparison is perfomed.
+* PowerShell will perform type casting left to right, resulting in incorrect comparisons when `$null` is cast to other scalar types.
 
 ## How
 

--- a/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
+++ b/RuleDocumentation/PossibleIncorrectComparisonWithNull.md
@@ -7,7 +7,7 @@
 To ensure that PowerShell performs comparisons correctly, the `$null` element should be on the left side of the operator.
 
 There are a number of reasons why this should occur:
-* When there is an array on the left side of a null equality comparison, PowerShell will check for a `$null` IN the array rather than if the array is null.
+* When there is an array on the left side of a null equality comparison, PowerShell will create a new array containing one `$null` item for each `$null` in the original array rather than check if the array is null.
 * PowerShell will perform type casting left to right, resulting in incorrect comparisons when `$null` is cast to other types.
 
 ## How


### PR DESCRIPTION
This is technically more accurate. PowerShell doesn't check for a $null in the array as was previously indicated.