### PR TITLE
Add exceptions to UseConsistentWhitespace rule

### DIFF
--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -298,19 +298,24 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 (tokenNode.Value.Extent.StartColumnNumber - tokenNode.Previous.Value.Extent.EndColumnNumber);
         }
 
+        private bool IsPreviousTokenOnSameLineAndApartByWhitespace(LinkedListNode<Token> tokenNode)
+        {
+            return IsPreviousTokenOnSameLine(tokenNode) && IsPreviousTokenApartByWhitespace(tokenNode);
+        }
+
         private IEnumerable<DiagnosticRecord> FindOperatorViolations(TokenOperations tokenOperations)
         {
-            Func<LinkedListNode<Token>, bool> predicate = tokenNode =>
-            {
-                return tokenNode.Previous != null
-                    && IsPreviousTokenOnSameLine(tokenNode)
-                    && IsPreviousTokenApartByWhitespace(tokenNode);
-            };
-
             foreach (var tokenNode in tokenOperations.GetTokenNodes(IsOperator))
             {
-                var hasWhitespaceBefore = predicate(tokenNode);
-                var hasWhitespaceAfter = predicate(tokenNode.Next);
+                if (tokenNode.Previous == null
+                    || tokenNode.Next == null
+                    || tokenNode.Value.Kind == TokenKind.DotDot)
+                {
+                    continue;
+                }
+
+                var hasWhitespaceBefore = IsPreviousTokenOnSameLineAndApartByWhitespace(tokenNode);
+                var hasWhitespaceAfter = IsPreviousTokenOnSameLineAndApartByWhitespace(tokenNode.Next);
 
                 if (!hasWhitespaceAfter || !hasWhitespaceBefore)
                 {

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -195,9 +195,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             foreach (var lcurly in tokenOperations.GetTokenNodes(TokenKind.LCurly))
             {
+
                 if (lcurly.Previous == null
                     || !IsPreviousTokenOnSameLine(lcurly)
-                    || lcurly.Previous.Value.Kind == TokenKind.LCurly)
+                    || lcurly.Previous.Value.Kind == TokenKind.LCurly
+                    || ((lcurly.Previous.Value.TokenFlags & TokenFlags.MemberName) == TokenFlags.MemberName))
                 {
                     continue;
                 }

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -173,6 +173,13 @@ $x = 1
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $violations.Count | Should Be 0
         }
+
+        It "Should not find violation if there are no whitespaces around DotDot operator" {
+            $def = @'
+1..5
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+        }
     }
 
     Context "When a comma is not followed by a space" {

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -41,8 +41,7 @@ if ($true){}
             $def = @'
 if($true) {}
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
 
         It "Should not find violation if an open brace follows a foreach member invocation" {
@@ -83,8 +82,7 @@ function foo($param1) {
 
 }
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
 
         It "Should not find a violation in a param block" {
@@ -93,8 +91,7 @@ function foo() {
     param( )
 }
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
 
         It "Should not find a violation in a nested open paren" {
@@ -103,16 +100,14 @@ function foo($param) {
     ((Get-Process))
 }
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
 
         It "Should not find a violation on a method call" {
             $def = @'
 $x.foo("bar")
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
     }
 
@@ -162,16 +157,14 @@ $x = @"
 "abc"
 "@
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
 
         It "Should not find violation if there are whitespaces of size 1 around an assignment operator for here string" {
             $def = @'
 $x = 1
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
 
         It "Should not find violation if there are no whitespaces around DotDot operator" {
@@ -202,8 +195,7 @@ $x = @(1,2)
             $def = @'
 $x = @(1, 2)
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
     }
 
@@ -227,8 +219,7 @@ $x = @{a=1;b=2}
             $def = @'
 $x = @{a=1; b=2}
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
 
         It "Should not find a violation if a new-line follows a semi-colon" {
@@ -238,16 +229,14 @@ $x = @{
     b=2
 }
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
 
         It "Should not find a violation if a end of input follows a semi-colon" {
             $def = @'
 $x = "abc";
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
 
 

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -45,6 +45,20 @@ if($true) {}
             $violations.Count | Should Be 0
         }
 
+        It "Should not find violation if an open brace follows a foreach member invocation" {
+            $def = @'
+(1..5).foreach{$_}
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+        }
+
+        It "Should not find violation if an open brace follows a where member invocation" {
+            $def = @'
+(1..5).where{$_}
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+        }
+
     }
 
     Context "When a parenthesis follows a keyword" {


### PR DESCRIPTION
* Ignore open braces in invocation of magic method. For example, ignore the open brace in `(1..5).foreach{$_}`. 
* Ignore range operator. For example, do not flag the `..` in `1..5`. 

Resolves PowerShell/PowerShellEditorServices#380