### PR TITLE
Added -ReportSummary switch 

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 
                 if (ReportSummary.IsPresent)
                 {
-                    logger.LogObject($"{DiagnosticSeverity.Error} : {errorCount} \t {DiagnosticSeverity.Warning} : {warningCount} \t {DiagnosticSeverity.Information} : {infoCount}", this);
+                    Host.UI.WriteLine($"{DiagnosticSeverity.Error} : {errorCount} \t {DiagnosticSeverity.Warning} : {warningCount} \t {DiagnosticSeverity.Information} : {infoCount}");
                 }
             }
 


### PR DESCRIPTION
After [this discussion](https://github.com/PowerShell/PSScriptAnalyzer/issues/857) I tinkered with it some more and found I could not use the output variable methods as the would require multiline statements. Multiline statements require script blocks, and running a script block using powershell.exe from a non-powershell session does not work. My non-powershell session in this case is the Visual Studio External Tools tool.

This change adds a -ReportSummary switch to emit an additional single line count of error, warning, and info results that looks like this (if you had no errors, five warnings, and seven info messages).
```
Error : 0        Warning : 5     Information : 7
```

I needed this so i could tell if the script analysis had actually completed, was in progress, or had failed to execute in some way. Without it, the output is blank. 
![image](https://user-images.githubusercontent.com/15381181/35772671-07e7c79a-0911-11e8-884b-835db29c39a3.png)

With the -ReportSummary switch , I know it ran...
![image](https://user-images.githubusercontent.com/15381181/35772705-3292a32a-0911-11e8-845a-f44616ee18fd.png)
