### PR TITLE
Warn against assignment to read-only automatic variables

### DIFF
--- a/Engine/Generic/DiagnosticRecordHelper.cs
+++ b/Engine/Generic/DiagnosticRecordHelper.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Globalization;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
+{
+    public static class DiagnosticRecordHelper
+    {
+        public static string FormatError(string format, params object[] args)
+        {
+            return String.Format(CultureInfo.CurrentCulture, format, args);
+        }
+    }
+}

--- a/RuleDocumentation/AvoidAssignmentToAutomaticVariable.md
+++ b/RuleDocumentation/AvoidAssignmentToAutomaticVariable.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-`PowerShell` exposes some of its build in variables that are known as automatic variables. Many of them are read-only and PowerShell would throw an error when trying to assign an value on those. The remaining automatic variables should only be assigned to in certain special cases to achieve a certain effect as a special technique.
+`PowerShell` exposes some of its built-in variables that are known as automatic variables. Many of them are read-only and PowerShell would throw an error when trying to assign an value on those. Other automatic variables should only be assigned to in certain special cases to achieve a certain effect as a special technique.
 
 To understand more about automatic variables, see ```Get-Help about_Automatic_Variables```.
 

--- a/RuleDocumentation/AvoidAssignmentToAutomaticVariable.md
+++ b/RuleDocumentation/AvoidAssignmentToAutomaticVariable.md
@@ -1,0 +1,33 @@
+# AvoidAssignmentToAutomaticVariable
+
+**Severity Level: Warning**
+
+## Description
+
+`PowerShell` exposes some of its build in variables that are known as automatic variables. Many of them are read-only and PowerShell would throw an error when trying to assign an value on those. The remaining automatic variables should only be assigned to in certain special cases to achieve a certain effect as a special technique.
+
+To understand more about automatic variables, see ```Get-Help about_Automatic_Variables```.
+
+## How
+
+Use variable names in functions or their parameters that do not conflict with automatic variables.
+
+## Example
+
+### Wrong
+
+The variable `$Error` is an automatic variables that exists in the global scope and should therefore never be used as a variable or parameter name.
+
+``` PowerShell
+function foo($Error){ }
+```
+
+``` PowerShell
+function Get-CustomErrorMessage($ErrorMessage){ $Error = "Error occurred: $ErrorMessage" }
+```
+
+### Correct
+
+``` PowerShell
+function Get-CustomErrorMessage($ErrorMessage){ $FinalErrorMessage = "Error occurred: $ErrorMessage" }
+```

--- a/Rules/AvoidAssignmentToAutomaticVariable.cs
+++ b/Rules/AvoidAssignmentToAutomaticVariable.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         private static readonly IList<string> _readOnlyAutomaticVariables = new List<string>()
             {
                 // Attempting to assign to any of those read-only variable would result in an error at runtime
-                "?", "true", "false", "Host", "PSCulture", "Error", "ExecutionContext", "Home", "PID", "PSEdition", "PSHome", "PSUICulture", "PSVersionTable", "SHellId"
+                "?", "true", "false", "Host", "PSCulture", "Error", "ExecutionContext", "Home", "PID", "PSEdition", "PSHome", "PSUICulture", "PSVersionTable", "ShellId"
             };
 
         /// <summary>

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -98,47 +98,47 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to AvoidAssignmentToAutomaticVariable.
+        /// </summary>
+        internal static string AvoidAssignmentToAutomaticVariableName {
+            get {
+                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariableName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use a different variable name.
         /// </summary>
-        internal static string AvoidAssignmentToAutomaticVariable {
+        internal static string AvoidAssignmentToReadOnlyAutomaticVariable {
             get {
-                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariable", resourceCulture);
+                return ResourceManager.GetString("AvoidAssignmentToReadOnlyAutomaticVariable", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Changing automtic variables might have undesired side effects.
         /// </summary>
-        internal static string AvoidAssignmentToAutomaticVariableCommonName {
+        internal static string AvoidAssignmentToReadOnlyAutomaticVariableCommonName {
             get {
-                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariableCommonName", resourceCulture);
+                return ResourceManager.GetString("AvoidAssignmentToReadOnlyAutomaticVariableCommonName", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Automatic variables are built into PowerShell and are ony meant to be consumed but not changed..
+        ///   Looks up a localized string similar to This automatic variables is built into PowerShell and readonly..
         /// </summary>
-        internal static string AvoidAssignmentToAutomaticVariableDescription {
+        internal static string AvoidAssignmentToReadOnlyAutomaticVariableDescription {
             get {
-                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariableDescription", resourceCulture);
+                return ResourceManager.GetString("AvoidAssignmentToReadOnlyAutomaticVariableDescription", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Variable {0} should use a different name since it is an automatic variable..
+        ///   Looks up a localized string similar to Variable {0} should use a different name since it is a readonly automatic variable..
         /// </summary>
-        internal static string AvoidAssignmentToAutomaticVariableError {
+        internal static string AvoidAssignmentToReadOnlyAutomaticVariableError {
             get {
-                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariableError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to AvoidAssignmentToAutomaticVariable.
-        /// </summary>
-        internal static string AvoidAssignmentToAutomaticVariableName {
-            get {
-                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariableName", resourceCulture);
+                return ResourceManager.GetString("AvoidAssignmentToReadOnlyAutomaticVariableError", resourceCulture);
             }
         }
         

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Variable {0} should use a different name since it is a readonly automatic variable..
+        ///   Looks up a localized string similar to The Variable &apos;{0}&apos; cannot be assigned since it is a readonly automatic variable that is built into PowerShell, please use a different name..
         /// </summary>
         internal static string AvoidAssignmentToReadOnlyAutomaticVariableError {
             get {

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -11,8 +11,8 @@
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
     using System;
     using System.Reflection;
-
-
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -94,6 +94,51 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         internal static string AlignAssignmentStatementName {
             get {
                 return ResourceManager.GetString("AlignAssignmentStatementName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use a different variable name.
+        /// </summary>
+        internal static string AvoidAssignmentToAutomaticVariable {
+            get {
+                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Changing automtic variables might have undesired side effects.
+        /// </summary>
+        internal static string AvoidAssignmentToAutomaticVariableCommonName {
+            get {
+                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariableCommonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Automatic variables are built into PowerShell and are ony meant to be consumed but not changed..
+        /// </summary>
+        internal static string AvoidAssignmentToAutomaticVariableDescription {
+            get {
+                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariableDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Variable {0} should use a different name since it is an automatic variable..
+        /// </summary>
+        internal static string AvoidAssignmentToAutomaticVariableError {
+            get {
+                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariableError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidAssignmentToAutomaticVariable.
+        /// </summary>
+        internal static string AvoidAssignmentToAutomaticVariableName {
+            get {
+                return ResourceManager.GetString("AvoidAssignmentToAutomaticVariableName", resourceCulture);
             }
         }
         
@@ -2366,7 +2411,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Function '{0}' has verb that could change system state. Therefore, the function has to support &apos;ShouldProcess&apos;..
+        ///   Looks up a localized string similar to Function &apos;{0}&apos; has verb that could change system state. Therefore, the function has to support &apos;ShouldProcess&apos;..
         /// </summary>
         internal static string UseShouldProcessForStateChangingFunctionsError {
             get {
@@ -2636,7 +2681,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to There is no call to Write-Verbose in DSC function '{0}'. If you are using Write-Verbose in a helper function, suppress this rule application..
+        ///   Looks up a localized string similar to There is no call to Write-Verbose in DSC function &apos;{0}&apos;. If you are using Write-Verbose in a helper function, suppress this rule application..
         /// </summary>
         internal static string UseVerboseMessageInDSCResourceErrorFunction {
             get {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -957,7 +957,6 @@
   <data name="UseConsistentWhitespaceErrorSeparatorSemi" xml:space="preserve">
     <value>Use space after a semicolon.</value>
   </data>
-
   <data name="UseSupportsShouldProcessName" xml:space="preserve">
     <value>UseSupportsShouldProcess</value>
   </data>
@@ -981,5 +980,20 @@
   </data>
   <data name="AlignAssignmentStatementError" xml:space="preserve">
     <value>Assignment statements are not aligned</value>
+  </data>
+  <data name="AvoidAssignmentToAutomaticVariable" xml:space="preserve">
+    <value>Use a different variable name</value>
+  </data>
+  <data name="AvoidAssignmentToAutomaticVariableCommonName" xml:space="preserve">
+    <value>Changing automtic variables might have undesired side effects</value>
+  </data>
+  <data name="AvoidAssignmentToAutomaticVariableDescription" xml:space="preserve">
+    <value>Automatic variables are built into PowerShell and are ony meant to be consumed but not changed.</value>
+  </data>
+  <data name="AvoidAssignmentToAutomaticVariableError" xml:space="preserve">
+    <value>Variable {0} should use a different name since it is an automatic variable.</value>
+  </data>
+  <data name="AvoidAssignmentToAutomaticVariableName" xml:space="preserve">
+    <value>AvoidAssignmentToAutomaticVariable</value>
   </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -991,7 +991,7 @@
     <value>This automatic variables is built into PowerShell and readonly.</value>
   </data>
   <data name="AvoidAssignmentToReadOnlyAutomaticVariableError" xml:space="preserve">
-    <value>Variable {0} should use a different name since it is a readonly automatic variable.</value>
+    <value>The Variable '{0}' cannot be assigned since it is a readonly automatic variable that is built into PowerShell, please use a different name.</value>
   </data>
   <data name="AvoidAssignmentToAutomaticVariableName" xml:space="preserve">
     <value>AvoidAssignmentToAutomaticVariable</value>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -981,17 +981,17 @@
   <data name="AlignAssignmentStatementError" xml:space="preserve">
     <value>Assignment statements are not aligned</value>
   </data>
-  <data name="AvoidAssignmentToAutomaticVariable" xml:space="preserve">
+  <data name="AvoidAssignmentToReadOnlyAutomaticVariable" xml:space="preserve">
     <value>Use a different variable name</value>
   </data>
-  <data name="AvoidAssignmentToAutomaticVariableCommonName" xml:space="preserve">
+  <data name="AvoidAssignmentToReadOnlyAutomaticVariableCommonName" xml:space="preserve">
     <value>Changing automtic variables might have undesired side effects</value>
   </data>
-  <data name="AvoidAssignmentToAutomaticVariableDescription" xml:space="preserve">
-    <value>Automatic variables are built into PowerShell and are ony meant to be consumed but not changed.</value>
+  <data name="AvoidAssignmentToReadOnlyAutomaticVariableDescription" xml:space="preserve">
+    <value>This automatic variables is built into PowerShell and readonly.</value>
   </data>
-  <data name="AvoidAssignmentToAutomaticVariableError" xml:space="preserve">
-    <value>Variable {0} should use a different name since it is an automatic variable.</value>
+  <data name="AvoidAssignmentToReadOnlyAutomaticVariableError" xml:space="preserve">
+    <value>Variable {0} should use a different name since it is a readonly automatic variable.</value>
   </data>
   <data name="AvoidAssignmentToAutomaticVariableName" xml:space="preserve">
     <value>AvoidAssignmentToAutomaticVariable</value>

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -61,7 +61,7 @@ Describe "Test Name parameters" {
 
         It "get Rules with no parameters supplied" {
 			$defaultRules = Get-ScriptAnalyzerRule
-            $expectedNumRules = 53
+            $expectedNumRules = 54
             if ((Test-PSEditionCoreClr) -or (Test-PSVersionV3) -or (Test-PSVersionV4))
             {
                 # for PSv3 PSAvoidGlobalAliases is not shipped because

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -61,7 +61,7 @@ Describe "Test Name parameters" {
 
         It "get Rules with no parameters supplied" {
 			$defaultRules = Get-ScriptAnalyzerRule
-            $expectedNumRules = 52
+            $expectedNumRules = 53
             if ((Test-PSEditionCoreClr) -or (Test-PSVersionV3) -or (Test-PSVersionV4))
             {
                 # for PSv3 PSAvoidGlobalAliases is not shipped because

--- a/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
+++ b/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
@@ -54,8 +54,9 @@ Describe "AvoidAssignmentToAutomaticVariables" {
         It "Setting Variable '<VariableName>' throws exception to verify the variables is read-only" -TestCases $testCases_ReadOnlyVariables {
             param ($VariableName)
             
-            # Setting the $Error variable has the side effect of the ErrorVariable to contain only the exception message string -> exclude
-            if ($VariableName -ne 'Error')
+            # Setting the $Error variable has the side effect of the ErrorVariable to contain only the exception message string, therefore exclude this case.
+            # For the library test in WMF 4, assigning a value $PSEdition does not seem to throw an error, therefore this special case is excluded as well.
+            if ($VariableName -ne 'Error' -and ($VariableName -ne 'PSEdition' -and $PSVersionTable.PSVersion.Major -ne 4))
             {
                 try
                 {

--- a/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
+++ b/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
@@ -1,0 +1,16 @@
+﻿Import-Module PSScriptAnalyzer
+$ruleName = "PSAvoidAssignmentToAutomaticVariable"
+
+Describe "AvoidAssignmentToAutomaticVariables" {
+    Context "ReadOnly Variables" {
+        It "'?' Variable" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition '$? = Get-Alias' | Where-Object { $_.RuleName -eq $ruleName }
+            $warnings.Count | Should Be 1
+        }
+
+        It "True Variable" {
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition '$true = Get-Alias' | Where-Object { $_.RuleName -eq $ruleName }
+            $warnings.Count | Should Be 1
+        }
+    }
+}

--- a/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
+++ b/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
@@ -25,7 +25,7 @@ Describe "AvoidAssignmentToAutomaticVariables" {
         It "Variable '<VariableName>' produces warning of severity error" -TestCases $testCases_ReadOnlyVariables {
             param ($VariableName)
 
-            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "`$$($VariableName) = 'foo'" | Where-Object { $_.RuleName -eq $ruleName }
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "`$${VariableName} = 'foo'" | Where-Object { $_.RuleName -eq $ruleName }
             $warnings.Count | Should Be 1
             $warnings.Severity | Should Be $readOnlyVariableSeverity
         }
@@ -41,7 +41,7 @@ Describe "AvoidAssignmentToAutomaticVariables" {
         It "Using Variable '<VariableName>' as parameter name in param block produces warning of severity error" -TestCases $testCases_ReadOnlyVariables {
             param ($VariableName)
 
-            [System.Array] $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "function foo{Param(`$$VariableName)}" | Where-Object {$_.RuleName -eq $ruleName }
+            [System.Array] $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "function foo(`$$VariableName){}" | Where-Object {$_.RuleName -eq $ruleName }
             $warnings.Count | Should Be 1
             $warnings.Severity | Should Be $readOnlyVariableSeverity
         }

--- a/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
+++ b/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
@@ -2,15 +2,27 @@
 $ruleName = "PSAvoidAssignmentToAutomaticVariable"
 
 Describe "AvoidAssignmentToAutomaticVariables" {
-    Context "ReadOnly Variables" {
-        It "'?' Variable" {
-            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition '$? = Get-Alias' | Where-Object { $_.RuleName -eq $ruleName }
+    Context "ReadOnly Variables produce warning of severity error" {
+        It "Variable '<VariableName>'" -TestCases @(
+            @{ VariableName = '?' }
+            @{ VariableName = 'Error' }
+            @{ VariableName = 'ExecutionContext' }
+            @{ VariableName = 'false' }
+            @{ VariableName = 'Home' }
+            @{ VariableName = 'Host' }
+            @{ VariableName = 'PID' }
+            @{ VariableName = 'PSCulture' }
+            @{ VariableName = 'PSEdition' }
+            @{ VariableName = 'PSHome' }
+            @{ VariableName = 'PSUICulture' }
+            @{ VariableName = 'PSVersionTable' }
+            @{ VariableName = 'ShellId' }
+            @{ VariableName = 'true' }
+        ) {
+            param ($VariableName)
+            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "`$$($VariableName) = Get-Alias" | Where-Object { $_.RuleName -eq $ruleName }
             $warnings.Count | Should Be 1
-        }
-
-        It "True Variable" {
-            $warnings = Invoke-ScriptAnalyzer -ScriptDefinition '$true = Get-Alias' | Where-Object { $_.RuleName -eq $ruleName }
-            $warnings.Count | Should Be 1
+            $warnings.Severity | Should Be  "Error"
         }
     }
 }


### PR DESCRIPTION
This is the first of a series of PRs to address issues #858 and #712
Because the analysis of automatic variables is quite complex and in certain cases assignment to automatic variables can be by design, the list of 'naughty' variable assignments is going to be opinionated.
Therefore I decided to start with the read-only variables first where PowerShell will throw an error if assignment or usage as function parameter is attempted.
Note that I still have to look into the other tests that started failing.