### PR TITLE
Add tabbed indentation capability to UseConsistentIndentation rule

### DIFF
--- a/Engine/Settings/CodeFormatting.psd1
+++ b/Engine/Settings/CodeFormatting.psd1
@@ -24,6 +24,7 @@
 
         PSUseConsistentIndentation = @{
             Enable          = $true
+            Kind            = 'space'
             IndentationSize = 4
         }
 

--- a/Engine/Settings/CodeFormattingAllman.psd1
+++ b/Engine/Settings/CodeFormattingAllman.psd1
@@ -24,6 +24,7 @@
 
         PSUseConsistentIndentation = @{
             Enable          = $true
+            Kind            = 'space'
             IndentationSize = 4
         }
 

--- a/Engine/Settings/CodeFormattingOTBS.psd1
+++ b/Engine/Settings/CodeFormattingOTBS.psd1
@@ -24,6 +24,7 @@
 
         PSUseConsistentIndentation = @{
             Enable          = $true
+            Kind            = 'space'
             IndentationSize = 4
         }
 

--- a/Engine/Settings/CodeFormattingStroustrup.psd1
+++ b/Engine/Settings/CodeFormattingStroustrup.psd1
@@ -25,6 +25,7 @@
 
         PSUseConsistentIndentation = @{
             Enable          = $true
+            Kind            = 'space'
             IndentationSize = 4
         }
 

--- a/RuleDocumentation/UseConsistentIndentation.md
+++ b/RuleDocumentation/UseConsistentIndentation.md
@@ -28,3 +28,10 @@ Enable or disable the rule during ScriptAnalyzer invocation.
 #### IndentationSize: bool (Default value is `4`)
 
 Indentation size in the number of space characters.
+
+#### Kind: string (Default value is `space`)
+
+Represents the kind of indentation to be used. Possible values are: `space`, `tab`. If any invalid value is given, the property defaults to `space`.
+
+`space` means `IndentationSize` number of `space` characters are used to provide one level of indentation.
+`tab` means a tab character, `\t`.

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -265,12 +265,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         private int GetIndentation(int indentationLevel)
         {
-            return indentationLevel * this.IndentationSize;
+            // todo if condition can be evaluated during rule configuration
+            return indentationLevel * (InsertSpaces ? this.IndentationSize : 1);
         }
 
         private char GetIndentationChar()
         {
-            return indentationKind == IndentationKind.Space ? ' ' : '\t';
+            // todo can be evaluated during rule configuration
+            return InsertSpaces ? ' ' : '\t';
         }
 
         private string GetIndentationString(int indentationLevel)

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -36,6 +36,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         [ConfigurableRuleProperty(defaultValue: 4)]
         public int IndentationSize { get; protected set; }
 
+        [ConfigurableRuleProperty(defaultValue: true)]
+        public bool InsertSpaces { get; protected set; }
+
         private enum IndentationKind { Space, Tab };
 
         // TODO make this configurable

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -129,8 +129,8 @@ function foo {
 get-process |
 where-object {$_.Name -match 'powershell'}
 '@
-          $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-          $violations.Count | Should Be 1
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should Be 1
         }
 
         It "Should not find a violation if a pipleline element is indented correctly" {
@@ -138,8 +138,8 @@ where-object {$_.Name -match 'powershell'}
 get-process |
     where-object {$_.Name -match 'powershell'}
 '@
-          $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-          $violations.Count | Should Be 0
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should Be 0
         }
 
         It "Should ignore comment in the pipleline" {
@@ -149,8 +149,8 @@ get-process |
 select Name,Id |
        format-list
 '@
-          $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-          $violations.Count | Should Be 3
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should Be 3
         }
 
         It "Should indent properly after line continuation (backtick) character" {

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -8,8 +8,8 @@ $indentationUnit = ' '
 $indentationSize = 4
 $ruleConfiguration = @{
     Enable          = $true
-    InsertSpaces    = $true
     IndentationSize = 4
+    Kind            = 'space'
 }
 
 $settings = @{
@@ -173,7 +173,7 @@ $x = "this " + `
 
     Context "When tabs instead of spaces are used for indentation" {
         BeforeAll {
-            $ruleConfiguration.'InsertSpaces' = $false
+            $ruleConfiguration.'Kind' = 'tab'
         }
 
         It "Should indent using tabs" {


### PR DESCRIPTION
Adds a `Kind` switch to the `PSUseConsistentIndentationRule` rule which for now takes either `space` or `tab` as input. If `space` input is provided the rule will set 1 unit of indentation as `IndentationSize` number of spaces otherwise `\t`.