### PR TITLE
Adapt release script and documentation due to upgrade to .Net Core 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Creating a Release
 - Update changelog (`changelog.md`) with the new version number and change set. When updating the changelog please follow the same pattern as that of previous change sets (otherwise this may break the next step).
 - Import the ReleaseMaker module and execute `New-Release` cmdlet to perform the following actions.
   - Update module manifest (engine/PSScriptAnalyzer.psd1) with the new version number and change set
-  - Update the version number in `engine/project.json` and `rules/project.json`
+  - Update the version number in `Engine/Engine.csproj` and `Rules/Rules.csproj`
   - Create a release build in `out/`
 
 ```powershell

--- a/Utils/ReleaseMaker.psm1
+++ b/Utils/ReleaseMaker.psm1
@@ -93,7 +93,6 @@ function New-ReleaseBuild
     try
     {
         remove-item out/ -recurse -force
-        dotnet restore
         .\buildCoreClr.ps1 -Framework net451 -Configuration Release -Build
         .\buildCoreClr.ps1 -Framework net451 -Configuration PSV3Release -Build
         .\buildCoreClr.ps1 -Framework netstandard1.6 -Configuration Release -Build


### PR DESCRIPTION
The upgrade from the .Net Core 1.0Preview2 to .Net Core 2.0 has missed minor places to adapt:
- dotnet restore is not required any more -> remove call in `New-Release` function
- update readme.md with change from project.json to csproj file names