### PR TITLE
Fix PSAvoidUsingCmdletAliases warnings of internal build/release scripts in root and Utils folder

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -38,20 +38,20 @@ function CreateIfNotExists([string] $folderPath) {
 }
 
 function Get-BuildInputs($project) {
-    pushd $buildRoot/$project
-    gci -Filter *.cs
-    gci -Directory -Exclude obj, bin | gci -Filter *.cs -Recurse
-    popd
+    Push-Location $buildRoot/$project
+    Get-ChildItem -Filter *.cs
+    Get-ChildItem -Directory -Exclude obj, bin | Get-ChildItem -Filter *.cs -Recurse
+    Pop-Location
 }
 
 function Get-BuildOutputs($project) {
     $bin = "$buildRoot/$project/bin/$Configuration/$Framework"
     $obj = "$buildRoot/$project/obj/$Configuration/$Framework"
     if (Test-Path $bin) {
-        gci $bin -Recurse
+        Get-ChildItem $bin -Recurse
     }
     if (Test-Path $obj) {
-        gci $obj -Recurse
+        Get-ChildItem $obj -Recurse
     }
 }
 

--- a/New-StronglyTypedCsFileForResx.ps1
+++ b/New-StronglyTypedCsFileForResx.ps1
@@ -110,7 +110,7 @@ internal class {0} {{
         }}
     }}
 '@
-    $entries = $xml.root.data | % {
+    $entries = $xml.root.data | ForEach-Object {
         if ($_) {
             $val = $_.value.Replace("`n", "`n    ///")
             $name = $_.name.Replace(' ', '_')

--- a/Utils/New-CommandDataFile.ps1
+++ b/Utils/New-CommandDataFile.ps1
@@ -82,8 +82,8 @@ $shortModuleInfos = Get-ChildItem -Path $builtinModulePath `
         $module = $_
         Write-Progress $module.Name
         $commands = Get-Command -Module $module
-        $shortCommands = $commands | select -Property Name,@{Label='CommandType';Expression={$_.CommandType.ToString()}},ParameterSets
-        $shortModuleInfo = $module | select -Property Name,@{Label='Version';Expression={$_.Version.ToString()}}
+        $shortCommands = $commands | Select-Object -Property Name,@{Label='CommandType';Expression={$_.CommandType.ToString()}},ParameterSets
+        $shortModuleInfo = $module | Select-Object -Property Name,@{Label='Version';Expression={$_.Version.ToString()}}
         Add-Member -InputObject $shortModuleInfo -NotePropertyName 'ExportedCommands' -NotePropertyValue $shortCommands
         Add-Member -InputObject $shortModuleInfo -NotePropertyName 'ExportedAliases' -NotePropertyValue $module.ExportedAliases.Keys -PassThru
     }
@@ -95,12 +95,12 @@ $shortModuleInfos = Get-ChildItem -Path $builtinModulePath `
 $psCoreSnapinName = 'Microsoft.PowerShell.Core'
 Write-Progress $psCoreSnapinName
 $commands = Get-Command -Module $psCoreSnapinName
-$shortCommands = $commands | select -Property Name,@{Label='CommandType';Expression={$_.CommandType.ToString()}},ParameterSets
+$shortCommands = $commands | Select-Object -Property Name,@{Label='CommandType';Expression={$_.CommandType.ToString()}},ParameterSets
 $shortModuleInfo = New-Object -TypeName PSObject -Property @{Name=$psCoreSnapinName; Version=$commands[0].PSSnapin.PSVersion.ToString()}
 Add-Member -InputObject $shortModuleInfo -NotePropertyName 'ExportedCommands' -NotePropertyValue $shortCommands
 
 # Find the exported aliases for the commands in Microsoft.PowerShell.Core
-$aliases = Get-Alias * | where {($commands).Name -contains $_.ResolvedCommandName}
+$aliases = Get-Alias * | Where-Object { ($commands).Name -contains $_.ResolvedCommandName }
 if ($null -eq $aliases) {
     $aliases = @()
 }

--- a/Utils/ReleaseMaker.psm1
+++ b/Utils/ReleaseMaker.psm1
@@ -89,7 +89,7 @@ function Get-VersionsFromChangeLog
 function New-ReleaseBuild
 {
     $solutionPath = Get-SolutionPath
-    pushd $solutionPath
+    Push-Location $solutionPath
     try
     {
         remove-item out/ -recurse -force
@@ -101,7 +101,7 @@ function New-ReleaseBuild
     }
     finally
     {
-        popd
+        Pop-Location
     }
 }
 

--- a/Utils/RuleMaker.psm1
+++ b/Utils/RuleMaker.psm1
@@ -286,7 +286,7 @@ Function Add-RuleStrings($Rule)
 Function Remove-RuleStrings($Rule)
 {
     $stringsXml = Get-RuleStrings $Rule
-    $nodesToRemove = $stringsXml.root.GetElementsByTagName("data") | ? {$_.name -match $Rule.Name}
+    $nodesToRemove = $stringsXml.root.GetElementsByTagName("data") | Where-Object { $_.name -match $Rule.Name }
     $nodesToRemove | Foreach-Object { $stringsXml.root.RemoveChild($_) }
     Set-RuleStrings $stringsXml
 }
@@ -307,7 +307,7 @@ Function Set-RuleProjectXml($projectXml)
 
 Function Get-CompileTargetGroup($projectXml)
 {
-    $projectXml.Project.ItemGroup | ? {$_.Compile -ne $null}
+    $projectXml.Project.ItemGroup | Where-Object { $_.Compile -ne $null }
 }
 
 Function Add-RuleToProject($Rule)
@@ -324,7 +324,7 @@ Function Remove-RuleFromProject($Rule)
 {
     $projectXml = Get-RuleProjectXml
     $compileItemgroup = Get-CompileTargetGroup $projectXml
-    $itemToRemove = $compileItemgroup.Compile | ? {$_.Include -eq $Rule.SourceFileName}
+    $itemToRemove = $compileItemgroup.Compile | Where-Object { $_.Include -eq $Rule.SourceFileName }
     $compileItemgroup.RemoveChild($itemToRemove)
     Set-RuleProjectXml $projectXml
 }


### PR DESCRIPTION
## PR Summary

Fix `PSAvoidUsingCmdletAliases` warnings in scripts of root and Utils folder using the new `-Fix` switch. Encoding was corrected to stay the same. This fix can be considered risk free.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] NA User facing documentation needed
- [x] Change is not breaking
- [ ] NA Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
