### PR TITLE
Fix FixPSUseDeclaredVarsMoreThanAssignments to also detect variables that are strongly typed

### DIFF
--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -135,6 +135,17 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // Only checks for the case where lhs is a variable. Ignore things like $foo.property
                 VariableExpressionAst assignmentVarAst = assignmentAst.Left as VariableExpressionAst;
 
+                if (assignmentVarAst == null)
+                {
+                    // If the variable is declared in a strongly typed way, e.g. [string]$s = 'foo' then the type is ConvertExpressionAst.
+                    // Therefore we need to the VariableExpressionAst from its Child property.
+                    var assignmentVarAstAsConvertExpressionAst = assignmentAst.Left as ConvertExpressionAst;
+                    if (assignmentVarAstAsConvertExpressionAst != null && assignmentVarAstAsConvertExpressionAst.Child != null)
+                    {
+                        assignmentVarAst = assignmentVarAstAsConvertExpressionAst.Child as VariableExpressionAst;
+                    }
+                }
+
                 if (assignmentVarAst != null)
                 {
                     // Ignore if variable is global or environment variable or scope is function

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -38,6 +38,12 @@ function MyFunc2() {
             Should Be 1
         }
 
+        It "flags strongly typed variables" {
+            Invoke-ScriptAnalyzer -ScriptDefinition '[string]$s=''mystring''' -IncludeRule $violationName  | `
+            Get-Count | `
+            Should Be 1
+        }
+
         It "does not flag `$InformationPreference variable" {
             Invoke-ScriptAnalyzer -ScriptDefinition '$InformationPreference=Stop' -IncludeRule $violationName  | `
             Get-Count | `


### PR DESCRIPTION
Fix issue #832
The problem was this line:
````csharp
// Only checks for the case where lhs is a variable. Ignore things like $foo.property
VariableExpressionAst assignmentVarAst = assignmentAst.Left as VariableExpressionAst;
````
`[string]$someVariable` is a `ConvertExpressionAst` in this case and therefore I needed to do some work to get the VariableExpressionAst out of it in this case