### PR TITLE
Fix PlaceCloseBrace rule behavior for NewLineAfter switch

### DIFF
--- a/Rules/PlaceCloseBrace.cs
+++ b/Rules/PlaceCloseBrace.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         ///
         /// Default value is false.
         /// </summary>
-        [ConfigurableRuleProperty(defaultValue:false)]
+        [ConfigurableRuleProperty(defaultValue: false)]
         public bool NoEmptyLineBefore { get; protected set; }
 
         /// <summary>
@@ -82,11 +82,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             var tokens = Helper.Instance.Tokens;
             var diagnosticRecords = new List<DiagnosticRecord>();
-            var curlyStack = new Stack<Tuple<Token, int>> ();
+            var curlyStack = new Stack<Tuple<Token, int>>();
 
             // TODO move part common with PlaceOpenBrace to one place
             var tokenOps = new TokenOperations(tokens, ast);
-            tokensToIgnore = new HashSet<Token> (tokenOps.GetCloseBracesInCommandElements());
+            tokensToIgnore = new HashSet<Token>(tokenOps.GetCloseBracesInCommandElements());
 
             // Ignore close braces that are part of a one line if-else statement
             // E.g. $x = if ($true) { "blah" } else { "blah blah" }
@@ -323,7 +323,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 if ((tokens[expectedNewLinePos].Kind == TokenKind.Else
                     || tokens[expectedNewLinePos].Kind == TokenKind.ElseIf)
                     && !tokensToIgnore.Contains(closeBraceToken))
-                    {
+                {
                     return new DiagnosticRecord(
                         GetError(Strings.PlaceCloseBraceErrorShouldFollowNewLine),
                         closeBraceToken.Extent,

--- a/Rules/PlaceCloseBrace.cs
+++ b/Rules/PlaceCloseBrace.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             var token2 = tokens[closeBracePos + 2];
             var branchTokenPos = IsBranchingStatementToken(token1) && !ApartByWhitespace(closeBraceToken, token1) ?
                              closeBracePos + 1 :
-                             token1.Kind == TokenKind.NewLine || IsBranchingStatementToken(token2) ?
+                             token1.Kind == TokenKind.NewLine && IsBranchingStatementToken(token2) ?
                                 closeBracePos + 2 :
                                 -1;
 
@@ -377,7 +377,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             var e1 = token1.Extent;
             var e2 = token2.Extent;
             return e1.StartLineNumber == e2.StartLineNumber &&
-                e1.EndColumnNumber - e2.StartColumnNumber == 1;
+                e2.StartColumnNumber - e1.EndColumnNumber == 1;
         }
 
         private List<CorrectionExtent> GetCorrectionsForUncuddledBranches(

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -906,6 +906,9 @@
   <data name="PlaceCloseBraceErrorShouldFollowNewLine" xml:space="preserve">
     <value>Close brace does not follow a new line.</value>
   </data>
+  <data name="PlaceCloseBraceErrorShouldCuddleBranchStatement" xml:space="preserve">
+    <value>Close brace follows a new line.</value>
+  </data>
   <data name="UseConsistentIndentationName" xml:space="preserve">
     <value>UseConsistentIndentation</value>
   </data>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -907,7 +907,7 @@
     <value>Close brace does not follow a new line.</value>
   </data>
   <data name="PlaceCloseBraceErrorShouldCuddleBranchStatement" xml:space="preserve">
-    <value>Close brace follows a new line.</value>
+    <value>Close brace before a branch statement is followed by a new line.</value>
   </data>
   <data name="UseConsistentIndentationName" xml:space="preserve">
     <value>UseConsistentIndentation</value>

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -5,15 +5,15 @@ Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 $ruleConfiguration = @{
-    Enable = $true
-    NoEmptyLineBefore = $true
+    Enable             = $true
+    NoEmptyLineBefore  = $true
     IgnoreOneLineBlock = $true
-    NewLineAfter = $true
+    NewLineAfter       = $true
 }
 
 $settings = @{
     IncludeRules = @("PSPlaceCloseBrace")
-    Rules = @{
+    Rules        = @{
         PSPlaceCloseBrace = $ruleConfiguration
     }
 }
@@ -148,11 +148,11 @@ if (Test-Path "blah") {
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $violations.Count | Should Be 1
             $params = @{
-                RawContent = $def
+                RawContent       = $def
                 DiagnosticRecord = $violations[0]
                 CorrectionsCount = 1
-                ViolationText = '}'
-                CorrectionText = '}' + [System.Environment]::NewLine
+                ViolationText    = '}'
+                CorrectionText   = '}' + [System.Environment]::NewLine
             }
             Test-CorrectionExtentFromContent @params
         }
@@ -168,11 +168,11 @@ if (Test-Path "blah") {
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $violations.Count | Should Be 1
             $params = @{
-                RawContent = $def
+                RawContent       = $def
                 DiagnosticRecord = $violations[0]
                 CorrectionsCount = 1
-                ViolationText = '}'
-                CorrectionText = '}' + [System.Environment]::NewLine
+                ViolationText    = '}'
+                CorrectionText   = '}' + [System.Environment]::NewLine
             }
             Test-CorrectionExtentFromContent @params
         }

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -200,7 +200,7 @@ Some-Command -Param1 @{
         }
     }
 
-    Context "When a close brace should be followed by a new line" {
+    Context "When a close brace should not be followed by a new line" {
         BeforeAll {
             $ruleConfiguration.'NoEmptyLineBefore' = $false
             $ruleConfiguration.'IgnoreOneLineBlock' = $false
@@ -220,21 +220,6 @@ else {
             $violations.Count | Should Be 1
         }
 
-        It "Should not find a violation if a branching statement is on a new line if open brance is not on same line" {
-            $def = @'
-if ($true)
-{
-    $true
-}
-else
-{
-    $false
-}
-'@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
-        }
-
         It "Should correct violation by cuddling the else branch statement" {
             $def = @'
 if ($true) {
@@ -249,6 +234,92 @@ if ($true) {
     $true
 } else {
     $false
+}
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+        }
+
+        It "Should correct violation if the close brace and following keyword are apart by less than a space" {
+$def = @'
+if ($true) {
+    $true
+}else {
+    $false
+}
+'@
+             $expected = @'
+if ($true) {
+    $true
+} else {
+    $false
+}
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+        }
+
+        It "Should correct violation if the close brace and following keyword are apart by more than a space" {
+$def = @'
+if ($true) {
+    $true
+}     else {
+    $false
+}
+'@
+             $expected = @'
+if ($true) {
+    $true
+} else {
+    $false
+}
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+        }
+
+        It "Should correct violations in an if-else-elseif block" {
+            $def = @'
+$x = 1
+if ($x -eq 1) {
+    "1"
+}
+elseif ($x -eq 2) {
+    "2"
+}
+else {
+    "3"
+}
+'@
+             $expected = @'
+$x = 1
+if ($x -eq 1) {
+    "1"
+} elseif ($x -eq 2) {
+    "2"
+} else {
+    "3"
+}
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+        }
+
+        It "Should correct violations in a try-catch-finally block" {
+            $def = @'
+try {
+    "try"
+}
+catch {
+    "catch"
+}
+finally {
+    "finally"
+}
+'@
+            $expected = @'
+try {
+    "try"
+} catch {
+    "catch"
+} finally {
+    "finally"
 }
 '@
             Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -199,4 +199,59 @@ Some-Command -Param1 @{
             $violations.Count | Should Be 0
         }
     }
+
+    Context "When a close brace should be followed by a new line" {
+        BeforeAll {
+            $ruleConfiguration.'NoEmptyLineBefore' = $false
+            $ruleConfiguration.'IgnoreOneLineBlock' = $false
+            $ruleConfiguration.'NewLineAfter' = $false
+        }
+
+        It "Should find a violation if a branching statement is on a new line if open brance is on same line" {
+            $def = @'
+if ($true) {
+    $true
+}
+else {
+    $false
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should Be 1
+        }
+
+        It "Should not find a violation if a branching statement is on a new line if open brance is not on same line" {
+            $def = @'
+if ($true)
+{
+    $true
+}
+else
+{
+    $false
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should Be 0
+        }
+
+        It "Should correct violation by cuddling the else branch statement" {
+            $def = @'
+if ($true) {
+    $true
+}
+else {
+    $false
+}
+'@
+             $expected = @'
+if ($true) {
+    $true
+} else {
+    $false
+}
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+        }
+    }
 }

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -324,5 +324,19 @@ try {
 '@
             Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
         }
+
+        It "Should not find violations when a script has two close braces in succession" {
+            $def = @'
+function foo {
+if ($true) {
+"true"
+} else {
+"false"
+}
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should Be 0
+        }
     }
 }

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -130,7 +130,7 @@ $x = if ($true) { "blah" } else { "blah blah" }
         }
     }
 
-    Context "When a close brace should be follow a new line" {
+    Context "When a close brace should be followed by a new line" {
         BeforeAll {
             $ruleConfiguration.'NoEmptyLineBefore' = $false
             $ruleConfiguration.'IgnoreOneLineBlock' = $false


### PR DESCRIPTION
Prior to the fix, whenever the user sets `NewLineAfter = $false`, the rule would ignore instances where a new line would follow a close brace. With this PR, whenveer `NewLineAfter = $false`, the rule enforces no new line after close braces that are followed branching statements. This would provide the ability to _cuddle_ the following statements:
- else
- elseif
- catch
- finally.

