### PR TITLE
Fix regressions introduced by PR 882

### DIFF
--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -97,7 +97,7 @@ Describe "Test importing correct customized rules" {
 		    $customizedRulePath.Count | Should Be 1
 		}
 
-        It "will show the custom rule when given a rule folder path with trailing backslash" -skip:(!$IsWindows){
+        It "will show the custom rule when given a rule folder path with trailing backslash" -skip:$($IsLinux -or $IsMacOS) {
 			# needs fixing for linux
             $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory/samplerule/ | Where-Object {$_.RuleName -eq $measure}
             $customizedRulePath.Count | Should Be 1
@@ -106,7 +106,7 @@ Describe "Test importing correct customized rules" {
 		It "will show the custom rules when given a glob" {
 			# needs fixing for Linux
 			$expectedNumRules = 4
-			if (!$IsWindows)
+			if ($IsLinux -or $IsMacOS)
 			{
 				$expectedNumRules = 3
 			}
@@ -122,7 +122,7 @@ Describe "Test importing correct customized rules" {
 		It "will show the custom rules when given glob with recurse switch" {
 			# needs fixing for Linux
 			$expectedNumRules = 5
-			if (!$IsWindows)
+			if ($IsLinux -or $IsMacOS)
 			{
 				$expectedNumRules = 4
 			}
@@ -162,7 +162,7 @@ Describe "Test importing correct customized rules" {
 		{
             It "will show the custom rule in the results when given a rule folder path with trailing backslash" {
 				# needs fixing for Linux
-				if ($IsWindows)
+				if (!$IsLinux -and !$IsMacOS)
 				{
 					$customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\ | Where-Object {$_.Message -eq $message}
 					$customizedRulePath.Count | Should Be 1

--- a/Tests/Engine/ModuleDependencyHandler.tests.ps1
+++ b/Tests/Engine/ModuleDependencyHandler.tests.ps1
@@ -177,10 +177,13 @@ Describe "Resolve DSC Resource Dependency" {
             $env:PSModulePath | Should Be $oldPSModulePath
         }
 
-        $env:LOCALAPPDATA = $oldLocalAppDataPath
-        $env:TEMP = $oldTempPath
-        Remove-Item -Recurse -Path $tempModulePath -Force
-        Remove-Item -Recurse -Path $tempPath -Force
+        if (!$skipTest)
+        {
+            $env:LOCALAPPDATA = $oldLocalAppDataPath
+            $env:TEMP = $oldTempPath
+            Remove-Item -Recurse -Path $tempModulePath -Force
+            Remove-Item -Recurse -Path $tempPath -Force
+        }
 
         It "Keeps the environment variables unchanged" -skip:$skipTest {
             Test-EnvironmentVariables($oldEnvVars)

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -106,7 +106,7 @@ function SuppressPwdParam()
     }
 
     Context "Rule suppression within DSC Configuration definition" {
-        It "Suppresses rule" -skip:((!$IsWindows) -or ($PSVersionTable.PSVersion.Major -lt 5)) {
+        It "Suppresses rule" -skip:($IsLinux -or $IsMacOS -or ($PSVersionTable.PSVersion.Major -lt 5)) {
             $suppressedRule = Invoke-ScriptAnalyzer -ScriptDefinition $ruleSuppressionInConfiguration -SuppressedOnly
             $suppressedRule.Count | Should Be 1
         }

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -66,7 +66,7 @@ $x = @{ }
     }
 
     Context "When assignment statements are in DSC Configuration" {
-        It "Should find violations when assignment statements are not aligned" -skip:(!$IsWindows) {
+        It "Should find violations when assignment statements are not aligned" -skip:($IsLinux -or $IsMacOS) {
             $def = @'
 Configuration MyDscConfiguration {
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,12 +59,11 @@ test_script:
     - ps: |
         copy-item "C:\projects\psscriptanalyzer\out\PSScriptAnalyzer" "$Env:ProgramFiles\WindowsPowerShell\Modules\" -Recurse -Force
         $testResultsFile = ".\TestResults.xml"
-        $ruleTestResultsFile = ".\RuleTestResults.xml"
         $testScripts = "C:\projects\psscriptanalyzer\Tests\Engine","C:\projects\psscriptanalyzer\Tests\Rules"
         $testResults = Invoke-Pester -Script $testScripts -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
-        if ($engineTestResults.FailedCount -gt 0) {
-            throw "$($engineTestResults.FailedCount) tests failed."
+        if ($testResults.FailedCount -gt 0) {
+            throw "$($testResults.FailedCount) tests failed."
         }
 
 # Upload the project along with TestResults as a zip archive


### PR DESCRIPTION
## PR Summary

When running the tests locally on Windows PowerShell after having pulled the latest changes in the development branch from PR #882, I noticed a regression (4 failed tests and 15 skipped tests);
- `$IsWindows` returns false on `Windows PowerShell` because this automatic variable was only introduced in `PowerShell Core`. I have missed this detail during the review and therefore this was partially my fault.
- As a result of the above, some tests were skipped and flagged as a failure and therefore some test code was reverted to its previous state before the PR in question so that it passes again (tested locally on Windows PowerShell 5.1).
- A variable rename caused the AppVeyor script to not throw and make the build red if there was a failure

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] NA User facing documentation needed
- [x] Change is not breaking
- [ ] NA Make sure you've added a new test if existing tests do not effectively test the code changed
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
