### PR TITLE
Improve rule documentation of AvoidUsingWriteHost

### DIFF
--- a/RuleDocumentation/AvoidUsingWriteHost.md
+++ b/RuleDocumentation/AvoidUsingWriteHost.md
@@ -11,29 +11,32 @@ Commands with the `Show` verb do not have this check applied.
 
 ## How
 
-Replace `Write-Host` with `Write-Output` or `Write-Verbose`.
+Replace `Write-Host` with `Write-Output` or `Write-Verbose` depending on whether the intention is logging or returning one or multiple objects.
 
 ## Example
 
 ### Wrong
 
 ``` PowerShell
-function Test
+function Get-MeaningOfLife
 {
 	...
-	Write-Host "Executing.."
+	Write-Host "Computing the answer to the ultimate question of life, the universe and everything"
 	...
+	Write-Host 42
 }
 ```
 
 ### Correct
 
 ``` PowerShell
-function Test
+function Get-MeaningOfLife
 {
+	[CmdletBinding()]Param() # to make it possible to set the VerbosePreference when calling the function
 	...
-	Write-Output "Executing.."
+	Write-Verbose "Computing the answer to the ultimate question of life, the universe and everything"
 	...
+	Write-Output 42
 }
 
 function Show-Something


### PR DESCRIPTION
Currently the rule documentation about AvoidUsingWriteHost correctly suggests the 2 alternative functions to be used (```Write-Host``` and ```Write-Verbose```) but does not offer guidance which of the 2 one should pick.
Therefore I propose the added guidance and a better example to show the difference. The guidance is based on the blog post [here](http://www.jsnover.com/blog/2013/12/07/write-host-considered-harmful/) from Jeffrey Snover about the issues with ```Write-Host```
To make the example more useful and add a bit of humour, it uses a well known reference to the movie ```The Hitchhiker's Guide to the Galaxy``` but if you feel that this is not appropriate, then I can of course replace it with something else.