### PR TITLE
Make documentation of AvoidUsingPositionalParameters match the implementation

### DIFF
--- a/RuleDocumentation/AvoidUsingPositionalParameters.md
+++ b/RuleDocumentation/AvoidUsingPositionalParameters.md
@@ -6,9 +6,9 @@
 
 When developing PowerShell content that will potentially need to be maintained over time, either by the original author or others, you should use full command names and parameter names.
 
-The use of positional parameters can reduce the readability of code and potentially introduce errors.
+The use of positional parameters can reduce the readability of code and potentially introduce errors. Furthermore it is possible that future signatures of a Cmdlet could change in a way that would break existing scripts if calls to the Cmdlet rely on the position of the parameters.
 
-For simple CmdLets with only a few parameters, the risk is much smaller and in order for this rule to be not too noisy, this rule gets only triggered when there are 3 or more parameters supplied.
+For simple Cmdlets with only a few positional parameters, the risk is much smaller and in order for this rule to be not too noisy, this rule gets only triggered when there are 3 or more parameters supplied. A simple example where the risk of using positional parameters is negligible, is e.g. `Test-Path $Path`.
 
 ## How
 

--- a/RuleDocumentation/AvoidUsingPositionalParameters.md
+++ b/RuleDocumentation/AvoidUsingPositionalParameters.md
@@ -1,12 +1,14 @@
 # AvoidUsingPositionalParameters
 
-**Severity Level: Warning**
+** Severity Level: Information **
 
 ## Description
 
 When developing PowerShell content that will potentially need to be maintained over time, either by the original author or others, you should use full command names and parameter names.
 
 The use of positional parameters can reduce the readability of code and potentially introduce errors.
+
+For simple CmdLets with only a few parameters, the risk is much smaller and in order for this rule to be not too noisy, this rule gets only triggered when there are 3 or more parameters supplied.
 
 ## How
 
@@ -17,11 +19,11 @@ Use full parameter names when calling commands.
 ### Wrong
 
 ``` PowerShell
-Get-ChildItem *.txt
+Get-Command Get-ChildItem Microsoft.PowerShell.Management System.Management.Automation.Cmdlet
 ```
 
 ### Correct
 
 ``` PowerShell
-Get-Content -Path *.txt
+Get-Command -Noun Get-ChildItem -Module Microsoft.PowerShell.Management -ParameterType System.Management.Automation.Cmdlet
 ```


### PR DESCRIPTION
## PR Summary

Closes #863

The above PR found some problems that were due to the documentation not being updated in [PR 306](https://github.com/PowerShell/PSScriptAnalyzer/pull/306) that changed the `AvoidUsingPositionalParameters` rule to only be triggered on 3 or more parameters

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] NA User facing documentation needed
- [x] Change is not breaking
- [ ] NA Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
