### PR TITLE
Add a Range parameter to Invoke-Formatter cmdlet

### DIFF
--- a/Engine/Commands/InvokeFormatterCommand.cs
+++ b/Engine/Commands/InvokeFormatterCommand.cs
@@ -80,8 +80,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             }
 #endif
 
-            this.range = new Range(Range[0], Range[1], Range[2], Range[3]);
-
+            this.range = Range == null ? null : new Range(Range[0], Range[1], Range[2], Range[3]);
             try
             {
                 inputSettings = PSSASettings.Create(Settings, this.MyInvocation.PSScriptRoot, this);

--- a/Engine/Commands/InvokeFormatterCommand.cs
+++ b/Engine/Commands/InvokeFormatterCommand.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         [Parameter(Mandatory = false)]
         [ValidateNotNull]
         public object Range { get; set; }
+
 #if DEBUG
         /// <summary>
         /// Attaches to an instance of a .Net debugger
@@ -80,7 +81,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 
             try
             {
-                range = GetRange();
+                SetRange();
             }
             catch (Exception e)
             {
@@ -124,17 +125,19 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             this.WriteObject(formattedScriptDefinition);
         }
 
-        private Range GetRange()
+        private void SetRange()
         {
             if (Range == null)
             {
-                return null;
+                this.range = null;
+                return;
             }
 
             var range = Range as Range;
             if (range != null)
             {
-                return range;
+                this.range = range;
+                return;
             }
 
             var objArr = Range as object[];
@@ -167,7 +170,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 
             intArr = new int[objArr.Length];
             objArr.CopyTo(intArr, 0);
-            return new Range(intArr[0], intArr[1], intArr[2], intArr[3]);
+            this.range = new Range(intArr[0], intArr[1], intArr[2], intArr[3]);
         }
 
         private void ValidateInputSettings()

--- a/Engine/Commands/InvokeFormatterCommand.cs
+++ b/Engine/Commands/InvokeFormatterCommand.cs
@@ -45,7 +45,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         [ValidateNotNull]
         public object Settings { get; set; } = defaultSettingsPreset;
 
-        [Parameter(Mandatory = false)]
+        /// <summary>
+        /// The range within which formatting should take place.
+        ///
+        /// The parameter is an array of integers of length 4 such that the first, second, third and last
+        /// elements correspond to the start line number, start column number, end line number and
+        /// end column number. These numbers must be greater than 0.
+        /// </summary>
+        /// <returns></returns>
+        [Parameter(Mandatory = false, Position = 3)]
         [ValidateNotNull]
         [ValidateCount(4, 4)]
         public int[] Range { get; set; }

--- a/Engine/Commands/InvokeFormatterCommand.cs
+++ b/Engine/Commands/InvokeFormatterCommand.cs
@@ -145,7 +145,18 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 
             var objArr = Range as object[];
             int[] intArr;
-            if (objArr == null)
+            if (objArr != null)
+            {
+                if (!objArr.All(x => x is int))
+                {
+                    throw new ArgumentException(
+                        "Array should contain integer elements.",
+                        nameof(Range));
+                }
+                intArr = new int[objArr.Length];
+                objArr.CopyTo(intArr, 0);
+            }
+            else
             {
                 // todo check passing int[] casted parameter
                 intArr = Range as int[];
@@ -157,22 +168,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                 }
             }
 
-            if (objArr.Length != 4)
+            if (intArr.Length != 4)
             {
                 throw new ArgumentException(
                     "Array should be of length 4.",
                     nameof(Range));
             }
 
-            if (!objArr.All(x => x is int))
-            {
-                throw new ArgumentException(
-                    "Array should contain integer elements.",
-                    nameof(Range));
-            }
-
-            intArr = new int[objArr.Length];
-            objArr.CopyTo(intArr, 0);
             this.range = new Range(intArr[0], intArr[1], intArr[2], intArr[3]);
         }
 

--- a/Engine/Commands/InvokeFormatterCommand.cs
+++ b/Engine/Commands/InvokeFormatterCommand.cs
@@ -133,7 +133,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                 return;
             }
 
-            var range = Range as Range;
+            // When the range object is constructed with `[range]::new syntax`, `Range as Range` cast works.
+            // However, if the range object is constructed with `new-object "range"` syntax, then
+            // we need to use the ImmediatedBaseObject property to cast.
+            var range = (Range as Range ?? (Range as PSObject)?.ImmediateBaseObject as Range);
             if (range != null)
             {
                 this.range = range;

--- a/Engine/EditableText.cs
+++ b/Engine/EditableText.cs
@@ -106,14 +106,27 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
         // TODO Add a method that takes multiple edits, checks if they are unique and applies them.
 
+        /// <summary>
+        /// Checks if the range falls within the bounds of the text.
+        /// </summary>
+        /// <param name="range"></param>
+        /// <returns></returns>
         public bool IsValidRange(Range range)
         {
+            if (range == null)
+            {
+                throw new ArgumentNullException(nameof(range));
+            }
+
             return range.Start.Line <= Lines.Length
                 && range.End.Line <= Lines.Length
                 && range.Start.Column <= Lines[range.Start.Line - 1].Length
                 && range.End.Column <= Lines[range.End.Line - 1].Length + 1;
         }
 
+        /// <summary>
+        /// Returns the text representation of the object.
+        /// </summary>
         public override string ToString()
         {
             return Text;

--- a/Engine/EditableText.cs
+++ b/Engine/EditableText.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
         private void ValidateTextEditExtent(TextEdit textEdit)
         {
-            if (IsValidRange(textEdit))
+            if (!IsValidRange(textEdit))
             {
                 throw new ArgumentException(String.Format(
                     CultureInfo.CurrentCulture,

--- a/Engine/EditableText.cs
+++ b/Engine/EditableText.cs
@@ -106,6 +106,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
         // TODO Add a method that takes multiple edits, checks if they are unique and applies them.
 
+        public bool IsValidRange(Range range)
+        {
+            return range.Start.Line <= Lines.Length
+                && range.End.Line <= Lines.Length
+                && range.Start.Column <= Lines[range.Start.Line - 1].Length
+                && range.End.Column <= Lines[range.End.Line - 1].Length + 1;
+        }
+
         public override string ToString()
         {
             return Text;
@@ -123,10 +131,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
         private void ValidateTextEditExtent(TextEdit textEdit)
         {
-            if (textEdit.StartLineNumber > Lines.Length
-                || textEdit.EndLineNumber > Lines.Length
-                || textEdit.StartColumnNumber > Lines[textEdit.StartLineNumber - 1].Length
-                || textEdit.EndColumnNumber > Lines[textEdit.EndLineNumber - 1].Length + 1)
+            if (IsValidRange(textEdit))
             {
                 throw new ArgumentException(String.Format(
                     CultureInfo.CurrentCulture,

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1559,6 +1559,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             // todo validate range
             var isRangeNull = range == null;
+            if (!isRangeNull && !text.IsValidRange(range))
+            {
+                this.outputWriter.ThrowTerminatingError(new ErrorRecord(
+                    new ArgumentException("Invalid Range", nameof(range)),
+                    "FIX_ERROR",
+                    ErrorCategory.InvalidArgument,
+                    range));
+            }
+
             range = isRangeNull ? null : SnapToEdges(text, range);
             var previousLineCount = text.Lines.Length;
             var previousUnusedCorrections = 0;

--- a/Tests/Engine/InvokeFormatter.tests.ps1
+++ b/Tests/Engine/InvokeFormatter.tests.ps1
@@ -50,25 +50,6 @@ function foo {
 
             Invoke-Formatter -ScriptDefinition $def -Range @(3, 1, 4, 1) | Should Be $expected
         }
-
-        It "Should format only within the range when a range object is given" {
-            $def = @"
-function foo {
-"xyz"
-"abc"
-}
-"@
-
-            $expected = @"
-function foo {
-"xyz"
-    "abc"
-}
-"@
-
-            $range = New-Object -TypeName "Microsoft.Windows.PowerShell.ScriptAnalyzer.Range" -ArgumentList 3, 1, 4, 1
-            Invoke-Formatter -ScriptDefinition $def -Range $range | Should Be $expected
-        }
     }
 
     Context "When no settings are given" {

--- a/Tests/Engine/InvokeFormatter.tests.ps1
+++ b/Tests/Engine/InvokeFormatter.tests.ps1
@@ -31,6 +31,46 @@ function foo {
             Invoke-Formatter $def $settings | Should Be $expected
         }
     }
+
+    Context "When a range is given" {
+        It "Should format only within the range when a range list is given" {
+            $def = @"
+function foo {
+"xyz"
+"abc"
+}
+"@
+
+            $expected = @"
+function foo {
+"xyz"
+    "abc"
+}
+"@
+
+            Invoke-Formatter -ScriptDefinition $def -Range @(3, 1, 4, 1) | Should Be $expected
+        }
+
+        It "Should format only within the range when a range object is given" {
+            $def = @"
+function foo {
+"xyz"
+"abc"
+}
+"@
+
+            $expected = @"
+function foo {
+"xyz"
+    "abc"
+}
+"@
+
+            $range = New-Object -TypeName "Microsoft.Windows.PowerShell.ScriptAnalyzer.Range" -ArgumentList 3, 1, 4, 1
+            Invoke-Formatter -ScriptDefinition $def -Range $range | Should Be $expected
+        }
+    }
+
     Context "When no settings are given" {
         It "Should format using default settings" {
             $def = @'

--- a/docs/markdown/Invoke-Formatter.md
+++ b/docs/markdown/Invoke-Formatter.md
@@ -102,7 +102,7 @@ Accept wildcard characters: False
 The range within which formatting should take place. The parameter is an array of integers of length 4 such that the first, second, third and last elements correspond to the start line number, start column number, end line number and end column number. These numbers must be greater than 0.
 
 ```yaml
-Type: int[]
+Type: Int32[]
 Parameter Sets: (All)
 
 Required: False

--- a/docs/markdown/Invoke-Formatter.md
+++ b/docs/markdown/Invoke-Formatter.md
@@ -10,7 +10,7 @@ Formats a script text based on the input settings or default settings.
 ## SYNTAX
 
 ```
-Invoke-Formatter [-ScriptDefinition] <String> [-Settings <object>]
+Invoke-Formatter [-ScriptDefinition] <String> [-Settings <object>] [-Range <int[]>]
 ```
 
 ## DESCRIPTION
@@ -94,6 +94,20 @@ Parameter Sets: (All)
 Required: False
 Position: 2
 Default value: CodeFormatting
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Range
+The range within which formatting should take place. The parameter is an array of integers of length 4 such that the first, second, third and last elements correspond to the start line number, start column number, end line number and end column number. These numbers must be greater than 0.
+
+```yaml
+Type: int[]
+Parameter Sets: (All)
+
+Required: False
+Position: 3
+Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
The primary purpose of adding this parameter is to enable range formatting from vscode powershell extension.