### PR TITLE
Warn when an if statement contains an assignment

### DIFF
--- a/Engine/Generic/IScriptRule.cs
+++ b/Engine/Generic/IScriptRule.cs
@@ -10,11 +10,7 @@
 // THE SOFTWARE.
 //
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Management.Automation.Language;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic

--- a/RuleDocumentation/PossibleIncorrectUsageOfAssignmentOperator.md
+++ b/RuleDocumentation/PossibleIncorrectUsageOfAssignmentOperator.md
@@ -1,0 +1,7 @@
+# PossibleIncorrectUsageOfAssignmentOperator
+
+**Severity Level: Information**
+
+## Description
+
+In many programming languages, the equality operator is denoted as `==` or `=`, but `PowerShell` uses `-eq`. Since assignment inside if statements are very rare, this rule wants to call out this case because it might have been unintentional.

--- a/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
+++ b/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
@@ -1,0 +1,109 @@
+﻿//
+// Copyright (c) Microsoft Corporation.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+using System;
+using System.Collections.Generic;
+#if !CORECLR
+using System.ComponentModel.Composition;
+#endif
+using System.Management.Automation.Language;
+using System.Globalization;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
+{
+    /// <summary>
+    /// PossibleIncorrectUsageOfAssignmentOperator: Warn if someone uses the '=' or '==' by accident in an if statement because in most cases that is not the intention.
+    /// </summary>
+#if !CORECLR
+[Export(typeof(IScriptRule))]
+#endif
+    public class PossibleIncorrectUsageOfAssignmentOperator : AstVisitor, IScriptRule
+    {
+        List<DiagnosticRecord> records;
+        string fileName;
+
+        /// <summary>
+        /// AnalyzeScript: 
+        /// The idea is to get all AssignmentStatementAsts and then check if the parent is an IfStatementAst, which includes if, elseif and else statements.
+        /// This is just a simple smoke check to catch cases like 'if (($a=$b)){}' but was not made too complex avoid false positives.
+        /// It does not catch cases with expressions inside the if staement like e.g. 'if (($a=$b)){}'
+        /// </summary>
+        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
+            if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
+
+            IEnumerable<Ast> ifStatementAsts = ast.FindAll(testAst => testAst is AssignmentStatementAst, searchNestedScriptBlocks: true);
+            foreach (var aast in ifStatementAsts)
+            {
+                if (aast.Parent is IfStatementAst)
+                {
+                    yield return new DiagnosticRecord(
+                        Strings.PossibleIncorrectUsageOfAssignmentOperatorError, aast.Extent,
+                        GetName(), DiagnosticSeverity.Information, fileName);
+                }
+            }
+        }
+
+        /// <summary>
+        /// GetName: Retrieves the name of this rule.
+        /// </summary>
+        /// <returns>The name of this rule</returns>
+        public string GetName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.PossibleIncorrectUsageOfAssignmentOperatorName);
+        }
+
+        /// <summary>
+        /// GetCommonName: Retrieves the common name of this rule.
+        /// </summary>
+        /// <returns>The common name of this rule</returns>
+        public string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.PossibleIncorrectUsageOfAssignmentOperatorCommonName);
+        }
+
+        /// <summary>
+        /// GetDescription: Retrieves the description of this rule.
+        /// </summary>
+        /// <returns>The description of this rule</returns>
+        public string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingWriteHostDescription);
+        }
+
+        /// <summary>
+        /// GetSourceType: Retrieves the type of the rule: builtin, managed or module.
+        /// </summary>
+        public SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Information;
+        }
+
+        /// <summary>
+        /// GetSourceName: Retrieves the module/assembly name the rule is from.
+        /// </summary>
+        public string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+    }
+}

--- a/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
+++ b/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
@@ -29,9 +29,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 #endif
     public class PossibleIncorrectUsageOfAssignmentOperator : AstVisitor, IScriptRule
     {
-        List<DiagnosticRecord> records;
-        string fileName;
-
         /// <summary>
         /// AnalyzeScript: 
         /// The idea is to get all AssignmentStatementAsts and then check if the parent is an IfStatementAst, which includes if, elseif and else statements.

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -11,8 +11,8 @@
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
     using System;
     using System.Reflection;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -1538,6 +1538,33 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;=&apos; operator means assignment. Did you mean the equal operator &apos;-eq&apos;?.
+        /// </summary>
+        internal static string PossibleIncorrectUsageOfAssignmentOperatorCommonName {
+            get {
+                return ResourceManager.GetString("PossibleIncorrectUsageOfAssignmentOperatorCommonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Did you really mean to make an assignment inside an if statement? If you rather meant to check for equality, use the &apos;-eq&apos;  operator..
+        /// </summary>
+        internal static string PossibleIncorrectUsageOfAssignmentOperatorError {
+            get {
+                return ResourceManager.GetString("PossibleIncorrectUsageOfAssignmentOperatorError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to PossibleIncorrectUsageOfAssignmentOperator.
+        /// </summary>
+        internal static string PossibleIncorrectUsageOfAssignmentOperatorName {
+            get {
+                return ResourceManager.GetString("PossibleIncorrectUsageOfAssignmentOperatorName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Basic Comment Help.
         /// </summary>
         internal static string ProvideCommentHelpCommonName {
@@ -2366,7 +2393,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Function '{0}' has verb that could change system state. Therefore, the function has to support &apos;ShouldProcess&apos;..
+        ///   Looks up a localized string similar to Function &apos;{0}&apos; has verb that could change system state. Therefore, the function has to support &apos;ShouldProcess&apos;..
         /// </summary>
         internal static string UseShouldProcessForStateChangingFunctionsError {
             get {
@@ -2636,7 +2663,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is no call to Write-Verbose in DSC function '{0}'. If you are using Write-Verbose in a helper function, suppress this rule application..
+        ///   Looks up a localized string similar to There is no call to Write-Verbose in DSC function &apos;{0}&apos;. If you are using Write-Verbose in a helper function, suppress this rule application..
         /// </summary>
         internal static string UseVerboseMessageInDSCResourceErrorFunction {
             get {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -957,7 +957,6 @@
   <data name="UseConsistentWhitespaceErrorSeparatorSemi" xml:space="preserve">
     <value>Use space after a semicolon.</value>
   </data>
-
   <data name="UseSupportsShouldProcessName" xml:space="preserve">
     <value>UseSupportsShouldProcess</value>
   </data>
@@ -981,5 +980,14 @@
   </data>
   <data name="AlignAssignmentStatementError" xml:space="preserve">
     <value>Assignment statements are not aligned</value>
+  </data>
+  <data name="PossibleIncorrectUsageOfAssignmentOperatorCommonName" xml:space="preserve">
+    <value>'=' operator means assignment. Did you mean the equal operator '-eq'?</value>
+  </data>
+  <data name="PossibleIncorrectUsageOfAssignmentOperatorError" xml:space="preserve">
+    <value>Did you really mean to make an assignment inside an if statement? If you rather meant to check for equality, use the '-eq'  operator.</value>
+  </data>
+  <data name="PossibleIncorrectUsageOfAssignmentOperatorName" xml:space="preserve">
+    <value>PossibleIncorrectUsageOfAssignmentOperator</value>
   </data>
 </root>

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -61,7 +61,7 @@ Describe "Test Name parameters" {
 
         It "get Rules with no parameters supplied" {
 			$defaultRules = Get-ScriptAnalyzerRule
-            $expectedNumRules = 52
+            $expectedNumRules = 53
             if ((Test-PSEditionCoreClr) -or (Test-PSVersionV3) -or (Test-PSVersionV4))
             {
                 # for PSv3 PSAvoidGlobalAliases is not shipped because
@@ -159,7 +159,7 @@ Describe "TestSeverity" {
 
     It "filters rules based on multiple severity inputs"{
         $rules = Get-ScriptAnalyzerRule -Severity Error,Information
-        $rules.Count | Should be 14
+        $rules.Count | Should be 15
     }
 
         It "takes lower case inputs" {

--- a/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
@@ -1,4 +1,4 @@
-﻿#Import-Module PSScriptAnalyzer
+﻿Import-Module PSScriptAnalyzer
 $ruleName = "PSPossibleIncorrectUsageOfAssignmentOperator"
 
 Describe "PossibleIncorrectUsageOfAssignmentOperator" {

--- a/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
@@ -29,5 +29,10 @@ Describe "PossibleIncorrectUsageOfAssignmentOperator" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a -eq $b){$a=$b}' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 0
         }
+
+        It "returns no violations when there is an evaluation on the RHS" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = Get-ChildItem){}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 0
+        }
     }
 }

--- a/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
@@ -54,5 +54,10 @@ Describe "PossibleIncorrectUsageOfAssignmentOperator" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = (Get-ChildItem)){}' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 0
         }
+
+        It "returns no violations when there is an evaluation on the RHS wrapped in an expression and also includes a variable" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = (Get-ChildItem $b)){}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 0
+        }
     }
 }

--- a/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
@@ -1,0 +1,33 @@
+﻿#Import-Module PSScriptAnalyzer
+$ruleName = "PSPossibleIncorrectUsageOfAssignmentOperator"
+
+Describe "PossibleIncorrectUsageOfAssignmentOperator" {
+    Context "When there are violations" {
+        It "assignment inside if statemenet causes warning" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a=$b){}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 1
+        }
+
+        It "assignment inside elseif statemenet causes warning" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a -eq $b){}elseif($a = $b){}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 1
+        }
+
+        It "assignment inside else statemenet causes warning" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a -eq $b){}else{$a = $b}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 1
+        }
+
+        It "double equals inside if statemenet causes warning" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a == $b){}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 1
+        }
+    }
+
+    Context "When there are no violations" {
+        It "returns no violations when there is no equality operator" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a -eq $b){$a=$b}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 0
+        }
+    }
+}

--- a/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
@@ -1,25 +1,40 @@
-﻿Import-Module PSScriptAnalyzer
+﻿#Import-Module PSScriptAnalyzer
 $ruleName = "PSPossibleIncorrectUsageOfAssignmentOperator"
 
 Describe "PossibleIncorrectUsageOfAssignmentOperator" {
     Context "When there are violations" {
-        It "assignment inside if statemenet causes warning" {
+        It "assignment inside if statement causes warning" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a=$b){}' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 1
         }
 
-        It "assignment inside elseif statemenet causes warning" {
+        It "assignment inside if statement causes warning when when wrapped in command expression" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a=($b)){}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 1
+        }
+
+        It "assignment inside if statement causes warning when wrapped in expression" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a="$b"){}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 1
+        }
+
+        It "assignment inside elseif statement causes warning" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a -eq $b){}elseif($a = $b){}' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 1
         }
 
-        It "assignment inside else statemenet causes warning" {
-            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a -eq $b){}else{$a = $b}' | Where-Object {$_.RuleName -eq $ruleName}
+        It "double equals inside if statement causes warning" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a == $b){}' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 1
         }
 
-        It "double equals inside if statemenet causes warning" {
-            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a == $b){}' | Where-Object {$_.RuleName -eq $ruleName}
+        It "double equals inside if statement causes warning when wrapping it in command expresion" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a == ($b)){}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 1
+        }
+
+        It "double equals inside if statement causes warning when wrapped in expression" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a == "$b"){}' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 1
         }
     }
@@ -32,6 +47,11 @@ Describe "PossibleIncorrectUsageOfAssignmentOperator" {
 
         It "returns no violations when there is an evaluation on the RHS" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = Get-ChildItem){}' | Where-Object {$_.RuleName -eq $ruleName}
+            $warnings.Count | Should Be 0
+        }
+
+        It "returns no violations when there is an evaluation on the RHS wrapped in an expression" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = (Get-ChildItem)){}' | Where-Object {$_.RuleName -eq $ruleName}
             $warnings.Count | Should Be 0
         }
     }

--- a/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
@@ -1,4 +1,4 @@
-﻿#Import-Module PSScriptAnalyzer
+Import-Module PSScriptAnalyzer
 $ruleName = "PSPossibleIncorrectUsageOfAssignmentOperator"
 
 Describe "PossibleIncorrectUsageOfAssignmentOperator" {


### PR DESCRIPTION
Closes #809
This is a simple prototype that checks if there is an assignment ast inside an if statement.
It currently works and catches cases like `if( ($a = $b_){}` and `if( ($a = $b_){}` but also warns if the execution block of the if statement contains an assignment like e.g. in `if ($a -eq $b){$a=$b}`. This needs to be fixed and is being tracked by the currently failing test.
The idea is to keep it simple to avoid false positives. For example the rule does not catch cases where there is an evalution inside the if statemenet as e.g. in `if ( ($a == $b) ){}`