### PR TITLE
Use the typewriter apostrophe instead the typographic apostrophe

### DIFF
--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -2366,7 +2366,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Function ’{0}’ has verb that could change system state. Therefore, the function has to support &apos;ShouldProcess&apos;..
+        ///   Looks up a localized string similar to Function '{0}' has verb that could change system state. Therefore, the function has to support &apos;ShouldProcess&apos;..
         /// </summary>
         internal static string UseShouldProcessForStateChangingFunctionsError {
             get {
@@ -2636,7 +2636,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is no call to Write-Verbose in DSC function ‘{0}’. If you are using Write-Verbose in a helper function, suppress this rule application..
+        ///   Looks up a localized string similar to There is no call to Write-Verbose in DSC function '{0}'. If you are using Write-Verbose in a helper function, suppress this rule application..
         /// </summary>
         internal static string UseVerboseMessageInDSCResourceErrorFunction {
             get {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -280,7 +280,7 @@
     <value>It is a best practice to emit informative, verbose messages in DSC resource functions. This helps in debugging issues when a DSC configuration is executed.</value>
   </data>
   <data name="UseVerboseMessageInDSCResourceErrorFunction" xml:space="preserve">
-    <value>There is no call to Write-Verbose in DSC function ‘{0}’. If you are using Write-Verbose in a helper function, suppress this rule application.</value>
+    <value>There is no call to Write-Verbose in DSC function '{0}'. If you are using Write-Verbose in a helper function, suppress this rule application.</value>
   </data>
   <data name="UseVerboseMessageInDSCResourceCommonName" xml:space="preserve">
     <value>Use verbose message in DSC resource</value>
@@ -658,7 +658,7 @@
     <value>Functions that have verbs like New, Start, Stop, Set, Reset, Restart that change system state should support 'ShouldProcess'.</value>
   </data>
   <data name="UseShouldProcessForStateChangingFunctionsError" xml:space="preserve">
-    <value>Function ’{0}’ has verb that could change system state. Therefore, the function has to support 'ShouldProcess'.</value>
+    <value>Function '{0}' has verb that could change system state. Therefore, the function has to support 'ShouldProcess'.</value>
   </data>
   <data name="UseShouldProcessForStateChangingFunctionsName" xml:space="preserve">
     <value>UseShouldProcessForStateChangingFunctions</value>

--- a/Tests/DisabledRules/ProvideVerboseMessage.tests.ps1
+++ b/Tests/DisabledRules/ProvideVerboseMessage.tests.ps1
@@ -1,5 +1,5 @@
 ﻿Import-Module PSScriptAnalyzer
-$violationMessage = [regex]::Escape("There is no call to Write-Verbose in the function ‘Verb-Files’.")
+$violationMessage = [regex]::Escape("There is no call to Write-Verbose in the function 'Verb-Files'.")
 $violationName = "PSProvideVerboseMessage"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\BadCmdlet.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
+++ b/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
@@ -1,5 +1,5 @@
 ﻿Import-Module PSScriptAnalyzer
-$violationMessage = "Function ’Set-MyObject’ has verb that could change system state. Therefore, the function has to support 'ShouldProcess'"
+$violationMessage = "Function 'Set-MyObject' has verb that could change system state. Therefore, the function has to support 'ShouldProcess'"
 $violationName = "PSUseShouldProcessForStateChangingFunctions"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\UseShouldProcessForStateChangingFunctions.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/UseVerboseMessageInDSCResource.Tests.ps1
+++ b/Tests/Rules/UseVerboseMessageInDSCResource.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module PSScriptAnalyzer
 
-$violationMessage = "There is no call to Write-Verbose in DSC function ‘Test-TargetResource’. If you are using Write-Verbose in a helper function, suppress this rule application."
+$violationMessage = "There is no call to Write-Verbose in DSC function 'Test-TargetResource'. If you are using Write-Verbose in a helper function, suppress this rule application."
 $violationName = "PSDSCUseVerboseMessageInDSCResource"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\DSCResourceModule\DSCResources\MSFT_WaitForAll\MSFT_WaitForAll.psm1 | Where-Object {$_.RuleName -eq $violationName}


### PR DESCRIPTION
All rules use the typewriter apostrophe in the description.