### PR TITLE
Fix NullReferenceException in AlignAssignmentStatement rule when CheckHashtable is enabled

### DIFF
--- a/Rules/AlignAssignmentStatement.cs
+++ b/Rules/AlignAssignmentStatement.cs
@@ -300,8 +300,20 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             foreach (var kvp in hashtableAst.KeyValuePairs)
             {
                 var keyStartOffset = kvp.Item1.Extent.StartOffset;
+                bool keyStartOffSetReached = false;
                 var keyTokenNode = tokenOps.GetTokenNodes(
-                    token => token.Kind == TokenKind.Equals).FirstOrDefault();
+                    token =>
+                    {
+                        if (keyStartOffSetReached)
+                        {
+                            return token.Kind == TokenKind.Equals;
+                        }
+                        if (token.Extent.StartOffset == keyStartOffset)
+                        {
+                            keyStartOffSetReached = true;
+                        }
+                        return false;
+                        }).FirstOrDefault();
                 if (keyTokenNode == null || keyTokenNode.Value == null)
                 {
                     continue;

--- a/Rules/AlignAssignmentStatement.cs
+++ b/Rules/AlignAssignmentStatement.cs
@@ -301,17 +301,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 var keyStartOffset = kvp.Item1.Extent.StartOffset;
                 var keyTokenNode = tokenOps.GetTokenNodes(
-                    token => token.Extent.StartOffset == keyStartOffset).FirstOrDefault();
-                if (keyTokenNode == null
-                    || keyTokenNode.Next == null
-                    || keyTokenNode.Next.Value.Kind != TokenKind.Equals)
+                    token => token.Kind == TokenKind.Equals).FirstOrDefault();
+                if (keyTokenNode == null || keyTokenNode.Value == null)
                 {
-                    return null;
+                    continue;
                 }
+                var assignmentToken = keyTokenNode.Value.Extent;
 
                 nodeTuples.Add(new Tuple<IScriptExtent, IScriptExtent>(
-                    kvp.Item1.Extent,
-                    keyTokenNode.Next.Value.Extent));
+                    kvp.Item1.Extent, assignmentToken));
             }
 
             return nodeTuples;

--- a/Tests/Engine/SettingsTest/Issue828/Issue828.tests.ps1
+++ b/Tests/Engine/SettingsTest/Issue828/Issue828.tests.ps1
@@ -1,0 +1,27 @@
+Describe "Issue 828: No NullReferenceExceptionin AlignAssignmentStatement rule when CheckHashtable is enabled" {
+    It "Should not throw" {
+        # For details, see here: https://github.com/PowerShell/PSScriptAnalyzer/issues/828
+        # The issue states basically that calling 'Invoke-ScriptAnalyzer .' with a certain settings file being in the same location that has CheckHashtable enabled
+        # combined with a script contatining the command '$MyObj | % { @{$_.Name = $_.Value} }' could make it throw a NullReferencException.
+        $cmdletThrewError = $false
+        $initialErrorActionPreference = $ErrorActionPreference
+        $initialLocation = Get-Location
+        try
+        {
+            Set-Location $PSScriptRoot
+            $ErrorActionPreference = 'Stop'
+            Invoke-ScriptAnalyzer .
+        }
+        catch
+        {
+            $cmdletThrewError = $true
+        }
+        finally
+        {
+            $ErrorActionPreference = $initialErrorActionPreference
+            Set-Location $initialLocation
+        }
+        
+        $cmdletThrewError | Should Be $false
+    }
+}

--- a/Tests/Engine/SettingsTest/Issue828/PSScriptAnalyzerSettings.psd1
+++ b/Tests/Engine/SettingsTest/Issue828/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,63 @@
+@{
+    Severity     = @(
+        'Error', 
+        'Warning', 
+        'Information'
+    )
+    ExcludeRules = @(
+        'PSUseOutputTypeCorrectly',
+        'PSUseShouldProcessForStateChangingFunctions'
+    )
+    Rules        = @{
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+        PSAvoidUsingCmdletAliases  = @{
+            # only whitelist verbs from *-Object cmdlets
+            Whitelist = @(
+                '%',
+                '?',
+                'compare',
+                'foreach',
+                'group',
+                'measure',
+                'select',
+                'sort',
+                'tee',
+                'where'
+            )
+        }
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NoEmptyLineBefore  = $false
+            IgnoreOneLineBlock = $true
+            NewLineAfter       = $false
+        }
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+        PSProvideCommentHelp       = @{
+            Enable                  = $true
+            ExportedOnly            = $true
+            BlockComment            = $true
+            VSCodeSnippetCorrection = $true
+            Placement               = "before"
+        }
+        PSUseConsistentIndentation = @{
+            Enable          = $true
+            IndentationSize = 4
+            Kind            = "space"
+        }
+        PSUseConsistentWhitespace  = @{
+            Enable         = $true
+            CheckOpenBrace = $true
+            CheckOpenParen = $true
+            CheckOperator  = $false
+            CheckSeparator = $true
+        }
+    }
+}

--- a/Tests/Engine/SettingsTest/Issue828/script.ps1
+++ b/Tests/Engine/SettingsTest/Issue828/script.ps1
@@ -1,0 +1,2 @@
+# This script has to be like that in order to reproduce the issue
+$MyObj | % { @{$_.Name = $_.Value} }


### PR DESCRIPTION
Fix #828
`$MyObj | % { @{$_.Name = $_.Value} }'` produces a NullReferencException when the `PSAlignAssignmentStatement` setting `CheckHashtable` is turned on
The reason for it was because the previous implementation expected the key in a hashtable to not contain more than 1 token expression. A lazy fix would have been to use a `continue` statement in the `GetExtents` function instead of returning null. However, the existing algorithm was improved to deal with keys containing expressions consisting of more than 1 token. The fix consists basically in traversing further until the equal statement is reached.