### PR TITLE
Upgrade platyPS from Version 0.5 to 0.9

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -202,7 +202,7 @@ task buildDocs -Inputs $bdInputs -Outputs $bdOutputs {
     Copy-Item -Path $docsPath\about_PSScriptAnalyzer.help.txt -Destination $outputDocsPath -Force
 
     # Build documentation using platyPS
-    if ($null -eq (Get-Module platyPS -ListAvailable -Verbose:$verbosity | Where-Object { $_.Version -ge 0.5 })) {
+    if ($null -eq (Get-Module platyPS -ListAvailable -Verbose:$verbosity | Where-Object { $_.Version -ge 0.9 })) {
         throw "Cannot find platyPS of version greater or equal to 0.9. Please install it from https://www.powershellgallery.com/packages/platyPS/ using e.g. the following command: Install-Module platyPS"
     }
     Import-Module platyPS

--- a/.build.ps1
+++ b/.build.ps1
@@ -202,10 +202,10 @@ task buildDocs -Inputs $bdInputs -Outputs $bdOutputs {
     Copy-Item -Path $docsPath\about_PSScriptAnalyzer.help.txt -Destination $outputDocsPath -Force
 
     # Build documentation using platyPS
-    if ((Get-Module PlatyPS -ListAvailable) -eq $null) {
-        throw "Cannot find PlatyPS. Please install it from https://www.powershellgallery.com."
+    if ($null -eq (Get-Module platyPS -ListAvailable -Verbose:$verbosity | Where-Object { $_.Version -ge 0.5 })) {
+        throw "Cannot find platyPS of version greater or equal to 0.9. Please install it from https://www.powershellgallery.com/packages/platyPS/ using e.g. the following command: Install-Module platyPS"
     }
-    Import-Module PlatyPS
+    Import-Module platyPS
     if (-not (Test-Path $markdownDocsPath -Verbose:$verbosity)) {
         throw "Cannot find markdown documentation folder."
     }

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Exit
 ### From Source
 
 * [.NET Core 2.1.4 SDK](https://github.com/dotnet/core/blob/master/release-notes/download-archives/2.0.5-download.md)
-* [PlatyPS 0.5.0 or greater](https://github.com/PowerShell/platyPS)
+* [PlatyPS 0.9.0 or greater](https://github.com/PowerShell/platyPS/releases)
 * Optionally but recommended for development: [Visual Studio 2017](https://www.visualstudio.com/downloads/)
 
 #### Steps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ cache:
 
 # Install Pester
 install:
-    - ps: nuget install platyPS -Version 0.5.0 -source https://www.powershellgallery.com/api/v2 -outputDirectory "$Env:ProgramFiles\WindowsPowerShell\Modules\." -ExcludeVersion
+    - ps: nuget install platyPS -Version 0.9.0 -source https://www.powershellgallery.com/api/v2 -outputDirectory "$Env:ProgramFiles\WindowsPowerShell\Modules\." -ExcludeVersion
     - ps: |
         $requiredPesterVersion = '3.4.0'
         $pester = Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq $requiredPesterVersion }

--- a/build.ps1
+++ b/build.ps1
@@ -95,13 +95,13 @@ if ($BuildDocs)
     Copy-Item -Path $docsPath\about_PSScriptAnalyzer.help.txt -Destination $outputDocsPath -Force -Verbose:$verbosity
 
     # Build documentation using platyPS
-    if ((Get-Module PlatyPS -ListAvailable -Verbose:$verbosity) -eq $null)
+    if ($null -eq (Get-Module platyPS -ListAvailable -Verbose:$verbosity | Where-Object { $_.Version -ge 0.5 }))
     {
-        throw "Cannot find PlatyPS. Please install it from https://www.powershellgallery.com."
+        "Cannot find platyPS. Please install it from https://www.powershellgallery.com/packages/platyPS/ using e.g. the following command: Install-Module platyPS"
     }
-    if ((Get-Module PlatyPS -Verbose:$verbosity) -eq $null)
+    if ((Get-Module platyPS -Verbose:$verbosity) -eq $null)
     {
-        Import-Module PlatyPS -Verbose:$verbosity
+        Import-Module platyPS -Verbose:$verbosity
     }
     if (-not (Test-Path $markdownDocsPath -Verbose:$verbosity))
     {


### PR DESCRIPTION
## PR Summary

- The current [platyPS](https://www.powershellgallery.com/packages/platyPS/0.9.0) version is nearly 2 years old, therefore update it to not only get the latest bug fixes but also keep up to date to keep future upgrades easy.
- Add build tools check for version as well and fix PSSA warning PSPossibleIncorrectComparisonWithNull in script
- Also updates the platyPs markdown link to point directly to the release page.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] NA User facing documentation needed
- [x] Change is not breaking
- [ ] NA Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
