### PR TITLE
Upgrade from .Net Core SDK 1.1 to 2.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ Exit
 
 ### From Source
 
-#### Requirements
-* [.NET Core 1.1.5 SDK](https://github.com/dotnet/core/blob/master/release-notes/download-archives/1.1.5.md)
+* [.NET Core 2.1.4 SDK](https://github.com/dotnet/core/blob/master/release-notes/download-archives/2.0.5-download.md)
 * [PlatyPS 0.5.0 or greater](https://github.com/PowerShell/platyPS)
 * Optionally but recommended for development: [Visual Studio 2017](https://www.visualstudio.com/downloads/)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,9 @@ build_script:
         $PSVersionTable
         Push-Location C:\projects\psscriptanalyzer
         dotnet --version
+        # Test build using netstandard to test whether APIs are being called that are not available in .Net Core. Remove output afterwards.
+        .\buildCoreClr.ps1 -Framework netstandard1.6 -Configuration $env:BuildConfiguration -Build
+        git clean -dfx
         C:\projects\psscriptanalyzer\buildCoreClr.ps1 -Framework net451 -Configuration $env:BuildConfiguration -Build
         C:\projects\psscriptanalyzer\build.ps1 -BuildDocs
         Pop-Location

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ build_script:
         Push-Location C:\projects\psscriptanalyzer
         dotnet --version
         # Test build using netstandard to test whether APIs are being called that are not available in .Net Core. Remove output afterwards.
-        .\buildCoreClr.ps1 -Framework netstandard1.6 -Configuration $env:BuildConfiguration -Build
+        .\buildCoreClr.ps1 -Framework netstandard1.6 -Configuration Release -Build
         git clean -dfx
         C:\projects\psscriptanalyzer\buildCoreClr.ps1 -Framework net451 -Configuration $env:BuildConfiguration -Build
         C:\projects\psscriptanalyzer\build.ps1 -BuildDocs

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,10 +28,10 @@ install:
         }
     - ps: |
         # the legacy WMF4 image only has the old preview SDKs of dotnet
-        if (-not ((dotnet --version).StartsWith('1.1')))
+        if (-not ((dotnet --version).StartsWith('2.1.4')))
         {
             Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile dotnet-install.ps1
-            .\dotnet-install.ps1 -Channel 1.1
+            .\dotnet-install.ps1 -Version 2.1.4
         }
 
 build_script:

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
         "Rules"
     ],
     "sdk": {
-        "version": "1.1.5"
+        "version": "2.1.4"
     }
 }


### PR DESCRIPTION
Closes #851 
This is a cleaner version of PR #853 containing the latest PR with the upgrade to the RTM version of .Net Core.