### PR TITLE
Add -EnableExit switch to Invoke-ScriptAnalyzer for exit and return exit code for CI purposes

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -193,6 +193,17 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         private bool fix;
 
         /// <summary>
+        /// Sets the exit code to the number of warnings for usage in CI.
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter EnableExit
+        {
+            get { return enableExit; }
+            set { enableExit = value; }
+        }
+        private bool enableExit;
+
+        /// <summary>
         /// Returns path to the file that contains user profile or hash table for ScriptAnalyzer
         /// </summary>
         [Alias("Profile")]
@@ -417,6 +428,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                 {
                     logger.LogObject(diagnostic, this);
                 }
+            }
+
+            if (EnableExit.IsPresent)
+            {
+                this.Host.SetShouldExit(diagnosticRecords.Count());
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Usage
 ``` PowerShell
 Get-ScriptAnalyzerRule [-CustomizedRulePath <string[]>] [-Name <string[]>] [<CommonParameters>] [-Severity <string[]>]
 
-Invoke-ScriptAnalyzer [-Path] <string> [-CustomizedRulePath <string[]>] [-ExcludeRule <string[]>] [-IncludeRule <string[]>] [-Severity <string[]>] [-Recurse] [<CommonParameters>]
+Invoke-ScriptAnalyzer [-Path] <string> [-CustomizedRulePath <string[]>] [-ExcludeRule <string[]>] [-IncludeRule <string[]>] [-Severity <string[]>] [-Recurse] [-EnableExit] [<CommonParameters>]
 ```
 
 [Back to ToC](#table-of-contents)

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -497,3 +497,10 @@ Describe "Test -Fix Switch" {
         $actualScriptContentAfterFix | Should Be $expectedScriptContentAfterFix
     }
 }
+
+Describe "Test -EnableExit Switch" {
+    It "Returns exit code equivalent to number of warnings" {
+        $process = Start-Process powershell -ArgumentList 'Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit' -PassThru
+        $process.ExitCode | Should Be 1
+    }
+}

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -500,7 +500,7 @@ Describe "Test -Fix Switch" {
 
 Describe "Test -EnableExit Switch" {
     It "Returns exit code equivalent to number of warnings" {
-        $process = Start-Process powershell -ArgumentList '-WindowStyle Hidden -Command Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit' -PassThru -Wait
-        $process.ExitCode | Should Be 1
+        powershell -Command 'Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit'
+        $LASTEXITCODE  | Should Be 1
     }
 }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -500,7 +500,7 @@ Describe "Test -Fix Switch" {
 
 Describe "Test -EnableExit Switch" {
     It "Returns exit code equivalent to number of warnings" {
-        $process = Start-Process powershell -ArgumentList 'Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit' -PassThru
+        $process = Start-Process powershell -ArgumentList '-WindowStyle Hidden -Command Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit' -PassThru -Wait
         $process.ExitCode | Should Be 1
     }
 }

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -53,7 +53,7 @@ function Invoke-ScriptAnalyzer {
         [Parameter(Mandatory = $false)]
         [switch] $Fix,
 		
-		[Parameter(Mandatory = $false)]
+        [Parameter(Mandatory = $false)]
         [switch] $EnableExit
 	)	
 
@@ -97,7 +97,7 @@ function Invoke-ScriptAnalyzer {
         $results = $scriptAnalyzer.AnalyzeScriptDefinition($ScriptDefinition);
     }
 	
-	if ($null -ne $results)
+	if ($EnableExit.IsPresent -and $null -ne $results)
 	{
 		exit $results.Count
 	}

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -81,26 +81,28 @@ function Invoke-ScriptAnalyzer {
 	);
 
     if ($PSCmdlet.ParameterSetName -eq "File")
-	{
-		$supportsShouldProcessFunc = [Func[string, string, bool]]{ return $PSCmdlet.Shouldprocess }
-		if ($Fix.IsPresent)
-		{
-			$results = $scriptAnalyzer.AnalyzeAndFixPath($Path, $supportsShouldProcessFunc, $Recurse.IsPresent);
-		}
-		else
-		{
-			$results = $scriptAnalyzer.AnalyzePath($Path, $supportsShouldProcessFunc, $Recurse.IsPresent);
-		}
+    {
+        $supportsShouldProcessFunc = [Func[string, string, bool]] { return $PSCmdlet.Shouldprocess }
+        if ($Fix.IsPresent)
+        {
+            $results = $scriptAnalyzer.AnalyzeAndFixPath($Path, $supportsShouldProcessFunc, $Recurse.IsPresent);
+        }
+        else
+        {
+            $results = $scriptAnalyzer.AnalyzePath($Path, $supportsShouldProcessFunc, $Recurse.IsPresent);
+        }
     }
     else
-	{
+    {
         $results = $scriptAnalyzer.AnalyzeScriptDefinition($ScriptDefinition);
-    }
-	
-	if ($EnableExit.IsPresent -and $null -ne $results)
-	{
-		exit $results.Count
 	}
+	
+	$results
+	
+    if ($EnableExit.IsPresent -and $null -ne $results)
+    {
+        exit $results.Count
+    }
 }
 
 # Define an implementation of the IOutputWriter interface

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -51,7 +51,10 @@ function Invoke-ScriptAnalyzer {
         [switch] $SuppressedOnly,
 
         [Parameter(Mandatory = $false)]
-        [switch] $Fix
+        [switch] $Fix,
+		
+		[Parameter(Mandatory = $false)]
+        [switch] $EnableExit
 	)	
 
     if ($null -eq $CustomRulePath)
@@ -77,17 +80,27 @@ function Invoke-ScriptAnalyzer {
 		$SuppressedOnly.IsPresent
 	);
 
-    if ($PSCmdlet.ParameterSetName -eq "File") {
+    if ($PSCmdlet.ParameterSetName -eq "File")
+	{
 		$supportsShouldProcessFunc = [Func[string, string, bool]]{ return $PSCmdlet.Shouldprocess }
 		if ($Fix.IsPresent)
 		{
-			return $scriptAnalyzer.AnalyzeAndFixPath($Path, $supportsShouldProcessFunc, $Recurse.IsPresent);
+			$results = $scriptAnalyzer.AnalyzeAndFixPath($Path, $supportsShouldProcessFunc, $Recurse.IsPresent);
 		}
-        return $scriptAnalyzer.AnalyzePath($Path, $supportsShouldProcessFunc, $Recurse.IsPresent);
+		else
+		{
+			$results = $scriptAnalyzer.AnalyzePath($Path, $supportsShouldProcessFunc, $Recurse.IsPresent);
+		}
     }
-    else {
-        return $scriptAnalyzer.AnalyzeScriptDefinition($ScriptDefinition);
+    else
+	{
+        $results = $scriptAnalyzer.AnalyzeScriptDefinition($ScriptDefinition);
     }
+	
+	if ($null -ne $results)
+	{
+		exit $results.Count
+	}
 }
 
 # Define an implementation of the IOutputWriter interface

--- a/docs/markdown/Invoke-ScriptAnalyzer.md
+++ b/docs/markdown/Invoke-ScriptAnalyzer.md
@@ -12,14 +12,14 @@ Evaluates a script or module based on selected best practice rules
 ### UNNAMED_PARAMETER_SET_1
 ```
 Invoke-ScriptAnalyzer [-Path] <String> [-CustomRulePath <String>] [-RecurseCustomRulePath]
- [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-Fix]
+ [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-Fix] [-EnableExit]
  [-Settings <String>]
 ```
 
 ### UNNAMED_PARAMETER_SET_2
 ```
 Invoke-ScriptAnalyzer [-ScriptDefinition] <String> [-CustomRulePath <String>] [-RecurseCustomRulePath]
- [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly]
+ [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-EnableExit]
  [-Settings <String>]
 ```
 
@@ -48,6 +48,7 @@ To get rules that were suppressed, run
 Invoke-ScriptAnalyzer with the SuppressedOnly parameter.
 For instructions on suppressing a rule, see the description of
 the SuppressedOnly parameter.
+For usage in CI systems, the -EnableExit exits the shell with an exit code equal to  the number of error records.
 
 The PSScriptAnalyzer module tests the Windows PowerShell code in a script, module, or DSC resource to determine
 whether, and to what extent, it fulfils best practice standards.
@@ -407,6 +408,20 @@ When you used Fix, Invoke-ScriptAnalyzer runs as usual but will apply the fixes 
 ```yaml
 Type: SwitchParameter
 Parameter Sets: UNNAMED_PARAMETER_SET_1
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+
+### -EnableExit
+Exits PowerShell and returns an exit code equal to the number of error records. This can be useful in CI systems.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
 Aliases:
 
 Required: False

--- a/docs/markdown/Invoke-ScriptAnalyzer.md
+++ b/docs/markdown/Invoke-ScriptAnalyzer.md
@@ -415,6 +415,7 @@ Position: Named
 Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
+```
 
 ### -EnableExit
 Exits PowerShell and returns an exit code equal to the number of error records. This can be useful in CI systems.


### PR DESCRIPTION
To close #840 
Behaviour is similar to the equivalent switch in `Invoke-Pester`, i.e. the shell exits with an exit code equal to the number of error records.