### PR TITLE
Fix typo in .Description for Measure-RequiresModules

### DIFF
--- a/Tests/Engine/CommunityAnalyzerRules/CommunityAnalyzerRules.psm1
+++ b/Tests/Engine/CommunityAnalyzerRules/CommunityAnalyzerRules.psm1
@@ -126,7 +126,7 @@ function Measure-RequiresRunAsAdministrator
 .DESCRIPTION
     The #Requires statement prevents a script from running unless the Windows PowerShell version, modules, snap-ins, and module and snap-in version prerequisites are met.
     From Windows PowerShell 3.0, the #Requires statement let script developers specify Windows PowerShell modules that the script requires.
-    To fix a violation of this rule, please consider to use #Requires -RunAsAdministrator instead of using Import-Module.
+    To fix a violation of this rule, please consider to use #Requires -Modules instead of using Import-Module.
 .EXAMPLE
     Measure-RequiresModules -ScriptBlockAst $ScriptBlockAst
 .INPUTS

--- a/Tests/Engine/CommunityAnalyzerRules/CommunityAnalyzerRules.psm1
+++ b/Tests/Engine/CommunityAnalyzerRules/CommunityAnalyzerRules.psm1
@@ -126,7 +126,7 @@ function Measure-RequiresRunAsAdministrator
 .DESCRIPTION
     The #Requires statement prevents a script from running unless the Windows PowerShell version, modules, snap-ins, and module and snap-in version prerequisites are met.
     From Windows PowerShell 3.0, the #Requires statement let script developers specify Windows PowerShell modules that the script requires.
-    To fix a violation of this rule, please consider to use #Requires -Modules instead of using Import-Module.
+    To fix a violation of this rule, please consider to use #Requires -Modules { <Module-Name> | <Hashtable> } instead of using Import-Module.
 .EXAMPLE
     Measure-RequiresModules -ScriptBlockAst $ScriptBlockAst
 .INPUTS


### PR DESCRIPTION
## PR Summary

Fix typo - Change "-RunAsAdministrator" to "-Modules" in .Description for Measure-RequiresModules.

Error is presumed to have been copy and paste from Measure-RequiresRunAsAdministrator, where it was appropriate. 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [NA] User facing documentation needed
- [x] Change is not breaking
- [NA] Make sure you've added a new test if existing tests do not effectively test the code changed
- [NA] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
