### PR TITLE
Fix PlaceCloseBrace rule behavior for NewLineAfter option

### DIFF
--- a/Rules/PlaceCloseBrace.cs
+++ b/Rules/PlaceCloseBrace.cs
@@ -314,11 +314,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             if (tokens.Length > 1 && tokens.Length > expectedNewLinePos)
             {
                 var closeBraceToken = tokens[closeBracePos];
-                if (tokens[expectedNewLinePos].Kind != TokenKind.NewLine
-                    && tokens[expectedNewLinePos].Kind != TokenKind.Comment
-                    && !tokensToIgnore.Contains(tokens[closeBracePos]))
+                if ((tokens[expectedNewLinePos].Kind == TokenKind.Else
+                    || tokens[expectedNewLinePos].Kind == TokenKind.ElseIf))
                     {
-
                     return new DiagnosticRecord(
                         GetError(Strings.PlaceCloseBraceErrorShouldFollowNewLine),
                         closeBraceToken.Extent,


### PR DESCRIPTION
This change constrains the behavior of PlaceCloseBrace rule when NewLineAfter option is set to true. Previously, if this option is set to true, the rule will trigger on any close brace that is not followed by a new line except if the close brace is part of a command element AND script block expression. This caused the rule to be too aggressive. We illustrate two such instances.

In the following instance the rule would trigger on the close brace that precedes the comma in the array expression. In VSCode
```powershell
Some-Command -Param1 @{
 key="value"
},@{
 key="value"
}
```
would get formatted to
```powershell
Some-Command -Param1 @{
 key="value"
}
,@{
 key="value"
}
```

In the following instance the rule would trigger on the close brace that precedes the the parameter `-param2` in the command expression. In VSCode,
```powershell
Some-Command -Param1 @{
 key="value"
} -Param2
```
would get formatted to
```powershell
Some-Command -Param1 @{
 key="value"
}
-Param2
```

Fixes PowerShell/vscode-powershell#559