### PR TITLE
Fix whitelisted aliases comparison in PSAvoidUsingCmdletAliases rule

### DIFF
--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -18,6 +18,7 @@ using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
 #endif
 using System.Globalization;
+using System.Linq;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
@@ -119,7 +120,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // You can also review the remark section in following document,
                 // MSDN: CommandAst.GetCommandName Method
                 if (aliasName == null
-                    || whiteList.Contains(aliasName))
+                    || whiteList.Contains<string>(aliasName, StringComparer.OrdinalIgnoreCase))
                 {
                     continue;
                 }

--- a/Tests/Rules/AvoidUsingAlias.tests.ps1
+++ b/Tests/Rules/AvoidUsingAlias.tests.ps1
@@ -61,7 +61,16 @@ Configuration MyDscConfiguration {
     }
 
     Context "Settings file provides whitelist" {
-        $whiteListTestScriptDef = 'gci; cd;'
+        BeforeAll {
+            $whiteListTestScriptDef = 'gci; cd;'
+            $settings = @{
+                'Rules' = @{
+                    'PSAvoidUsingCmdletAliases' = @{
+                        'Whitelist' = @('cd')
+                    }
+                }
+            }
+        }
 
         It "honors the whitelist provided as hashtable" {
             $settings = @{
@@ -80,6 +89,11 @@ Configuration MyDscConfiguration {
             $settingsFilePath = (Join-Path $directory (Join-Path 'TestSettings' 'AvoidAliasSettings.psd1')).ToString()
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $whiteListTestScriptDef -Settings $settingsFilePath -IncludeRule $violationName
             $violations.Count | Should be 1
+        }
+
+        It "honors the whitelist in a case-insensitive manner" {
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition "CD" -Settings $settings -IncludeRule $violationName
+            $violations.Count | Should Be 0
         }
     }
 }


### PR DESCRIPTION
Fixes #737 