### PR TITLE
Fix PSUseDeclaredVarsMoreThanAssignments when variable is assigned more than once to still give a warning

### DIFF
--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -166,7 +166,17 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         // Checks if this variableAst is part of the logged assignment
                         foreach (VariableExpressionAst varInAssignment in varsInAssignment)
                         {
-                            inAssignment |= varInAssignment.Equals(varAst);
+                            // Try casting to AssignmentStatementAst to be able to catch case where a variable is assigned more than once (https://github.com/PowerShell/PSScriptAnalyzer/issues/833)
+                            var varInAssignmentAsStatementAst = varInAssignment.Parent as AssignmentStatementAst;
+                            var varAstAsAssignmentStatementAst = varAst.Parent as AssignmentStatementAst;
+                            if (varInAssignmentAsStatementAst != null && varAstAsAssignmentStatementAst != null)
+                            {
+                                inAssignment = varInAssignmentAsStatementAst.Left.Extent.Text.Equals(varAstAsAssignmentStatementAst.Left.Extent.Text, StringComparison.OrdinalIgnoreCase);
+                            }
+                            else
+                            {
+                                inAssignment = varInAssignment.Equals(varAst);
+                            }
                         }
 
                         if (!inAssignment)

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -49,6 +49,18 @@ function MyFunc2() {
             Get-Count | `
             Should Be 0
         }
+
+        It "flags a variable that is defined twice but never used" {
+            Invoke-ScriptAnalyzer -ScriptDefinition '$myvar=1;$myvar=2' -IncludeRule $violationName | `
+            Get-Count | `
+            Should Be 1
+        }
+
+        It "does not flag a variable that is defined twice but gets assigned to another variable and flags the other variable instead" {
+            $results = Invoke-ScriptAnalyzer -ScriptDefinition '$myvar=1;$myvar=2;$mySecondvar=$myvar' -IncludeRule $violationName
+            $results | Get-Count | Should Be 1
+            $results[0].Extent | Should Be '$mySecondvar'
+        }
     }
 
     Context "When there are no violations" {


### PR DESCRIPTION
To resolve Issue #833 
Consider the case `$a=1;$a=2`. Then the `inAssignment` will be false for the 2nd ast because `varsInAssignment` already contains unly assignments to unique variables. Therefore no warning was produced. This PR makes it output a warning correctly by trying to cast it to an `AssignmentStatementAst` an then checks the text to see if it is actually the same variable.