### PR TITLE
Update PlaceCloseBrace rule behavior for NewLineAfter switch

### DIFF
--- a/Rules/PlaceCloseBrace.cs
+++ b/Rules/PlaceCloseBrace.cs
@@ -320,9 +320,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             if (tokens.Length > 1 && tokens.Length > expectedNewLinePos)
             {
                 var closeBraceToken = tokens[closeBracePos];
-                if ((tokens[expectedNewLinePos].Kind == TokenKind.Else
-                    || tokens[expectedNewLinePos].Kind == TokenKind.ElseIf)
-                    && !tokensToIgnore.Contains(closeBraceToken))
+                if (!tokensToIgnore.Contains(closeBraceToken) && IsBranchingStatementToken(tokens[expectedNewLinePos]))
                 {
                     return new DiagnosticRecord(
                         GetError(Strings.PlaceCloseBraceErrorShouldFollowNewLine),

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -177,6 +177,27 @@ if (Test-Path "blah") {
             Test-CorrectionExtentFromContent @params
         }
 
+        It "Should find a violation for a close brace followed by a catch statement" {
+             $def = @'
+try {
+    "try"
+} catch {
+    "catch"
+}
+
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should Be 1
+            $params = @{
+                RawContent       = $def
+                DiagnosticRecord = $violations[0]
+                CorrectionsCount = 1
+                ViolationText    = '}'
+                CorrectionText   = '}' + [System.Environment]::NewLine
+            }
+            Test-CorrectionExtentFromContent @params
+
+        }
         It "Should not find a violation for a close brace followed by a comma in an array expression" {
             $def = @'
 Some-Command -Param1 @{


### PR DESCRIPTION
Whenever the switch is set to false, we check if the following keyword is one of the branching statements (else, elseif, catch, finally) and if so then raise a violation. This makes the switch behavior exactly opposite to that of when it set to true.