### PR TITLE
Fix formatter crash

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceRoot}/bin/Debug/<target-framework>/<project-name.dll>",
+            "args": [],
+            "cwd": "${workspaceRoot}",
+            "externalConsole": false,
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        },
+        {
+            "name": ".NET Full Attach",
+            "type": "clr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ]
+}

--- a/Engine/EditableText.cs
+++ b/Engine/EditableText.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             return range.Start.Line <= Lines.Count
                 && range.End.Line <= Lines.Count
-                && range.Start.Column <= Lines[range.Start.Line - 1].Length
+                && range.Start.Column <= Lines[range.Start.Line - 1].Length + 1
                 && range.End.Column <= Lines[range.End.Line - 1].Length + 1;
         }
 

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -315,7 +315,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
 
                 var hasWhitespaceBefore = IsPreviousTokenOnSameLineAndApartByWhitespace(tokenNode);
-                var hasWhitespaceAfter = IsPreviousTokenOnSameLineAndApartByWhitespace(tokenNode.Next);
+                var hasWhitespaceAfter = tokenNode.Next.Value.Kind == TokenKind.NewLine
+                            || IsPreviousTokenOnSameLineAndApartByWhitespace(tokenNode.Next);
 
                 if (!hasWhitespaceAfter || !hasWhitespaceBefore)
                 {

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -173,6 +173,15 @@ $x = 1
 '@
             Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
         }
+
+        It "Should not find violation if a binary operator is followed by new line" {
+            $def = @'
+$x = $true -and
+            $false
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+        }
+
     }
 
     Context "When a comma is not followed by a space" {


### PR DESCRIPTION
The formatter used to crash because textedit extents were not compared correctly. 

Also fixes a bug in `UseConsistentWhitespace` rule where it would try to find a violation on a binary operator if it is at the end of a line. 