### PR TITLE
Fix Pester v4 installation for `Visual Studio 2017` image and use Pester v4 assertion operator syntax

### DIFF
--- a/Tests/DisabledRules/AvoidOneChar.tests.ps1
+++ b/Tests/DisabledRules/AvoidOneChar.tests.ps1
@@ -12,7 +12,7 @@ Describe "Avoid Using One Char" {
         }
 
         It "has the correct description message" {
-            $oneCharViolations[0].Message | Should Match $oneCharMessage
+            $oneCharViolations[0].Message | Should -Match $oneCharMessage
         }
     }
 

--- a/Tests/DisabledRules/AvoidOneChar.tests.ps1
+++ b/Tests/DisabledRules/AvoidOneChar.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {
 Describe "Avoid Using One Char" {
     Context "When there are violations" {
         It "has 1 One Char Violation" {
-            $oneCharViolations.Count | Should Be 1
+            $oneCharViolations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "Avoid Using One Char" {
 
     Context "When there are no violations" {
         It "has no violations" {
-            $noReservedCharViolations.Count | Should Be 0
+            $noReservedCharViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/AvoidTrapStatements.tests.ps1
+++ b/Tests/DisabledRules/AvoidTrapStatements.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {
 Describe "AvoidTrapStatement" {
     Context "When there are violations" {
         It "has 1 avoid trap violations" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -19,7 +19,7 @@ Describe "AvoidTrapStatement" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/AvoidTrapStatements.tests.ps1
+++ b/Tests/DisabledRules/AvoidTrapStatements.tests.ps1
@@ -12,7 +12,7 @@ Describe "AvoidTrapStatement" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
 
     }

--- a/Tests/DisabledRules/AvoidUnloadableModule.tests.ps1
+++ b/Tests/DisabledRules/AvoidUnloadableModule.tests.ps1
@@ -12,7 +12,7 @@ Describe "AvoidUnloadableModule" {
         }
 
         It "has the correct description message" {
-            $violations.Message | Should Match $unloadableMessage
+            $violations.Message | Should -Match $unloadableMessage
         }
     }
 

--- a/Tests/DisabledRules/AvoidUnloadableModule.tests.ps1
+++ b/Tests/DisabledRules/AvoidUnloadableModule.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\TestGoodModule\TestGoodModule.p
 Describe "AvoidUnloadableModule" {
     Context "When there are violations" {
         It "has 1 unloadable module violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "AvoidUnloadableModule" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/AvoidUsingClearHost.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingClearHost.tests.ps1
@@ -13,7 +13,7 @@ Describe "AvoidUsingClearHost" {
         }
 
         It "has the correct description message for Clear-Host" {
-            $violations[0].Message | Should Match $clearHostMessage
+            $violations[0].Message | Should -Match $clearHostMessage
         }
     }
 

--- a/Tests/DisabledRules/AvoidUsingClearHost.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingClearHost.tests.ps1
@@ -9,7 +9,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUsingClearHostNoViolations
 Describe "AvoidUsingClearHost" {
     Context "When there are violations" {
         It "has 3 Clear-Host violations" {
-            $violations.Count | Should Be 3
+            $violations.Count | Should -Be 3
         }
 
         It "has the correct description message for Clear-Host" {
@@ -19,7 +19,7 @@ Describe "AvoidUsingClearHost" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
@@ -1,9 +1,9 @@
 ﻿Import-Module PSScriptAnalyzer
 $violationMessage = @'
-The file path "D:\\Code" of AvoidUsingFilePath.ps1 is rooted. This should Be avoided if AvoidUsingFilePath.ps1 is published online
+The file path "D:\\Code" of AvoidUsingFilePath.ps1 is rooted. This should be avoided if AvoidUsingFilePath.ps1 is published online
 '@
 $violationUNCMessage = @'
-The file path "\\\\scratch2\\scratch\\" of AvoidUsingFilePath.ps1 is rooted. This should Be avoided if AvoidUsingFilePath.ps1 is published online.
+The file path "\\\\scratch2\\scratch\\" of AvoidUsingFilePath.ps1 is rooted. This should be avoided if AvoidUsingFilePath.ps1 is published online.
 '@
 
 $violationName = "PSAvoidUsingFilePath"

--- a/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
@@ -1,9 +1,9 @@
 ﻿Import-Module PSScriptAnalyzer
 $violationMessage = @'
-The file path "D:\\Code" of AvoidUsingFilePath.ps1 is rooted. This Should -Be avoided if AvoidUsingFilePath.ps1 is published online
+The file path "D:\\Code" of AvoidUsingFilePath.ps1 is rooted. This Should Be avoided if AvoidUsingFilePath.ps1 is published online
 '@
 $violationUNCMessage = @'
-The file path "\\\\scratch2\\scratch\\" of AvoidUsingFilePath.ps1 is rooted. This Should -Be avoided if AvoidUsingFilePath.ps1 is published online.
+The file path "\\\\scratch2\\scratch\\" of AvoidUsingFilePath.ps1 is rooted. This Should Be avoided if AvoidUsingFilePath.ps1 is published online.
 '@
 
 $violationName = "PSAvoidUsingFilePath"

--- a/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
@@ -18,11 +18,11 @@ Describe "AvoidUsingFilePath" {
         }
 
         It "has the correct description message with drive name" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
 
         It "has the correct description message (UNC)" {
-            $violations[2].Message | Should Match $violationUNCMessage
+            $violations[2].Message | Should -Match $violationUNCMessage
         }
     }
 

--- a/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
@@ -1,9 +1,9 @@
 ﻿Import-Module PSScriptAnalyzer
 $violationMessage = @'
-The file path "D:\\Code" of AvoidUsingFilePath.ps1 is rooted. This should be avoided if AvoidUsingFilePath.ps1 is published online
+The file path "D:\\Code" of AvoidUsingFilePath.ps1 is rooted. This Should -Be avoided if AvoidUsingFilePath.ps1 is published online
 '@
 $violationUNCMessage = @'
-The file path "\\\\scratch2\\scratch\\" of AvoidUsingFilePath.ps1 is rooted. This should be avoided if AvoidUsingFilePath.ps1 is published online.
+The file path "\\\\scratch2\\scratch\\" of AvoidUsingFilePath.ps1 is rooted. This Should -Be avoided if AvoidUsingFilePath.ps1 is published online.
 '@
 
 $violationName = "PSAvoidUsingFilePath"
@@ -14,7 +14,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUsingFilePathNoViolations.
 Describe "AvoidUsingFilePath" {
     Context "When there are violations" {
         It "has 4 avoid using file path violations" {
-            $violations.Count | Should Be 4
+            $violations.Count | Should -Be 4
         }
 
         It "has the correct description message with drive name" {
@@ -28,7 +28,7 @@ Describe "AvoidUsingFilePath" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
@@ -1,9 +1,9 @@
 ﻿Import-Module PSScriptAnalyzer
 $violationMessage = @'
-The file path "D:\\Code" of AvoidUsingFilePath.ps1 is rooted. This Should Be avoided if AvoidUsingFilePath.ps1 is published online
+The file path "D:\\Code" of AvoidUsingFilePath.ps1 is rooted. This should Be avoided if AvoidUsingFilePath.ps1 is published online
 '@
 $violationUNCMessage = @'
-The file path "\\\\scratch2\\scratch\\" of AvoidUsingFilePath.ps1 is rooted. This Should Be avoided if AvoidUsingFilePath.ps1 is published online.
+The file path "\\\\scratch2\\scratch\\" of AvoidUsingFilePath.ps1 is rooted. This should Be avoided if AvoidUsingFilePath.ps1 is published online.
 '@
 
 $violationName = "PSAvoidUsingFilePath"

--- a/Tests/DisabledRules/AvoidUsingInternalURLs.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingInternalURLs.tests.ps1
@@ -12,7 +12,7 @@ Describe "AvoidUsingInternalURLs" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/DisabledRules/AvoidUsingInternalURLs.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingInternalURLs.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUsingInternalURLsNoViolati
 Describe "AvoidUsingInternalURLs" {
     Context "When there are violations" {
         It "has 3 violations" {
-            $violations.Count | Should Be 3
+            $violations.Count | Should -Be 3
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "AvoidUsingInternalURLs" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/AvoidUsingUninitializedVariable.Tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingUninitializedVariable.Tests.ps1
@@ -8,17 +8,17 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUsingUninitializedVariable
 Describe "AvoidUsingUninitializedVariable" {
     Context "Script uses uninitialized variables - Violation" {
         It "Have 3 rule violations" {
-            $violations.Count | Should Be 3
+            $violations.Count | Should -Be 3
         }
 
         It "has the correct description message for UninitializedVariable rule violation" {
-            $violations[0].Message | Should Be $violationMessage            
+            $violations[0].Message | Should -Be $violationMessage            
         }
     }
 
     Context "Script uses initialized variables - No violation" {
         It "results in no rule violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/CommandNotFound.tests.ps1
+++ b/Tests/DisabledRules/CommandNotFound.tests.ps1
@@ -9,7 +9,7 @@ $noViolationsDSC = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $director
 Describe "CommandNotFound" {
     Context "When there are violations" {
         It "has 1 Command Not Found violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -19,11 +19,11 @@ Describe "CommandNotFound" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
 
         It "returns no violations for DSC configuration" {
-            $noViolationsDSC.Count | Should Be 0
+            $noViolationsDSC.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/CommandNotFound.tests.ps1
+++ b/Tests/DisabledRules/CommandNotFound.tests.ps1
@@ -13,7 +13,7 @@ Describe "CommandNotFound" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/DisabledRules/ProvideVerboseMessage.tests.ps1
+++ b/Tests/DisabledRules/ProvideVerboseMessage.tests.ps1
@@ -13,7 +13,7 @@ Describe "ProvideVerboseMessage" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
 
         It "Does not count violation in DSC class" {

--- a/Tests/DisabledRules/ProvideVerboseMessage.tests.ps1
+++ b/Tests/DisabledRules/ProvideVerboseMessage.tests.ps1
@@ -9,7 +9,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {
 Describe "ProvideVerboseMessage" {
     Context "When there are violations" {
         It "has 1 provide verbose violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -17,13 +17,13 @@ Describe "ProvideVerboseMessage" {
         }
 
         It "Does not count violation in DSC class" {
-            $dscViolations.Count | Should Be 0
+            $dscViolations.Count | Should -Be 0
         }
     }
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/TypeNotFound.tests.ps1
+++ b/Tests/DisabledRules/TypeNotFound.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {
 Describe "TypeNotFound" {
     Context "When there are violations" {
         It "has 2 Type Not Found violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "TypeNotFound" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/TypeNotFound.tests.ps1
+++ b/Tests/DisabledRules/TypeNotFound.tests.ps1
@@ -12,7 +12,7 @@ Describe "TypeNotFound" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/DisabledRules/UseTypeAtVariableAssignment.tests.ps1
+++ b/Tests/DisabledRules/UseTypeAtVariableAssignment.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {
 Describe "UseTypeAtVariableAssignment" {
     Context "When there are violations" {
         It "has 3 Use Type At Variable Assignement violations" {
-            $violations.Count | Should Be 3
+            $violations.Count | Should -Be 3
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "UseTypeAtVariableAssignment" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/DisabledRules/UseTypeAtVariableAssignment.tests.ps1
+++ b/Tests/DisabledRules/UseTypeAtVariableAssignment.tests.ps1
@@ -12,7 +12,7 @@ Describe "UseTypeAtVariableAssignment" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Engine/CorrectionExtent.tests.ps1
+++ b/Tests/Engine/CorrectionExtent.tests.ps1
@@ -7,13 +7,13 @@ Describe "Correction Extent" {
         It "creates the object with correct properties" {
             $correctionExtent = $obj = New-Object -TypeName $type -ArgumentList 1, 1, 1, 3, "get-childitem", "newfile", "cool description"
 
-            $correctionExtent.StartLineNumber | Should Be 1
-            $correctionExtent.EndLineNumber | Should Be 1
-            $correctionExtent.StartColumnNumber | Should Be 1
-            $correctionExtent.EndColumnNumber | Should be 3
-            $correctionExtent.Text | Should Be "get-childitem"
-            $correctionExtent.File | Should Be "newfile"
-            $correctionExtent.Description | Should Be "cool description"
+            $correctionExtent.StartLineNumber | Should -Be 1
+            $correctionExtent.EndLineNumber | Should -Be 1
+            $correctionExtent.StartColumnNumber | Should -Be 1
+            $correctionExtent.EndColumnNumber | Should -Be 3
+            $correctionExtent.Text | Should -Be "get-childitem"
+            $correctionExtent.File | Should -Be "newfile"
+            $correctionExtent.Description | Should -Be "cool description"
         }
     }
 }

--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -35,7 +35,7 @@ Describe "Test importing customized rules with null return results" {
     Context "Test Get-ScriptAnalyzer with customized rules" {
         It "will not terminate the engine" {
             $customizedRulePath = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $measure}
-            $customizedRulePath.Count | Should Be 1
+            $customizedRulePath.Count | Should -Be 1
         }
 
     }
@@ -43,7 +43,7 @@ Describe "Test importing customized rules with null return results" {
     Context "Test Invoke-ScriptAnalyzer with customized rules" {
         It "will not terminate the engine" {
             $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $measure}
-            $customizedRulePath.Count | Should Be 0
+            $customizedRulePath.Count | Should -Be 0
         }
     }
 
@@ -68,7 +68,7 @@ Describe "Test importing correct customized rules" {
 				}
 
 				$customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.Message -eq $message}
-				$customizedRulePath.Count | Should Be 1
+				$customizedRulePath.Count | Should -Be 1
 
 				# Force Get-Help not to prompt for interactive input to download help using Update-Help
 				# By adding this registry key we turn off Get-Help interactivity logic during ScriptRule parsing
@@ -89,18 +89,18 @@ Describe "Test importing correct customized rules" {
     Context "Test Get-ScriptAnalyzer with customized rules" {
         It "will show the custom rule" {
             $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.RuleName -eq $measure}
-            $customizedRulePath.Count | Should Be 1
+            $customizedRulePath.Count | Should -Be 1
         }
 
 		It "will show the custom rule when given a rule folder path" {
 			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule | Where-Object {$_.RuleName -eq $measure}
-		    $customizedRulePath.Count | Should Be 1
+		    $customizedRulePath.Count | Should -Be 1
 		}
 
         It "will show the custom rule when given a rule folder path with trailing backslash" -skip:(!$IsWindows){
 			# needs fixing for linux
             $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory/samplerule/ | Where-Object {$_.RuleName -eq $measure}
-            $customizedRulePath.Count | Should Be 1
+            $customizedRulePath.Count | Should -Be 1
 		}
 
 		It "will show the custom rules when given a glob" {
@@ -111,12 +111,12 @@ Describe "Test importing correct customized rules" {
 				$expectedNumRules = 3
 			}
 			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.RuleName -match $measure}
-			$customizedRulePath.Count | Should be $expectedNumRules
+			$customizedRulePath.Count | Should -Be $expectedNumRules
 		}
 
 		It "will show the custom rules when given recurse switch" {
 			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath "$directory\samplerule", "$directory\samplerule\samplerule2" | Where-Object {$_.RuleName -eq $measure}
-			$customizedRulePath.Count | Should be 5
+			$customizedRulePath.Count | Should -Be 5
 		}
 
 		It "will show the custom rules when given glob with recurse switch" {
@@ -127,35 +127,35 @@ Describe "Test importing correct customized rules" {
 				$expectedNumRules = 4
 			}
 			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.RuleName -eq $measure}
-			$customizedRulePath.Count | Should be $expectedNumRules
+			$customizedRulePath.Count | Should -Be $expectedNumRules
 		}
 
 		It "will show the custom rules when given glob with recurse switch" {
 			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule* | Where-Object {$_.RuleName -eq $measure}
-			$customizedRulePath.Count | Should be 3
+			$customizedRulePath.Count | Should -Be 3
 		}
     }
 
     Context "Test Invoke-ScriptAnalyzer with customized rules" {
         It "will show the custom rule in the results" {
             $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.Message -eq $message}
-            $customizedRulePath.Count | Should Be 1
+            $customizedRulePath.Count | Should -Be 1
         }
 
 		It "will show the custom rule in the results when given a rule folder path" {
             $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule | Where-Object {$_.Message -eq $message}
-            $customizedRulePath.Count | Should Be 1
+            $customizedRulePath.Count | Should -Be 1
         }
 
 		It "will set ScriptName property to the target file name" {
 			$violations = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule
-			$violations[0].ScriptName | Should Be 'TestScript.ps1'
+			$violations[0].ScriptName | Should -Be 'TestScript.ps1'
 		}
 
 		It "will set ScriptPath property to the target file path" {
 			$violations = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule
 			$expectedScriptPath = Join-Path $directory 'TestScript.ps1'
-			$violations[0].ScriptPath | Should Be $expectedScriptPath
+			$violations[0].ScriptPath | Should -Be $expectedScriptPath
 		}
 
         if (!$testingLibraryUsage)
@@ -165,59 +165,59 @@ Describe "Test importing correct customized rules" {
 				if ($IsWindows)
 				{
 					$customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\ | Where-Object {$_.Message -eq $message}
-					$customizedRulePath.Count | Should Be 1
+					$customizedRulePath.Count | Should -Be 1
 				}
 		    }
 
 		    It "will show the custom rules when given a glob" {
 			    $customizedRulePath = Invoke-ScriptAnalyzer  $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.Message -eq $message}
-			    $customizedRulePath.Count | Should be 3
+			    $customizedRulePath.Count | Should -Be 3
 		    }
 
 		    It "will show the custom rules when given recurse switch" {
 			    $customizedRulePath = Invoke-ScriptAnalyzer  $directory\TestScript.ps1 -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule | Where-Object {$_.Message -eq $message}
-			    $customizedRulePath.Count | Should be 3
+			    $customizedRulePath.Count | Should -Be 3
 		    }
 
 		    It "will show the custom rules when given glob with recurse switch" {
 			    $customizedRulePath = Invoke-ScriptAnalyzer  $directory\TestScript.ps1 -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.Message -eq $message}
-			    $customizedRulePath.Count | Should be 4
+			    $customizedRulePath.Count | Should -Be 4
 		    }
 
 		    It "will show the custom rules when given glob with recurse switch" {
 			    $customizedRulePath = Invoke-ScriptAnalyzer  $directory\TestScript.ps1 -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule* | Where-Object {$_.Message -eq $message}
-			    $customizedRulePath.Count | Should be 3
+			    $customizedRulePath.Count | Should -Be 3
 		    }
 
             It "Using IncludeDefaultRules Switch with CustomRulePath" {
                 $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomRulePath $directory\samplerule\samplerule.psm1 -IncludeDefaultRules
-                $customizedRulePath.Count | Should Be 2
+                $customizedRulePath.Count | Should -Be 2
             }
 
             It "Using IncludeDefaultRules Switch without CustomRulePath" {
                 $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -IncludeDefaultRules
-                $customizedRulePath.Count | Should Be 1
+                $customizedRulePath.Count | Should -Be 1
             }
 
             It "Not Using IncludeDefaultRules Switch and without CustomRulePath" {
                 $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1
-                $customizedRulePath.Count | Should Be 1
+                $customizedRulePath.Count | Should -Be 1
             }
 
 			It "loads custom rules that contain version in their path" -Skip:($PSVersionTable.PSVersion -lt [Version]'5.0.0') {
 			$customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomRulePath $directory\VersionedSampleRule\SampleRuleWithVersion
-			$customizedRulePath.Count | Should Be 1
+			$customizedRulePath.Count | Should -Be 1
 
 			$customizedRulePath = Get-ScriptAnalyzerRule -CustomRulePath $directory\VersionedSampleRule\SampleRuleWithVersion
-			$customizedRulePath.Count | Should Be 1
+			$customizedRulePath.Count | Should -Be 1
 			}
 
 			It "loads custom rules that contain version in their path with the RecurseCustomRule switch" -Skip:($PSVersionTable.PSVersion -lt [Version]'5.0.0') {
 			$customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomRulePath $directory\VersionedSampleRule -RecurseCustomRulePath
-			$customizedRulePath.Count | Should Be 1
+			$customizedRulePath.Count | Should -Be 1
 
 			$customizedRulePath = Get-ScriptAnalyzerRule -CustomRulePath $directory\VersionedSampleRule -RecurseCustomRulePath
-			$customizedRulePath.Count | Should Be 1
+			$customizedRulePath.Count | Should -Be 1
 		}
         }
 

--- a/Tests/Engine/EditableText.tests.ps1
+++ b/Tests/Engine/EditableText.tests.ps1
@@ -117,7 +117,7 @@ function foo {
                 -TypeName "Microsoft.Windows.PowerShell.ScriptAnalyzer.EditableText" `
                 -ArgumentList @($def)
 
-            {$text.Lines.Add("abc")} | Should Throw
+            {$text.Lines.Add("abc")} | Should -Throw
         }
 
         It "Should return the correct number of lines in the text" {

--- a/Tests/Engine/EditableText.tests.ps1
+++ b/Tests/Engine/EditableText.tests.ps1
@@ -14,7 +14,7 @@ Describe "EditableText class" {
             $edit = New-Object -TypeName $textEditType -ArgumentList 1,14,1,22,"one"
             $editableText = New-Object -TypeName $editableTextType -ArgumentList $def
             $result = $editableText.ApplyEdit($edit)
-            $result.ToString() | Should Be "This is just one line."
+            $result.ToString() | Should -Be "This is just one line."
         }
 
         It "Should replace in a single line string in the start" {
@@ -22,7 +22,7 @@ Describe "EditableText class" {
             $edit = New-Object -TypeName $textEditType -ArgumentList 1,1,1,5,"That"
             $editableText = New-Object -TypeName $editableTextType -ArgumentList $def
             $result = $editableText.ApplyEdit($edit)
-            $result.ToString() | Should Be 'That is just a single line.'
+            $result.ToString() | Should -Be 'That is just a single line.'
         }
 
         It "Should replace in a single line string in the end" {
@@ -30,7 +30,7 @@ Describe "EditableText class" {
             $edit = New-Object -TypeName $textEditType -ArgumentList 1,23,1,27,"sentence"
             $editableText = New-Object -TypeName $editableTextType -ArgumentList $def
             $result = $editableText.ApplyEdit($edit)
-            $result.ToString() | Should Be 'This is just a single sentence.'
+            $result.ToString() | Should -Be 'This is just a single sentence.'
         }
 
         It "Should replace in multi-line string" {
@@ -51,7 +51,7 @@ three
             $edit = New-Object -TypeName $textEditType -ArgumentList 2,12,3,5,$newText
             $editableText = New-Object -TypeName $editableTextType -ArgumentList $def
             $result = $editableText.ApplyEdit($edit)
-            $result.ToString() | Should Be $expected
+            $result.ToString() | Should -Be $expected
         }
 
         It "Should delete in a multi-line string" {
@@ -74,7 +74,7 @@ function foo {
             $edit = New-Object -TypeName $textEditType -ArgumentList 3,23,4,23,$newText
             $editableText = New-Object -TypeName $editableTextType -ArgumentList $def
             $result = $editableText.ApplyEdit($edit)
-            $result.ToString() | Should Be $expected
+            $result.ToString() | Should -Be $expected
         }
 
         It "Should insert in a multi-line string" {
@@ -102,7 +102,7 @@ function foo {
             $edit = New-Object -TypeName $textEditType -ArgumentList 2,1,2,1,$newText
             $editableText = New-Object -TypeName $editableTextType -ArgumentList $def
             $result = $editableText.ApplyEdit($edit)
-            $result.ToString() | Should Be $expected
+            $result.ToString() | Should -Be $expected
         }
 
         It "Should return a read-only collection of lines in the text" {
@@ -135,7 +135,7 @@ property1 = "value"
             $text = New-Object `
                 -TypeName "Microsoft.Windows.PowerShell.ScriptAnalyzer.EditableText" `
                 -ArgumentList @($def)
-            $text.LineCount | Should Be 9
+            $text.LineCount | Should -Be 9
         }
      }
 }

--- a/Tests/Engine/Extensions.tests.ps1
+++ b/Tests/Engine/Extensions.tests.ps1
@@ -91,7 +91,7 @@ Describe "FunctionDefinitionAst extension methods" {
         }
 
         It "Should set paramBlock" {
-            $paramBlockAst | Should -Not Be $null
+            $paramBlockAst | Should -Not -Be $null
         }
     }
 }
@@ -104,7 +104,7 @@ Describe "ParamBlockAst extension methods" {
                     [CmdletBinding()]
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0]
-            $extNamespace::GetCmdletBindingAttributeAst($funcDefnAst.Body.ParamBlock) | Should -Not Be $null
+            $extNamespace::GetCmdletBindingAttributeAst($funcDefnAst.Body.ParamBlock) | Should -Not -Be $null
         }
     }
 }
@@ -130,7 +130,7 @@ Describe "AttributeAst extension methods" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0]
             $attrAst = $extNamespace::GetSupportsShouldProcessAst($funcDefnAst.Body.ParamBlock.Attributes[0])
-            $attrAst | Should -Not Be $null
+            $attrAst | Should -Not -Be $null
             $attrAst.Extent.Text | Should -Be "SupportsShouldProcess"
         }
     }
@@ -157,7 +157,7 @@ Describe "NamedAttributeArgumentAst" {
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
             $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -Be $true
-            $expressionAst | Should -Not Be $null
+            $expressionAst | Should -Not -Be $null
         }
 
         It "Should return false if argument value is `$false" {
@@ -168,7 +168,7 @@ Describe "NamedAttributeArgumentAst" {
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
             $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -Be $false
-            $expressionAst | Should -Not Be $null
+            $expressionAst | Should -Not -Be $null
 
         }
     }

--- a/Tests/Engine/Extensions.tests.ps1
+++ b/Tests/Engine/Extensions.tests.ps1
@@ -91,7 +91,7 @@ Describe "FunctionDefinitionAst extension methods" {
         }
 
         It "Should set paramBlock" {
-            $paramBlockAst | Should Not Be $null
+            $paramBlockAst | Should -Not Be $null
         }
     }
 }
@@ -104,7 +104,7 @@ Describe "ParamBlockAst extension methods" {
                     [CmdletBinding()]
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0]
-            $extNamespace::GetCmdletBindingAttributeAst($funcDefnAst.Body.ParamBlock) | Should Not Be $null
+            $extNamespace::GetCmdletBindingAttributeAst($funcDefnAst.Body.ParamBlock) | Should -Not Be $null
         }
     }
 }
@@ -130,7 +130,7 @@ Describe "AttributeAst extension methods" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0]
             $attrAst = $extNamespace::GetSupportsShouldProcessAst($funcDefnAst.Body.ParamBlock.Attributes[0])
-            $attrAst | Should Not Be $null
+            $attrAst | Should -Not Be $null
             $attrAst.Extent.Text | Should -Be "SupportsShouldProcess"
         }
     }
@@ -157,7 +157,7 @@ Describe "NamedAttributeArgumentAst" {
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
             $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -Be $true
-            $expressionAst | Should Not Be $null
+            $expressionAst | Should -Not Be $null
         }
 
         It "Should return false if argument value is `$false" {
@@ -168,7 +168,7 @@ Describe "NamedAttributeArgumentAst" {
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
             $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -Be $false
-            $expressionAst | Should Not Be $null
+            $expressionAst | Should -Not Be $null
 
         }
     }

--- a/Tests/Engine/Extensions.tests.ps1
+++ b/Tests/Engine/Extensions.tests.ps1
@@ -21,10 +21,10 @@ function Test-Extent {
         $expectedEndLineNumber,
         $expectedEndColumnNumber)
 
-    $translatedExtent.StartLineNumber | Should Be $expectedStartLineNumber
-    $translatedExtent.StartColumnNumber | Should Be $expectedStartColumnNumber
-    $translatedExtent.EndLineNumber | Should Be $expectedEndLineNumber
-    $translatedExtent.EndColumnNumber | Should Be $expectedEndColumnNumber
+    $translatedExtent.StartLineNumber | Should -Be $expectedStartLineNumber
+    $translatedExtent.StartColumnNumber | Should -Be $expectedStartColumnNumber
+    $translatedExtent.EndLineNumber | Should -Be $expectedEndLineNumber
+    $translatedExtent.EndColumnNumber | Should -Be $expectedEndColumnNumber
 }
 
 $extNamespace = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Extensions.Extensions]
@@ -33,7 +33,7 @@ Describe "String extension methods" {
     Context "When a text is given to GetLines" {
         It "Should return only one line if input is a single line." {
             $def = "This is a single line"
-            $extNamespace::GetLines($def) | Get-Count | Should Be 1
+            $extNamespace::GetLines($def) | Get-Count | Should -Be 1
         }
 
         It "Should return 2 lines if input string has 2 lines." {
@@ -41,7 +41,7 @@ Describe "String extension methods" {
 This is line one.
 This is line two.
 '@
-            $extNamespace::GetLines($def) | Get-Count | Should Be 2
+            $extNamespace::GetLines($def) | Get-Count | Should -Be 2
         }
     }
 }
@@ -51,10 +51,10 @@ Describe "IScriptExtent extension methods" {
             $extent = Get-Extent $null 1 2 3 4
             $range = $extNamespace::ToRange($extent)
 
-            $range.Start.Line | Should Be $extent.StartLineNumber
-            $range.Start.Column | Should Be $extent.StartColumnNumber
-            $range.End.Line | Should Be $extent.EndLineNumber
-            $range.End.Column | Should Be $extent.EndColumnNumber
+            $range.Start.Line | Should -Be $extent.StartLineNumber
+            $range.Start.Column | Should -Be $extent.StartColumnNumber
+            $range.End.Line | Should -Be $extent.EndLineNumber
+            $range.End.Column | Should -Be $extent.EndColumnNumber
         }
     }
 }
@@ -68,11 +68,11 @@ Describe "FunctionDefinitionAst extension methods" {
         }
 
         It "Should return the parameters" {
-            $parameterAsts | Get-Count | Should Be 2
+            $parameterAsts | Get-Count | Should -Be 2
         }
 
         It "Should set paramBlock to `$null" {
-            $paramBlock | Should Be $null
+            $paramBlock | Should -Be $null
         }
     }
 
@@ -87,7 +87,7 @@ Describe "FunctionDefinitionAst extension methods" {
         }
 
         It "Should return the parameters" {
-            $parameterAsts | Get-Count | Should Be 2
+            $parameterAsts | Get-Count | Should -Be 2
         }
 
         It "Should set paramBlock" {
@@ -118,7 +118,7 @@ Describe "AttributeAst extension methods" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0]
             $extNamespace::IsCmdletBindingAttributeAst($funcDefnAst.Body.ParamBlock.Attributes[0]) |
-                Should Be $true
+                Should -Be $true
         }
     }
 
@@ -131,7 +131,7 @@ Describe "AttributeAst extension methods" {
                 }}.Ast.EndBlock.Statements[0]
             $attrAst = $extNamespace::GetSupportsShouldProcessAst($funcDefnAst.Body.ParamBlock.Attributes[0])
             $attrAst | Should Not Be $null
-            $attrAst.Extent.Text | Should Be "SupportsShouldProcess"
+            $attrAst.Extent.Text | Should -Be "SupportsShouldProcess"
         }
     }
 }
@@ -145,8 +145,8 @@ Describe "NamedAttributeArgumentAst" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
-            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should Be $true
-            $expressionAst | Should Be $null
+            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -Be $true
+            $expressionAst | Should -Be $null
         }
 
         It "Should return true if argument value is `$true" {
@@ -156,7 +156,7 @@ Describe "NamedAttributeArgumentAst" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
-            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should Be $true
+            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -Be $true
             $expressionAst | Should Not Be $null
         }
 
@@ -167,7 +167,7 @@ Describe "NamedAttributeArgumentAst" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
-            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should Be $false
+            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -Be $false
             $expressionAst | Should Not Be $null
 
         }

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -144,7 +144,7 @@ Describe "Test RuleExtension" {
             }
             catch
             {
-                $Error[0].FullyQualifiedErrorId | should match "PathNotFound,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.GetScriptAnalyzerRuleCommand"
+                $Error[0].FullyQualifiedErrorId | Should -Match "PathNotFound,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.GetScriptAnalyzerRuleCommand"
             }
         }
 

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -14,25 +14,25 @@ Describe "Test available parameters" {
     $params = $sa.Parameters
     Context "Name parameter" {
         It "has a RuleName parameter" {
-            $params.ContainsKey("Name") | Should Be $true
+            $params.ContainsKey("Name") | Should -Be $true
         }
 
         It "accepts string" {
-            $params["Name"].ParameterType.FullName | Should Be "System.String[]"
+            $params["Name"].ParameterType.FullName | Should -Be "System.String[]"
         }
     }
 
     Context "RuleExtension parameters" {
         It "has a RuleExtension parameter" {
-            $params.ContainsKey("CustomRulePath") | Should Be $true
+            $params.ContainsKey("CustomRulePath") | Should -Be $true
         }
 
         It "accepts string array" {
-            $params["CustomRulePath"].ParameterType.FullName | Should Be "System.String[]"
+            $params["CustomRulePath"].ParameterType.FullName | Should -Be "System.String[]"
         }
 
 		It "takes CustomizedRulePath parameter as an alias of CustomRulePath parameter" {
-			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should be $true
+			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should -Be $true
 		}
     }
 
@@ -42,21 +42,21 @@ Describe "Test Name parameters" {
     Context "When used correctly" {
         It "works with 1 name" {
             $rule = Get-ScriptAnalyzerRule -Name $cmdletAliases
-            $rule.Count | Should Be 1
-            $rule[0].RuleName | Should Be $cmdletAliases
+            $rule.Count | Should -Be 1
+            $rule[0].RuleName | Should -Be $cmdletAliases
         }
 
         It "works for DSC Rule" {
             $rule = Get-ScriptAnalyzerRule -Name $dscIdentical
-            $rule.Count | Should Be 1
-            $rule[0].RuleName | Should Be $dscIdentical
+            $rule.Count | Should -Be 1
+            $rule[0].RuleName | Should -Be $dscIdentical
         }
 
         It "works with 2 names" {
             $rules = Get-ScriptAnalyzerRule -Name $approvedVerbs, $cmdletAliases
-            $rules.Count | Should Be 2
-            ($rules | Where-Object {$_.RuleName -eq $cmdletAliases}).Count | Should Be 1
-            ($rules | Where-Object {$_.RuleName -eq $approvedVerbs}).Count | Should Be 1
+            $rules.Count | Should -Be 2
+            ($rules | Where-Object {$_.RuleName -eq $cmdletAliases}).Count | Should -Be 1
+            ($rules | Where-Object {$_.RuleName -eq $approvedVerbs}).Count | Should -Be 1
         }
 
         It "get Rules with no parameters supplied" {
@@ -73,25 +73,25 @@ Describe "Test Name parameters" {
 
                 $expectedNumRules--                
             }
-			$defaultRules.Count | Should be $expectedNumRules
+			$defaultRules.Count | Should -Be $expectedNumRules
 		}
 
         It "is a positional parameter" {
             $rules = Get-ScriptAnalyzerRule "PSAvoidUsingCmdletAliases"
-            $rules.Count | Should Be 1
+            $rules.Count | Should -Be 1
         }
     }
 
     Context "When used incorrectly" {
         It "1 incorrect name" {
             $rule = Get-ScriptAnalyzerRule -Name "This is a wrong name"
-            $rule.Count | Should Be 0
+            $rule.Count | Should -Be 0
         }
 
         It "1 incorrect and 1 correct" {
             $rule = Get-ScriptAnalyzerRule -Name $cmdletAliases, "This is a wrong name"
-            $rule.Count | Should Be 1
-            $rule[0].RuleName | Should Be $cmdletAliases
+            $rule.Count | Should -Be 1
+            $rule[0].RuleName | Should -Be $cmdletAliases
         }
     }
 }
@@ -108,31 +108,31 @@ Describe "Test RuleExtension" {
 		}
         It "with the module folder path" {
             $ruleExtension = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\CommunityAnalyzerRules | Where-Object {$_.SourceName -eq $community}
-            $ruleExtension.Count | Should Be $expectedNumCommunityRules
+            $ruleExtension.Count | Should -Be $expectedNumCommunityRules
         }
 
         It "with the psd1 path" {
             $ruleExtension = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\CommunityAnalyzerRules\CommunityAnalyzerRules.psd1 | Where-Object {$_.SourceName -eq $community}
-            $ruleExtension.Count | Should Be $expectedNumCommunityRules
+            $ruleExtension.Count | Should -Be $expectedNumCommunityRules
 
         }
 
         It "with the psm1 path" {
             $ruleExtension = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\CommunityAnalyzerRules\CommunityAnalyzerRules.psm1 | Where-Object {$_.SourceName -eq $community}
-            $ruleExtension.Count | Should Be $expectedNumCommunityRules
+            $ruleExtension.Count | Should -Be $expectedNumCommunityRules
         }
 
         It "with Name of a built-in rules" {
             $ruleExtension = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\CommunityAnalyzerRules\CommunityAnalyzerRules.psm1 -Name $singularNouns
-            $ruleExtension.Count | Should Be 0
+            $ruleExtension.Count | Should -Be 0
         }
 
         It "with Names of built-in, DSC and non-built-in rules" {
             $ruleExtension = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\CommunityAnalyzerRules\CommunityAnalyzerRules.psm1 -Name $singularNouns, $measureRequired, $dscIdentical
-            $ruleExtension.Count | Should be 1
-            ($ruleExtension | Where-Object {$_.RuleName -eq $measureRequired}).Count | Should Be 1
-            ($ruleExtension | Where-Object {$_.RuleName -eq $singularNouns}).Count | Should Be 0
-            ($ruleExtension | Where-Object {$_.RuleName -eq $dscIdentical}).Count | Should Be 0
+            $ruleExtension.Count | Should -Be 1
+            ($ruleExtension | Where-Object {$_.RuleName -eq $measureRequired}).Count | Should -Be 1
+            ($ruleExtension | Where-Object {$_.RuleName -eq $singularNouns}).Count | Should -Be 0
+            ($ruleExtension | Where-Object {$_.RuleName -eq $dscIdentical}).Count | Should -Be 0
         }
     }
 
@@ -154,28 +154,28 @@ Describe "Test RuleExtension" {
 Describe "TestSeverity" {
     It "filters rules based on the specified rule severity" {
         $rules = Get-ScriptAnalyzerRule -Severity Error
-        $rules.Count | Should be 6
+        $rules.Count | Should -Be 6
     }
 
     It "filters rules based on multiple severity inputs"{
         $rules = Get-ScriptAnalyzerRule -Severity Error,Information
-        $rules.Count | Should be 15
+        $rules.Count | Should -Be 15
     }
 
         It "takes lower case inputs" {
         $rules = Get-ScriptAnalyzerRule -Severity error
-        $rules.Count | Should be 6
+        $rules.Count | Should -Be 6
     }
 }
 
 Describe "TestWildCard" {
     It "filters rules based on the -Name wild card input" {
         $rules = Get-ScriptAnalyzerRule -Name PSDSC*
-        $rules.Count | Should be 7
+        $rules.Count | Should -Be 7
     }
 
     It "filters rules based on wild card input and severity"{
         $rules = Get-ScriptAnalyzerRule -Name PSDSC*　-Severity Information
-        $rules.Count | Should be 4
+        $rules.Count | Should -Be 4
     }
 }

--- a/Tests/Engine/GlobalSuppression.test.ps1
+++ b/Tests/Engine/GlobalSuppression.test.ps1
@@ -16,89 +16,89 @@ Describe "GlobalSuppression" {
     Context "Exclude Rule" {
         It "Raises 1 violation for cmdlet alias" {
             $withoutProfile = $violations | Where-Object { $_.RuleName -eq "PSAvoidUsingCmdletAliases"}
-            $withoutProfile.Count | Should Be 1
+            $withoutProfile.Count | Should -Be 1
             $withoutProfile = $violationsUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSAvoidUsingCmdletAliases"}
-            $withoutProfile.Count | Should Be 1
+            $withoutProfile.Count | Should -Be 1
         }
 
         It "Does not raise any violations for cmdlet alias with profile" {
             $withProfile = $suppression | Where-Object { $_.RuleName -eq "PSAvoidUsingCmdletAliases" }
-            $withProfile.Count | Should be 0
+            $withProfile.Count | Should -Be 0
             $withProfile = $suppressionUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSAvoidUsingCmdletAliases" }
-            $withProfile.Count | Should be 0
+            $withProfile.Count | Should -Be 0
         }
 
         It "Does not raise any violation for cmdlet alias using configuration hashtable" {
             $hashtableConfiguration = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Configuration @{"excluderules" = "PSAvoidUsingCmdletAliases"} |
                                         Where-Object { $_.RuleName -eq "PSAvoidUsingCmdletAliases"}
-            $hashtableConfiguration.Count | Should Be 0
+            $hashtableConfiguration.Count | Should -Be 0
 
             $hashtableConfiguration = Invoke-ScriptAnalyzer -ScriptDefinition (Get-Content -Raw "$directory\GlobalSuppression.ps1") -Configuration @{"excluderules" = "PSAvoidUsingCmdletAliases"} |
                                         Where-Object { $_.RuleName -eq "PSAvoidUsingCmdletAliases"}
-            $hashtableConfiguration.Count | Should Be 0
+            $hashtableConfiguration.Count | Should -Be 0
         }
     }
 
     Context "Include Rule" {
         It "Raises 1 violation for computername hard-coded" {
             $withoutProfile = $violations | Where-Object { $_.RuleName -eq "PSAvoidUsingComputerNameHardcoded" }
-            $withoutProfile.Count | Should Be 1
+            $withoutProfile.Count | Should -Be 1
             $withoutProfile = $violationsUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSAvoidUsingComputerNameHardcoded" }
-            $withoutProfile.Count | Should Be 1
+            $withoutProfile.Count | Should -Be 1
         }
 
         It "Does not raise any violations for computername hard-coded" {
             $withProfile = $suppression | Where-Object { $_.RuleName -eq "PSAvoidUsingComputerNameHardcoded" }
-            $withProfile.Count | Should be 0
+            $withProfile.Count | Should -Be 0
             $withProfile = $suppressionUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSAvoidUsingComputerNameHardcoded" }
-            $withProfile.Count | Should be 0
+            $withProfile.Count | Should -Be 0
         }
         
         It "Does not raise any violation for computername hard-coded using configuration hashtable" {
             $hashtableConfiguration = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Settings @{"includerules" = @("PSAvoidUsingCmdletAliases", "PSUseOutputTypeCorrectly")} |
                                         Where-Object { $_.RuleName -eq "PSAvoidUsingComputerNameHardcoded"}
-            $hashtableConfiguration.Count | Should Be 0
+            $hashtableConfiguration.Count | Should -Be 0
         }
     }
 
     Context "Severity" {
         It "Raises 1 violation for use output type correctly without profile" {
             $withoutProfile = $violations | Where-Object { $_.RuleName -eq "PSUseOutputTypeCorrectly" }
-            $withoutProfile.Count | Should Be 1
+            $withoutProfile.Count | Should -Be 1
             $withoutProfile = $violationsUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSUseOutputTypeCorrectly" }
-            $withoutProfile.Count | Should Be 1
+            $withoutProfile.Count | Should -Be 1
         }
 
         It "Does not raise any violations for use output type correctly with profile" {
             $withProfile = $suppression | Where-Object { $_.RuleName -eq "PSUseOutputTypeCorrectly" }
-            $withProfile.Count | Should be 0
+            $withProfile.Count | Should -Be 0
             $withProfile = $suppressionUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSUseOutputTypeCorrectly" }
-            $withProfile.Count | Should be 0
+            $withProfile.Count | Should -Be 0
         }
 
         It "Does not raise any violation for use output type correctly with configuration hashtable" {
             $hashtableConfiguration = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Settings @{"severity" = "warning"} |
                                     Where-Object {$_.RuleName -eq "PSUseOutputTypeCorrectly"}
-            $hashtableConfiguration.Count | should be 0
+            $hashtableConfiguration.Count | Should -Be 0
         }
     }
 
     Context "Error Case" {
         It "Raises Error for file not found" {
             $invokeWithError = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Settings ".\ThisFileDoesNotExist.ps1" -ErrorAction SilentlyContinue
-            $invokeWithError.Count | should be 0
+            $invokeWithError.Count | Should -Be 0
             $Error[0].FullyQualifiedErrorId | should match "SettingsFileNotFound,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
         }
 
         It "Raises Error for file with no hash table" {
             $invokeWithError = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Settings "$directory\GlobalSuppression.ps1" -ErrorAction SilentlyContinue
-            $invokeWithError.Count | should be 0
+            $invokeWithError.Count | Should -Be 0
             $Error[0].FullyQualifiedErrorId | should match "SettingsFileHasNoHashTable,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
         }
 
         It "Raises Error for wrong profile" {
             $invokeWithError = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Settings "$directory\WrongProfile.ps1" -ErrorAction SilentlyContinue
-            $invokeWithError.Count | should be 0
+            $invokeWithError.Count | Should -Be 0
             $Error[0].FullyQualifiedErrorId | should match "WrongSettingsKey,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
         }
     }

--- a/Tests/Engine/GlobalSuppression.test.ps1
+++ b/Tests/Engine/GlobalSuppression.test.ps1
@@ -87,19 +87,19 @@ Describe "GlobalSuppression" {
         It "Raises Error for file not found" {
             $invokeWithError = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Settings ".\ThisFileDoesNotExist.ps1" -ErrorAction SilentlyContinue
             $invokeWithError.Count | Should -Be 0
-            $Error[0].FullyQualifiedErrorId | should match "SettingsFileNotFound,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
+            $Error[0].FullyQualifiedErrorId | Should -Match "SettingsFileNotFound,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
         }
 
         It "Raises Error for file with no hash table" {
             $invokeWithError = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Settings "$directory\GlobalSuppression.ps1" -ErrorAction SilentlyContinue
             $invokeWithError.Count | Should -Be 0
-            $Error[0].FullyQualifiedErrorId | should match "SettingsFileHasNoHashTable,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
+            $Error[0].FullyQualifiedErrorId | Should -Match "SettingsFileHasNoHashTable,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
         }
 
         It "Raises Error for wrong profile" {
             $invokeWithError = Invoke-ScriptAnalyzer "$directory\GlobalSuppression.ps1" -Settings "$directory\WrongProfile.ps1" -ErrorAction SilentlyContinue
             $invokeWithError.Count | Should -Be 0
-            $Error[0].FullyQualifiedErrorId | should match "WrongSettingsKey,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
+            $Error[0].FullyQualifiedErrorId | Should -Match "WrongSettingsKey,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
         }
     }
 }

--- a/Tests/Engine/Helper.tests.ps1
+++ b/Tests/Engine/Helper.tests.ps1
@@ -14,18 +14,18 @@ Describe "Test Directed Graph" {
         $digraph.AddEdge('v2', 'v4');
 
         It "correctly adds the vertices" {
-            $digraph.NumVertices | Should Be 5
+            $digraph.NumVertices | Should -Be 5
         }
 
         It "correctly adds the edges" {
-            $digraph.GetOutDegree('v1') | Should Be 2
+            $digraph.GetOutDegree('v1') | Should -Be 2
             $neighbors = $digraph.GetNeighbors('v1')
-            $neighbors -contains 'v2' | Should Be $true
-            $neighbors -contains 'v5' | Should Be $true
+            $neighbors -contains 'v2' | Should -Be $true
+            $neighbors -contains 'v5' | Should -Be $true
         }
 
         It "finds the connection" {
-            $digraph.IsConnected('v1', 'v4') | Should Be $true
+            $digraph.IsConnected('v1', 'v4') | Should -Be $true
         }
     }
 }

--- a/Tests/Engine/InvokeFormatter.tests.ps1
+++ b/Tests/Engine/InvokeFormatter.tests.ps1
@@ -28,7 +28,7 @@ function foo {
                 }
             }
 
-            Invoke-Formatter $def $settings | Should Be $expected
+            Invoke-Formatter $def $settings | Should -Be $expected
         }
     }
 
@@ -48,7 +48,7 @@ function foo {
 }
 "@
 
-            Invoke-Formatter -ScriptDefinition $def -Range @(3, 1, 4, 1) | Should Be $expected
+            Invoke-Formatter -ScriptDefinition $def -Range @(3, 1, 4, 1) | Should -Be $expected
         }
     }
 
@@ -76,7 +76,7 @@ function foo {
 }
 '@
 
-            Invoke-Formatter -ScriptDefinition $def | Should Be $expected
+            Invoke-Formatter -ScriptDefinition $def | Should -Be $expected
         }
     }
 

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -21,55 +21,55 @@ Describe "Test available parameters" {
     $params = $sa.Parameters
     Context "Path parameter" {
         It "has a Path parameter" {
-            $params.ContainsKey("Path") | Should Be $true
+            $params.ContainsKey("Path") | Should -Be $true
         }
 
         It "accepts string" {
-            $params["Path"].ParameterType.FullName | Should Be "System.String"
+            $params["Path"].ParameterType.FullName | Should -Be "System.String"
         }
     }
 
     Context "Path parameter" {
         It "has a ScriptDefinition parameter" {
-            $params.ContainsKey("ScriptDefinition") | Should Be $true
+            $params.ContainsKey("ScriptDefinition") | Should -Be $true
         }
 
         It "accepts string" {
-            $params["ScriptDefinition"].ParameterType.FullName | Should Be "System.String"
+            $params["ScriptDefinition"].ParameterType.FullName | Should -Be "System.String"
         }
     }
 
     Context "CustomRulePath parameters" {
         It "has a CustomRulePath parameter" {
-            $params.ContainsKey("CustomRulePath") | Should Be $true
+            $params.ContainsKey("CustomRulePath") | Should -Be $true
         }
 
         It "accepts a string array" {
-				$params["CustomRulePath"].ParameterType.FullName | Should Be "System.String[]"
+				$params["CustomRulePath"].ParameterType.FullName | Should -Be "System.String[]"
         }
 
 		It "has a CustomizedRulePath alias"{
-			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should be $true
+			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should -Be $true
 		}
     }
 
     Context "IncludeRule parameters" {
         It "has an IncludeRule parameter" {
-            $params.ContainsKey("IncludeRule") | Should Be $true
+            $params.ContainsKey("IncludeRule") | Should -Be $true
         }
 
         It "accepts string array" {
-            $params["IncludeRule"].ParameterType.FullName | Should Be "System.String[]"
+            $params["IncludeRule"].ParameterType.FullName | Should -Be "System.String[]"
         }
     }
 
     Context "Severity parameters" {
         It "has a severity parameters" {
-            $params.ContainsKey("Severity") | Should Be $true
+            $params.ContainsKey("Severity") | Should -Be $true
         }
 
         It "accepts string array" {
-            $params["Severity"].ParameterType.FullName | Should Be "System.String[]"
+            $params["Severity"].ParameterType.FullName | Should -Be "System.String[]"
         }
     }
 
@@ -77,18 +77,18 @@ Describe "Test available parameters" {
     {
         Context "SaveDscDependency parameter" {
             It "has the parameter" {
-                $params.ContainsKey("SaveDscDependency") | Should Be $true
+                $params.ContainsKey("SaveDscDependency") | Should -Be $true
             }
 
             It "is a switch parameter" {
-                $params["SaveDscDependency"].ParameterType.FullName | Should Be "System.Management.Automation.SwitchParameter"
+                $params["SaveDscDependency"].ParameterType.FullName | Should -Be "System.Management.Automation.SwitchParameter"
             }
         }
     }
 
     Context "It has 2 parameter sets: File and ScriptDefinition" {
         It "Has 2 parameter sets" {
-            $sa.ParameterSets.Count | Should Be 2
+            $sa.ParameterSets.Count | Should -Be 2
         }
 
         It "Has File parameter set" {
@@ -100,7 +100,7 @@ Describe "Test available parameters" {
                 }
             }
 
-            $hasFile | Should Be $true
+            $hasFile | Should -Be $true
         }
 
         It "Has ScriptDefinition parameter set" {
@@ -112,7 +112,7 @@ Describe "Test available parameters" {
                 }
             }
 
-            $hasFile | Should Be $true
+            $hasFile | Should -Be $true
         }
 
     }
@@ -122,7 +122,7 @@ Describe "Test ScriptDefinition" {
     Context "When given a script definition" {
         It "Does not run rules on script with more than 10 parser errors" {
             $moreThanTenErrors = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue -ScriptDefinition (Get-Content -Raw "$directory\CSharp.ps1")
-            $moreThanTenErrors.Count | Should Be 0
+            $moreThanTenErrors.Count | Should -Be 0
         }
     }
 }
@@ -132,12 +132,12 @@ Describe "Test Path" {
         It "Has the same effect as without Path parameter" {
             $withPath = Invoke-ScriptAnalyzer $directory\TestScript.ps1
             $withoutPath = Invoke-ScriptAnalyzer -Path $directory\TestScript.ps1
-            $withPath.Count -eq $withoutPath.Count | Should Be $true
+            $withPath.Count -eq $withoutPath.Count | Should -Be $true
         }
 
         It "Does not run rules on script with more than 10 parser errors" {
             $moreThanTenErrors = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $directory\CSharp.ps1
-            $moreThanTenErrors.Count | Should Be 0
+            $moreThanTenErrors.Count | Should -Be 0
         }
     }
 
@@ -147,14 +147,14 @@ Describe "Test Path" {
 	   $scriptPath = Join-Path $directory $scriptName
 	   $expectedScriptPath = Resolve-Path $directory\TestScript.ps1
 	   $diagnosticRecords = Invoke-ScriptAnalyzer $scriptPath -IncludeRule "PSAvoidUsingEmptyCatchBlock"
-	   $diagnosticRecords[0].ScriptPath | Should Be $expectedScriptPath.Path
-	   $diagnosticRecords[0].ScriptName | Should Be $scriptName
+	   $diagnosticRecords[0].ScriptPath | Should -Be $expectedScriptPath.Path
+	   $diagnosticRecords[0].ScriptName | Should -Be $scriptName
 	}
 
 	It "has empty ScriptPath and ScriptName properties when a script definition is given" {
 	   $diagnosticRecords = Invoke-ScriptAnalyzer -ScriptDefinition gci -IncludeRule "PSAvoidUsingCmdletAliases"
-	   $diagnosticRecords[0].ScriptPath | Should Be ([System.String]::Empty)
-	   $diagnosticRecords[0].ScriptName | Should Be ([System.String]::Empty)
+	   $diagnosticRecords[0].ScriptPath | Should -Be ([System.String]::Empty)
+	   $diagnosticRecords[0].ScriptName | Should -Be ([System.String]::Empty)
 	}
     }
 
@@ -177,7 +177,7 @@ Describe "Test Path" {
     		It "Invokes on all the matching files" {
 			$numFilesResult = (Invoke-ScriptAnalyzer -Path $directory\TestTestPath*.ps1 | Select-Object -Property ScriptName -Unique).Count
 			$numFilesExpected = (Get-ChildItem -Path $directory\TestTestPath*.ps1).Count
-			$numFilesResult | Should be $numFilesExpected
+			$numFilesResult | Should -Be $numFilesExpected
 			}
 		}
 
@@ -189,7 +189,7 @@ Describe "Test Path" {
 			$numFilesExpected = (Get-ChildItem -Path $freeDrive\TestTestPath*.ps1).Count
 			$numFilesResult = (Invoke-ScriptAnalyzer -Path $freeDrive\TestTestPath*.ps1 | Select-Object -Property ScriptName -Unique).Count
 			Remove-PSDrive $freeDriveName
-			$numFilesResult | Should Be $numFilesExpected
+			$numFilesResult | Should -Be $numFilesExpected
 			}
 		}
 	}
@@ -199,7 +199,7 @@ Describe "Test Path" {
         $withPathWithDirectory = Invoke-ScriptAnalyzer -Recurse -Path $directory\RecursionDirectoryTest
 
         It "Has the same count as without Path parameter"{
-            $withoutPathWithDirectory.Count -eq $withPathWithDirectory.Count | Should Be $true
+            $withoutPathWithDirectory.Count -eq $withPathWithDirectory.Count | Should -Be $true
         }
 
         It "Analyzes all the files" {
@@ -209,7 +209,7 @@ Describe "Test Path" {
             Write-Output $globalVarsViolation.Count
             Write-Output $clearHostViolation.Count
             Write-Output $writeHostViolation.Count
-            $globalVarsViolation.Count -eq 1 -and $writeHostViolation.Count -eq 1 | Should Be $true
+            $globalVarsViolation.Count -eq 1 -and $writeHostViolation.Count -eq 1 | Should -Be $true
         }
     }
 }
@@ -218,12 +218,12 @@ Describe "Test ExcludeRule" {
     Context "When used correctly" {
         It "excludes 1 rule" {
             $noViolations = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -ExcludeRule $singularNouns | Where-Object {$_.RuleName -eq $singularNouns}
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
 
         It "excludes 3 rules" {
             $noViolations = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -ExcludeRule $rules | Where-Object {$rules -contains $_.RuleName}
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 
@@ -231,7 +231,7 @@ Describe "Test ExcludeRule" {
         It "does not exclude any rules" {
             $noExclude = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1
             $withExclude = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -ExcludeRule "This is a wrong rule"
-            $withExclude.Count -eq $noExclude.Count | Should Be $true
+            $withExclude.Count -eq $noExclude.Count | Should -Be $true
         }
     }
 
@@ -247,7 +247,7 @@ Describe "Test IncludeRule" {
     Context "When used correctly" {
         It "includes 1 rule" {
             $violations = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -IncludeRule $approvedVerb | Where-Object {$_.RuleName -eq $approvedVerb}
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "includes the given rules" {
@@ -258,21 +258,21 @@ Describe "Test IncludeRule" {
                 $expectedNumViolations = 1
             }
             $violations = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -IncludeRule $rules
-            $violations.Count | Should Be $expectedNumViolations
+            $violations.Count | Should -Be $expectedNumViolations
         }
     }
 
     Context "When used incorrectly" {
         It "does not include any rules" {
             $wrongInclude = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -IncludeRule "This is a wrong rule"
-            $wrongInclude.Count | Should Be 0
+            $wrongInclude.Count | Should -Be 0
         }
     }
 
     Context "IncludeRule supports wild card" {
         It "includes 1 wildcard rule"{
             $includeWildcard = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -IncludeRule $avoidRules
-            $includeWildcard.Count | Should be 0
+            $includeWildcard.Count | Should -Be 0
         }
 
         it "includes 2 wildcardrules" {
@@ -284,7 +284,7 @@ Describe "Test IncludeRule" {
             }
             $includeWildcard = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -IncludeRule $avoidRules
             $includeWildcard += Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -IncludeRule $useRules
-            $includeWildcard.Count | Should be $expectedNumViolations
+            $includeWildcard.Count | Should -Be $expectedNumViolations
         }
     }
 }
@@ -292,12 +292,12 @@ Describe "Test IncludeRule" {
 Describe "Test Exclude And Include" {1
     It "Exclude and Include different rules" {
         $violations = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -IncludeRule "PSAvoidUsingEmptyCatchBlock" -ExcludeRule "PSAvoidUsingPositionalParameters"
-        $violations.Count | Should be 1
+        $violations.Count | Should -Be 1
     }
 
     It "Exclude and Include the same rule" {
         $violations = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -IncludeRule "PSAvoidUsingEmptyCatchBlock" -ExcludeRule "PSAvoidUsingEmptyCatchBlock"
-        $violations.Count | Should be 0
+        $violations.Count | Should -Be 0
     }
 }
 
@@ -305,17 +305,17 @@ Describe "Test Severity" {
     Context "When used correctly" {
         It "works with one argument" {
             $errors = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -Severity Information
-            $errors.Count | Should Be 0
+            $errors.Count | Should -Be 0
         }
 
         It "works with 2 arguments" {
             $errors = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -Severity Information, Warning
-            $errors.Count | Should Be 1
+            $errors.Count | Should -Be 1
         }
 
         It "works with lowercase argument"{
              $errors = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -Severity information, warning
-            $errors.Count | Should Be 1
+            $errors.Count | Should -Be 1
         }
 
         It "works for dsc rules" {
@@ -331,12 +331,12 @@ Describe "Test Severity" {
             Invoke-ScriptAnalyzer -Path $testDataPath -Severity Error | `
                 Where-Object {$_.RuleName -eq "PSDSCUseVerboseMessageInDSCResource"} | `
                 Get-Count | `
-                Should Be 0
+                Should -Be 0
 
             Invoke-ScriptAnalyzer -Path $testDataPath -Severity Information | `
                 Where-Object {$_.RuleName -eq "PSDSCUseVerboseMessageInDSCResource"} | `
                 Get-Count | `
-                Should Be 2
+                Should -Be 2
         }
     }
 
@@ -352,33 +352,33 @@ Describe "Test CustomizedRulePath" {
     Context "When used correctly" {
         It "with the module folder path" {
             $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\CommunityAnalyzerRules | Where-Object {$_.RuleName -eq $measureRequired}
-            $customizedRulePath.Count | Should Be 1
+            $customizedRulePath.Count | Should -Be 1
         }
 
         It "with the psd1 path" {
             $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\CommunityAnalyzerRules\CommunityAnalyzerRules.psd1 | Where-Object {$_.RuleName -eq $measureRequired}
-            $customizedRulePath.Count | Should Be 1
+            $customizedRulePath.Count | Should -Be 1
 
         }
 
         It "with the psm1 path" {
             $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\CommunityAnalyzerRules\CommunityAnalyzerRules.psm1 | Where-Object {$_.RuleName -eq $measureRequired}
-            $customizedRulePath.Count | Should Be 1
+            $customizedRulePath.Count | Should -Be 1
         }
 
         It "with IncludeRule" {
             $customizedRulePathInclude = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\CommunityAnalyzerRules\CommunityAnalyzerRules.psm1 -IncludeRule "Measure-RequiresModules"
-            $customizedRulePathInclude.Count | Should Be 1
+            $customizedRulePathInclude.Count | Should -Be 1
         }
 
         It "with ExcludeRule" {
             $customizedRulePathExclude = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\CommunityAnalyzerRules\CommunityAnalyzerRules.psm1 -ExcludeRule "Measure-RequiresModules" | Where-Object {$_.RuleName -eq $measureRequired}
-            $customizedRulePathExclude.Count | Should be 0
+            $customizedRulePathExclude.Count | Should -Be 0
         }
 
 		It "When supplied with a collection of paths" {
             $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomRulePath ("$directory\CommunityAnalyzerRules", "$directory\samplerule", "$directory\samplerule\samplerule2")
-            $customizedRulePath.Count | Should Be 3
+            $customizedRulePath.Count | Should -Be 3
         }
     }
 
@@ -393,7 +393,7 @@ Describe "Test CustomizedRulePath" {
                 }
 
                 $v = Invoke-ScriptAnalyzer -Path $directory\TestScript.ps1 -Settings $settings
-                $v.Count | Should Be 1
+                $v.Count | Should -Be 1
             }
 
             It "Should use the IncludeDefaultRulePath parameter" {
@@ -404,7 +404,7 @@ Describe "Test CustomizedRulePath" {
                 }
 
                 $v = Invoke-ScriptAnalyzer -Path $directory\TestScript.ps1 -Settings $settings
-                $v.Count | Should Be 2
+                $v.Count | Should -Be 2
             }
 
             It "Should use the RecurseCustomRulePath parameter" {
@@ -415,7 +415,7 @@ Describe "Test CustomizedRulePath" {
                 }
 
                 $v = Invoke-ScriptAnalyzer -Path $directory\TestScript.ps1 -Settings $settings
-                $v.Count | Should Be 3
+                $v.Count | Should -Be 3
             }
         }
 
@@ -434,17 +434,17 @@ Describe "Test CustomizedRulePath" {
 
             It "Should combine CustomRulePaths" {
                 $v = Invoke-ScriptAnalyzer @isaParams -CustomRulePath "$directory\CommunityAnalyzerRules"
-                $v.Count | Should Be 2
+                $v.Count | Should -Be 2
             }
 
             It "Should override the settings IncludeDefaultRules parameter" {
                 $v = Invoke-ScriptAnalyzer @isaParams -IncludeDefaultRules
-                $v.Count | Should Be 2
+                $v.Count | Should -Be 2
             }
 
             It "Should override the settings RecurseCustomRulePath parameter" {
                 $v = Invoke-ScriptAnalyzer @isaParams -RecurseCustomRulePath
-                $v.Count | Should Be 3
+                $v.Count | Should -Be 3
             }
         }
     }
@@ -483,25 +483,25 @@ Describe "Test -Fix Switch" {
     It "Fixes warnings" {
         # we expect the script to contain warnings
         $warningsBeforeFix = Invoke-ScriptAnalyzer $testScript
-        $warningsBeforeFix.Count | Should Be 5
+        $warningsBeforeFix.Count | Should -Be 5
 
         # fix the warnings and expect that it should not return the fixed warnings
         $warningsWithFixSwitch = Invoke-ScriptAnalyzer $testScript -Fix
-        $warningsWithFixSwitch.Count | Should Be 0
+        $warningsWithFixSwitch.Count | Should -Be 0
 
         # double check that the warnings are really fixed
         $warningsAfterFix = Invoke-ScriptAnalyzer $testScript
-        $warningsAfterFix.Count | Should Be 0
+        $warningsAfterFix.Count | Should -Be 0
 
         # check content to ensure we have what we expect
         $actualScriptContentAfterFix = Get-Content $testScript -Raw
-        $actualScriptContentAfterFix | Should Be $expectedScriptContent
+        $actualScriptContentAfterFix | Should -Be $expectedScriptContent
     }
 }
 
 Describe "Test -EnableExit Switch" {
     It "Returns exit code equivalent to number of warnings" {
         powershell -Command 'Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit'
-        $LASTEXITCODE  | Should Be 1
+        $LASTEXITCODE  | Should -Be 1
     }
 }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -342,7 +342,7 @@ Describe "Test Severity" {
 
     Context "When used incorrectly" {
         It "throws error" {
-            { Invoke-ScriptAnalyzer -Severity "Wrong" $directory\TestScript.ps1 } | Should Throw
+            { Invoke-ScriptAnalyzer -Severity "Wrong" $directory\TestScript.ps1 } | Should -Throw
         }
     }
 }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -459,7 +459,7 @@ Describe "Test CustomizedRulePath" {
             {
                 if (-not $testingLibraryUsage)
 			    {
-                    $Error[0].FullyQualifiedErrorId | should match "PathNotFound,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
+                    $Error[0].FullyQualifiedErrorId | Should -Match "PathNotFound,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand"
                 }
             }
         }

--- a/Tests/Engine/ModuleDependencyHandler.tests.ps1
+++ b/Tests/Engine/ModuleDependencyHandler.tests.ps1
@@ -17,11 +17,11 @@ Describe "Resolve DSC Resource Dependency" {
         Function Test-EnvironmentVariables($oldEnv)
         {
             $newEnv = Get-Item Env:\* | Sort-Object -Property Key
-            $newEnv.Count | Should Be $oldEnv.Count
+            $newEnv.Count | Should -Be $oldEnv.Count
             foreach ($index in 1..$newEnv.Count)
             {
-                $newEnv[$index].Key | Should Be $oldEnv[$index].Key
-                $newEnv[$index].Value | Should Be $oldEnv[$index].Value
+                $newEnv[$index].Key | Should -Be $oldEnv[$index].Key
+                $newEnv[$index].Value | Should -Be $oldEnv[$index].Value
             }
         }
     }
@@ -43,19 +43,19 @@ Describe "Resolve DSC Resource Dependency" {
             $depHandler = $moduleHandlerType::new($rsp)
 
             $expectedPath = [System.IO.Path]::GetTempPath()
-            $depHandler.TempPath | Should Be $expectedPath
+            $depHandler.TempPath | Should -Be $expectedPath
 
             $expectedLocalAppDataPath = $env:LOCALAPPDATA
-            $depHandler.LocalAppDataPath | Should Be $expectedLocalAppDataPath
+            $depHandler.LocalAppDataPath | Should -Be $expectedLocalAppDataPath
 
             $expectedModuleRepository = "PSGallery"
-            $depHandler.ModuleRepository | Should Be $expectedModuleRepository
+            $depHandler.ModuleRepository | Should -Be $expectedModuleRepository
 
             $expectedPssaAppDataPath = Join-Path $depHandler.LocalAppDataPath "PSScriptAnalyzer"
-            $depHandler.PSSAAppDataPath | Should Be $expectedPssaAppDataPath
+            $depHandler.PSSAAppDataPath | Should -Be $expectedPssaAppDataPath
 
             $expectedPSModulePath = $oldPSModulePath + [System.IO.Path]::PathSeparator + $depHandler.TempModulePath
-            $env:PSModulePath | Should Be $expectedPSModulePath
+            $env:PSModulePath | Should -Be $expectedPSModulePath
 
             $depHandler.Dispose()
             $rsp.Dispose()
@@ -86,7 +86,7 @@ Describe "Resolve DSC Resource Dependency" {
             $parseError = $null
             $ast = [System.Management.Automation.Language.Parser]::ParseInput($sb, [ref]$tokens, [ref]$parseError)
             $resultModuleNames = $moduleHandlerType::GetModuleNameFromErrorExtent($parseError[0], $ast).ToArray()
-            $resultModuleNames[0] | Should Be 'SomeDscModule1'
+            $resultModuleNames[0] | Should -Be 'SomeDscModule1'
         }
 
         It "Extracts more than 1 module names" -skip:$skipTest {
@@ -100,9 +100,9 @@ Describe "Resolve DSC Resource Dependency" {
             $parseError = $null
             $ast = [System.Management.Automation.Language.Parser]::ParseInput($sb, [ref]$tokens, [ref]$parseError)
             $resultModuleNames = $moduleHandlerType::GetModuleNameFromErrorExtent($parseError[0], $ast).ToArray()
-            $resultModuleNames[0] | Should Be 'SomeDscModule1'
-            $resultModuleNames[1] | Should Be 'SomeDscModule2'
-            $resultModuleNames[2] | Should Be 'SomeDscModule3'
+            $resultModuleNames[0] | Should -Be 'SomeDscModule1'
+            $resultModuleNames[1] | Should -Be 'SomeDscModule2'
+            $resultModuleNames[2] | Should -Be 'SomeDscModule3'
         }
 
 
@@ -117,14 +117,14 @@ Describe "Resolve DSC Resource Dependency" {
             $parseError = $null
             $ast = [System.Management.Automation.Language.Parser]::ParseInput($sb, [ref]$tokens, [ref]$parseError)
             $resultModuleNames = $moduleHandlerType::GetModuleNameFromErrorExtent($parseError[0], $ast).ToArray()
-            $resultModuleNames[0] | Should Be 'SomeDscModule1'
+            $resultModuleNames[0] | Should -Be 'SomeDscModule1'
         }
     }
 
     Context "Invoke-ScriptAnalyzer without switch" {
         It "Has parse errors" -skip:$skipTest {
             $dr = Invoke-ScriptAnalyzer -Path $violationFilePath -ErrorVariable parseErrors -ErrorAction SilentlyContinue
-            $parseErrors.Count | Should Be 1
+            $parseErrors.Count | Should -Be 1
         }
     }
 
@@ -178,12 +178,12 @@ Describe "Resolve DSC Resource Dependency" {
         It "Doesn't have parse errors" -skip:$skipTest {
             # invoke script analyzer
             $dr = Invoke-ScriptAnalyzer -Path $violationFilePath -ErrorVariable parseErrors -ErrorAction SilentlyContinue
-            $dr.Count | Should Be 0
+            $dr.Count | Should -Be 0
         }
 
         It "Keeps PSModulePath unchanged before and after invocation" -skip:$skipTest {
             $dr = Invoke-ScriptAnalyzer -Path $violationFilePath -ErrorVariable parseErrors -ErrorAction SilentlyContinue
-            $env:PSModulePath | Should Be $oldPSModulePath
+            $env:PSModulePath | Should -Be $oldPSModulePath
         }
 
         It "Keeps the environment variables unchanged" -skip:$skipTest {

--- a/Tests/Engine/ModuleDependencyHandler.tests.ps1
+++ b/Tests/Engine/ModuleDependencyHandler.tests.ps1
@@ -66,12 +66,12 @@ Describe "Resolve DSC Resource Dependency" {
         }
 
         It "Throws if runspace is null" -skip:$skipTest {
-            {$moduleHandlerType::new($null)} | Should Throw
+            {$moduleHandlerType::new($null)} | Should -Throw
         }
 
         It "Throws if runspace is not opened" -skip:$skipTest {
             $rsp = [runspacefactory]::CreateRunspace()
-            {$moduleHandlerType::new($rsp)} | Should Throw
+            {$moduleHandlerType::new($rsp)} | Should -Throw
             $rsp.Dispose()
         }
 

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -245,20 +245,20 @@ foreach ($command in $commands) {
 		# If help is not found, synopsis in auto-generated help is the syntax diagram
 		It "should not be auto-generated" {
 			# Replace pester BeLike with powershell -like as pester 3.3.9 does not support BeLike
-			$Help.Synopsis -like '*`[`<CommonParameters`>`]*' | Should Be $false
+			$Help.Synopsis -like '*`[`<CommonParameters`>`]*' | Should -Be $false
 		}
 
-		# Should be a description for every function
+		# Should -Be a description for every function
 		It "gets description for $commandName" {
 			$Help.Description | Should Not BeNullOrEmpty
 		}
 
-		# Should be at least one example
+		# Should -Be at least one example
 		It "gets example code from $commandName" {
 			($Help.Examples.Example | Select-Object -First 1).Code | Should Not BeNullOrEmpty
 		}
 
-		# Should be at least one example description
+		# Should -Be at least one example description
 		It "gets example help from $commandName" {
 			($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should Not BeNullOrEmpty
 		}
@@ -282,17 +282,17 @@ foreach ($command in $commands) {
 				$parameterName = $parameter.Name
 				$parameterHelp = $Help.parameters.parameter | Where-Object Name -EQ $parameterName
 
-				# Should be a description for every parameter
+				# Should -Be a description for every parameter
 				It "gets help for parameter: $parameterName : in $commandName" {
 					# `$parameterHelp.Description.Text | Should Not BeNullOrEmpty` fails for -Settings paramter
 					# without explicit [string] casting on the Text property
-					[string]::IsNullOrEmpty($parameterHelp.Description.Text) | Should Be $false
+					[string]::IsNullOrEmpty($parameterHelp.Description.Text) | Should -Be $false
 				}
 
 				# Required value in Help should match IsMandatory property of parameter
 				It "help for $parameterName parameter in $commandName has correct Mandatory value" {
 					$codeMandatory = $parameter.IsMandatory.toString()
-					$parameterHelp.Required | Should Be $codeMandatory
+					$parameterHelp.Required | Should -Be $codeMandatory
 				}
 
 				# Parameter type in Help should match code
@@ -300,7 +300,7 @@ foreach ($command in $commands) {
 					$codeType = $parameter.ParameterType.Name
 					# To avoid calling Trim method on a null object.
 					$helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
-					$helpType | Should be $codeType
+					$helpType | Should -Be $codeType
 				}
 			}
 
@@ -310,7 +310,7 @@ foreach ($command in $commands) {
 				}
 				# Shouldn't find extra parameters in help.
 				It "finds help parameter in code: $helpParm" {
-					$helpParm -in $parameterNames | Should Be $true
+					$helpParm -in $parameterNames | Should -Be $true
 				}
 			}
 		}

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -248,17 +248,17 @@ foreach ($command in $commands) {
 			$Help.Synopsis -like '*`[`<CommonParameters`>`]*' | Should Be $false
 		}
 
-		# Should -Be a description for every function
+		# Should be a description for every function
 		It "gets description for $commandName" {
 			$Help.Description | Should -Not -BeNullOrEmpty
 		}
 
-		# Should -Be at least one example
+		# Should be at least one example
 		It "gets example code from $commandName" {
 			($Help.Examples.Example | Select-Object -First 1).Code | Should -Not -BeNullOrEmpty
 		}
 
-		# Should -Be at least one example description
+		# Should be at least one example description
 		It "gets example help from $commandName" {
 			($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should -Not -BeNullOrEmpty
 		}
@@ -282,20 +282,20 @@ foreach ($command in $commands) {
 				$parameterName = $parameter.Name
 				$parameterHelp = $Help.parameters.parameter | Where-Object Name -EQ $parameterName
 
-				# Should -Be a description for every parameter
+				# Should be a description for every parameter
 				It "gets help for parameter: $parameterName : in $commandName" {
 					# `$parameterHelp.Description.Text | Should -Not -BeNullOrEmpty` fails for -Settings paramter
 					# without explicit [string] casting on the Text property
 					$parameterHelp.Description.Text | Should -Not -BeNullOrEmpty
 				}
 
-				# Required value in Help Should -Match IsMandatory property of parameter
+				# Required value in Help should match IsMandatory property of parameter
 				It "help for $parameterName parameter in $commandName has correct Mandatory value" {
 					$codeMandatory = $parameter.IsMandatory.toString()
 					$parameterHelp.Required | Should -Be $codeMandatory
 				}
 
-				# Parameter type in Help Should -Match code
+				# Parameter type in Help should match code
 				It "help for $commandName has correct parameter type for $parameterName" {
 					$codeType = $parameter.ParameterType.Name
 					# To avoid calling Trim method on a null object.

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -244,7 +244,8 @@ foreach ($command in $commands) {
 
 		# If help is not found, synopsis in auto-generated help is the syntax diagram
 		It "should not be auto-generated" {
-			$Help.Synopsis | Should -Not -Be '*`[`<CommonParameters`>`]*'
+			# Replace pester BeLike with powershell -like as pester 3.3.9 does not support BeLike
+			$Help.Synopsis -like '*`[`<CommonParameters`>`]*' | Should Be $false
 		}
 
 		# Should -Be a description for every function

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -255,12 +255,12 @@ foreach ($command in $commands) {
 
 		# Should -Be at least one example
 		It "gets example code from $commandName" {
-			($Help.Examples.Example | Select-Object -First 1).Code | Should Not BeNullOrEmpty
+			($Help.Examples.Example | Select-Object -First 1).Code | Should -Not BeNullOrEmpty
 		}
 
 		# Should -Be at least one example description
 		It "gets example help from $commandName" {
-			($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should Not BeNullOrEmpty
+			($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should -Not BeNullOrEmpty
 		}
 
 		Context "Test parameter help for $commandName" {
@@ -284,7 +284,7 @@ foreach ($command in $commands) {
 
 				# Should -Be a description for every parameter
 				It "gets help for parameter: $parameterName : in $commandName" {
-					# `$parameterHelp.Description.Text | Should Not BeNullOrEmpty` fails for -Settings paramter
+					# `$parameterHelp.Description.Text | Should -Not BeNullOrEmpty` fails for -Settings paramter
 					# without explicit [string] casting on the Text property
 					[string]::IsNullOrEmpty($parameterHelp.Description.Text) | Should -Be $false
 				}

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -244,23 +244,22 @@ foreach ($command in $commands) {
 
 		# If help is not found, synopsis in auto-generated help is the syntax diagram
 		It "should not be auto-generated" {
-			# Replace pester BeLike with powershell -like as pester 3.3.9 does not support BeLike
-			$Help.Synopsis -like '*`[`<CommonParameters`>`]*' | Should -Be $false
+			$Help.Synopsis | Should -Not -Be '*`[`<CommonParameters`>`]*'
 		}
 
 		# Should -Be a description for every function
 		It "gets description for $commandName" {
-			$Help.Description | Should Not BeNullOrEmpty
+			$Help.Description | Should -Not -BeNullOrEmpty
 		}
 
 		# Should -Be at least one example
 		It "gets example code from $commandName" {
-			($Help.Examples.Example | Select-Object -First 1).Code | Should -Not BeNullOrEmpty
+			($Help.Examples.Example | Select-Object -First 1).Code | Should -Not -BeNullOrEmpty
 		}
 
 		# Should -Be at least one example description
 		It "gets example help from $commandName" {
-			($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should -Not BeNullOrEmpty
+			($Help.Examples.Example.Remarks | Select-Object -First 1).Text | Should -Not -BeNullOrEmpty
 		}
 
 		Context "Test parameter help for $commandName" {
@@ -284,9 +283,9 @@ foreach ($command in $commands) {
 
 				# Should -Be a description for every parameter
 				It "gets help for parameter: $parameterName : in $commandName" {
-					# `$parameterHelp.Description.Text | Should -Not BeNullOrEmpty` fails for -Settings paramter
+					# `$parameterHelp.Description.Text | Should -Not -BeNullOrEmpty` fails for -Settings paramter
 					# without explicit [string] casting on the Text property
-					[string]::IsNullOrEmpty($parameterHelp.Description.Text) | Should -Be $false
+					$parameterHelp.Description.Text | Should -Not -BeNullOrEmpty
 				}
 
 				# Required value in Help should match IsMandatory property of parameter

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -288,13 +288,13 @@ foreach ($command in $commands) {
 					$parameterHelp.Description.Text | Should -Not -BeNullOrEmpty
 				}
 
-				# Required value in Help should match IsMandatory property of parameter
+				# Required value in Help Should -Match IsMandatory property of parameter
 				It "help for $parameterName parameter in $commandName has correct Mandatory value" {
 					$codeMandatory = $parameter.IsMandatory.toString()
 					$parameterHelp.Required | Should -Be $codeMandatory
 				}
 
-				# Parameter type in Help should match code
+				# Parameter type in Help Should -Match code
 				It "help for $commandName has correct parameter type for $parameterName" {
 					$codeType = $parameter.ParameterType.Name
 					# To avoid calling Trim method on a null object.

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -52,9 +52,9 @@ Describe "RuleSuppressionWithoutScope" {
     Context "Function" {
         It "Does not raise violations" {
             $suppression = $violations | Where-Object { $_.RuleName -eq "PSProvideCommentHelp" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object { $_.RuleName -eq "PSProvideCommentHelp" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
         }
 
         It "Suppresses rule with extent created using ScriptExtent constructor" {
@@ -63,7 +63,7 @@ Describe "RuleSuppressionWithoutScope" {
               -IncludeRule "PSAvoidUsingUserNameAndPassWordParams" `
               -OutVariable ruleViolations `
               -SuppressedOnly
-            $ruleViolations.Count | Should Be 1
+            $ruleViolations.Count | Should -Be 1
 	    }
 
     }
@@ -71,18 +71,18 @@ Describe "RuleSuppressionWithoutScope" {
     Context "Script" {
         It "Does not raise violations" {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSProvideCommentHelp" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSProvideCommentHelp" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
         }
     }
 
     Context "RuleSuppressionID" {
         It "Only suppress violations for that ID" {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidDefaultValueForMandatoryParameter" }
-            $suppression.Count | Should Be 1
+            $suppression.Count | Should -Be 1
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidDefaultValueForMandatoryParameter" }
-            $suppression.Count | Should Be 1
+            $suppression.Count | Should -Be 1
         }
 
         It "Suppresses PSAvoidUsingPlainTextForPassword violation for the given ID" {
@@ -101,14 +101,14 @@ function SuppressPwdParam()
               -IncludeRule "PSAvoidUsingPlainTextForPassword" `
               -OutVariable ruleViolations `
               -SuppressedOnly
-            $ruleViolations.Count | Should Be 1
+            $ruleViolations.Count | Should -Be 1
         }
     }
 
     Context "Rule suppression within DSC Configuration definition" {
         It "Suppresses rule" -skip:((!$IsWindows) -or ($PSVersionTable.PSVersion.Major -lt 5)) {
             $suppressedRule = Invoke-ScriptAnalyzer -ScriptDefinition $ruleSuppressionInConfiguration -SuppressedOnly
-            $suppressedRule.Count | Should Be 1
+            $suppressedRule.Count | Should -Be 1
         }
     }
 
@@ -117,7 +117,7 @@ function SuppressPwdParam()
         Context "Bad Rule Suppression" {
             It "Throws a non-terminating error" {
                 Invoke-ScriptAnalyzer -ScriptDefinition $ruleSuppressionBad -IncludeRule "PSAvoidUsingUserNameAndPassWordParams" -ErrorVariable errorRecord -ErrorAction SilentlyContinue
-                $errorRecord.Count | Should Be 1
+                $errorRecord.Count | Should -Be 1
                 $errorRecord.FullyQualifiedErrorId | Should match "suppression message attribute error"
             }
         }
@@ -134,7 +134,7 @@ Write-Host "write-host"
                     -CustomRulePath (Join-Path $directory "CommunityAnalyzerRules") `
                     -OutVariable ruleViolations `
                     -SuppressedOnly
-                $ruleViolations.Count | Should Be 1
+                $ruleViolations.Count | Should -Be 1
             }
         }
     }
@@ -144,9 +144,9 @@ Describe "RuleSuppressionWithScope" {
     Context "FunctionScope" {
         It "Does not raise violations" {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidUsingPositionalParameters" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidUsingPositionalParameters" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
         }
     }
 
@@ -172,7 +172,7 @@ Describe "RuleSuppressionWithScope" {
             }
 '@
             $suppressed = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule 'PSAvoidUsingWriteHost' -SuppressedOnly
-            $suppressed.Count | Should Be 2
+            $suppressed.Count | Should -Be 2
         }
 
         It "suppresses objects that match glob pattern with glob in the end" {
@@ -192,7 +192,7 @@ Describe "RuleSuppressionWithScope" {
             }
 '@
             $suppressed = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule 'PSAvoidUsingWriteHost' -SuppressedOnly
-            $suppressed.Count | Should Be 2
+            $suppressed.Count | Should -Be 2
         }
 
         It "suppresses objects that match glob pattern with glob in the begining" {
@@ -212,7 +212,7 @@ Describe "RuleSuppressionWithScope" {
             }
 '@
             $suppressed = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule 'PSAvoidUsingWriteHost' -SuppressedOnly
-            $suppressed.Count | Should Be 1
+            $suppressed.Count | Should -Be 1
         }
     }
  }

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -118,7 +118,7 @@ function SuppressPwdParam()
             It "Throws a non-terminating error" {
                 Invoke-ScriptAnalyzer -ScriptDefinition $ruleSuppressionBad -IncludeRule "PSAvoidUsingUserNameAndPassWordParams" -ErrorVariable errorRecord -ErrorAction SilentlyContinue
                 $errorRecord.Count | Should -Be 1
-                $errorRecord.FullyQualifiedErrorId | Should match "suppression message attribute error"
+                $errorRecord.FullyQualifiedErrorId | Should -Match "suppression message attribute error"
             }
         }
 

--- a/Tests/Engine/RuleSuppressionClass.tests.ps1
+++ b/Tests/Engine/RuleSuppressionClass.tests.ps1
@@ -17,36 +17,36 @@ Describe "RuleSuppressionWithoutScope" {
     Context "Class" {
         It "Does not raise violations" {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidUsingInvokeExpression" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidUsingInvokeExpression" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
         }
     }
 
     Context "FunctionInClass" {
         It "Does not raise violations" {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidUsingCmdletAliases" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidUsingCmdletAliases" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
         }        
     }
 
     Context "Script" {
         It "Does not raise violations" {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSProvideCommentHelp" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSProvideCommentHelp" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
         }
     }
 
     Context "RuleSuppressionID" {
         It "Only suppress violations for that ID" {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidDefaultValueForMandatoryParameter" }
-            $suppression.Count | Should Be 1
+            $suppression.Count | Should -Be 1
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidDefaultValueForMandatoryParameter" }
-            $suppression.Count | Should Be 1
+            $suppression.Count | Should -Be 1
         }
     }
 }
@@ -55,18 +55,18 @@ Describe "RuleSuppressionWithScope" {
     Context "FunctionScope" {
         It "Does not raise violations" {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidUsingPositionalParameters" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidUsingPositionalParameters" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
         }
     }
 
     Context "ClassScope" {
         It "Does not raise violations" {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidUsingConvertToSecureStringWithPlainText" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidUsingConvertToSecureStringWithPlainText" }
-            $suppression.Count | Should Be 0
+            $suppression.Count | Should -Be 0
         }
     }
   }

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -13,20 +13,20 @@ Describe "Settings Precedence" {
         It "runs rules from the explicit setting file" {
             $settingsFilepath = [System.IO.Path]::Combine($project1Root, "ExplicitSettings.psd1")
             $violations = Invoke-ScriptAnalyzer -Path $project1Root -Settings $settingsFilepath -Recurse
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
     }
 
     Context "settings file is implicit" {
         It "runs rules from the implicit setting file" {
             $violations = Invoke-ScriptAnalyzer -Path $project1Root -Recurse
-            $violations.Count | Should Be 1
-            $violations[0].RuleName | Should Be "PSAvoidUsingCmdletAliases"
+            $violations.Count | Should -Be 1
+            $violations[0].RuleName | Should -Be "PSAvoidUsingCmdletAliases"
         }
 
         It "cannot find file if not named PSScriptAnalyzerSettings.psd1" {
             $violations = Invoke-ScriptAnalyzer -Path $project2Root -Recurse
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
     }
 }
@@ -39,7 +39,7 @@ Describe "Settings Class" {
 
         'IncludeRules', 'ExcludeRules', 'Severity', 'RuleArguments' | ForEach-Object {
             It ("Should return empty {0} property" -f $_) {
-                $settings.${$_}.Count | Should Be 0
+                $settings.${$_}.Count | Should -Be 0
             }
         }
     }
@@ -51,11 +51,11 @@ Describe "Settings Class" {
         }
 
         It "Should return an IncludeRules array with 1 element" {
-            $settings.IncludeRules.Count | Should Be 1
+            $settings.IncludeRules.Count | Should -Be 1
         }
 
         It "Should return the rule in the IncludeRules array" {
-            $settings.IncludeRules[0] | Should Be $ruleName
+            $settings.IncludeRules[0] | Should -Be $ruleName
         }
     }
 
@@ -72,15 +72,15 @@ Describe "Settings Class" {
         }
 
         It "Should return the rule arguments" {
-            $settings.RuleArguments["PSAvoidUsingCmdletAliases"]["WhiteList"].Count | Should Be 2
-            $settings.RuleArguments["PSAvoidUsingCmdletAliases"]["WhiteList"][0] | Should Be "cd"
-            $settings.RuleArguments["PSAvoidUsingCmdletAliases"]["WhiteList"][1] | Should Be "cp"
+            $settings.RuleArguments["PSAvoidUsingCmdletAliases"]["WhiteList"].Count | Should -Be 2
+            $settings.RuleArguments["PSAvoidUsingCmdletAliases"]["WhiteList"][0] | Should -Be "cd"
+            $settings.RuleArguments["PSAvoidUsingCmdletAliases"]["WhiteList"][1] | Should -Be "cp"
         }
 
-        It "Should be case insensitive" {
-            $settings.RuleArguments["psAvoidUsingCmdletAliases"]["whiteList"].Count | Should Be 2
-            $settings.RuleArguments["psAvoidUsingCmdletAliases"]["whiteList"][0] | Should Be "cd"
-            $settings.RuleArguments["psAvoidUsingCmdletAliases"]["whiteList"][1] | Should Be "cp"
+        It "Should -Be case insensitive" {
+            $settings.RuleArguments["psAvoidUsingCmdletAliases"]["whiteList"].Count | Should -Be 2
+            $settings.RuleArguments["psAvoidUsingCmdletAliases"]["whiteList"][0] | Should -Be "cd"
+            $settings.RuleArguments["psAvoidUsingCmdletAliases"]["whiteList"][1] | Should -Be "cp"
         }
     }
 
@@ -91,27 +91,27 @@ Describe "Settings Class" {
         }
 
         It "Should return 2 IncludeRules" {
-            $settings.IncludeRules.Count | Should Be 3
+            $settings.IncludeRules.Count | Should -Be 3
         }
 
         It "Should return 2 ExcludeRules" {
-            $settings.ExcludeRules.Count | Should Be 3
+            $settings.ExcludeRules.Count | Should -Be 3
         }
 
         It "Should return 1 rule argument" {
-            $settings.RuleArguments.Count | Should Be 3
+            $settings.RuleArguments.Count | Should -Be 3
         }
 
         It "Should parse boolean type argument" {
-            $settings.RuleArguments["PSUseConsistentIndentation"]["Enable"] | Should Be $true
+            $settings.RuleArguments["PSUseConsistentIndentation"]["Enable"] | Should -Be $true
         }
 
         It "Should parse int type argument" {
-            $settings.RuleArguments["PSUseConsistentIndentation"]["IndentationSize"] | Should Be 4
+            $settings.RuleArguments["PSUseConsistentIndentation"]["IndentationSize"] | Should -Be 4
         }
 
         It "Should parse string literal" {
-            $settings.RuleArguments["PSProvideCommentHelp"]["Placement"] | Should Be 'end'
+            $settings.RuleArguments["PSProvideCommentHelp"]["Placement"] | Should -Be 'end'
         }
     }
 
@@ -123,8 +123,8 @@ Describe "Settings Class" {
             }
 
             $settings = New-Object -TypeName $settingsTypeName  -ArgumentList $settingsHashtable
-            $settings.CustomRulePath.Count | Should Be 1
-            $settings.CustomRulePath[0] | Should be $rulePath
+            $settings.CustomRulePath.Count | Should -Be 1
+            $settings.CustomRulePath[0] | Should -Be $rulePath
         }
 
         It "Should return an array of n items when n items are given in a hashtable" {
@@ -134,15 +134,15 @@ Describe "Settings Class" {
             }
 
             $settings = New-Object -TypeName $settingsTypeName  -ArgumentList $settingsHashtable
-            $settings.CustomRulePath.Count | Should Be $rulePaths.Count
-            0..($rulePaths.Count - 1) | ForEach-Object { $settings.CustomRulePath[$_] | Should be $rulePaths[$_] }
+            $settings.CustomRulePath.Count | Should -Be $rulePaths.Count
+            0..($rulePaths.Count - 1) | ForEach-Object { $settings.CustomRulePath[$_] | Should -Be $rulePaths[$_] }
 
         }
 
         It "Should detect the parameter in a settings file" {
             $settings = New-Object -TypeName $settingsTypeName `
                               -ArgumentList ([System.IO.Path]::Combine($project1Root, "CustomRulePathSettings.psd1"))
-            $settings.CustomRulePath.Count | Should Be 2
+            $settings.CustomRulePath.Count | Should -Be 2
         }
     }
 
@@ -154,7 +154,7 @@ Describe "Settings Class" {
                 $settingsHashtable.Add($paramName, $true)
 
                 $settings = New-Object -TypeName $settingsTypeName -ArgumentList $settingsHashtable
-                $settings."$paramName" | Should Be $true
+                $settings."$paramName" | Should -Be $true
             }
 
             It "Should correctly set the value if a boolean is given - false" {
@@ -162,7 +162,7 @@ Describe "Settings Class" {
                 $settingsHashtable.Add($paramName, $false)
 
                 $settings = New-Object -TypeName $settingsTypeName -ArgumentList $settingsHashtable
-                $settings."$paramName" | Should Be $false
+                $settings."$paramName" | Should -Be $false
             }
 
             It "Should throw if a non-boolean value is given" {
@@ -175,7 +175,7 @@ Describe "Settings Class" {
             It "Should detect the parameter in a settings file" {
                 $settings = New-Object -TypeName $settingsTypeName `
                     -ArgumentList ([System.IO.Path]::Combine($project1Root, "CustomRulePathSettings.psd1"))
-                $settings."$paramName" | Should Be $true
+                $settings."$paramName" | Should -Be $true
             }
         }
     }

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -165,11 +165,11 @@ Describe "Settings Class" {
                 $settings."$paramName" | Should -Be $false
             }
 
-            It "Should throw if a non-boolean value is given" {
+            It "Should -Throw if a non-boolean value is given" {
                 $settingsHashtable = @{}
                 $settingsHashtable.Add($paramName, "some random string")
 
-                { New-Object -TypeName $settingsTypeName -ArgumentList $settingsHashtable } | Should Throw
+                { New-Object -TypeName $settingsTypeName -ArgumentList $settingsHashtable } | Should -Throw
             }
 
             It "Should detect the parameter in a settings file" {

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -43,6 +43,8 @@ Describe "Settings Class" {
             @{ Name = "Severity" }
             @{ Name = "RuleArguments" }
         ) {
+            Param($Name)
+
             ${settings}.${Name}.Count | Should -Be 0
         }
     }

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -37,10 +37,13 @@ Describe "Settings Class" {
             $settings = New-Object -TypeName $settingsTypeName -ArgumentList @{}
         }
 
-        'IncludeRules', 'ExcludeRules', 'Severity', 'RuleArguments' | ForEach-Object {
-            It ("Should return empty {0} property" -f $_) {
-                $settings.${$_}.Count | Should -Be 0
-            }
+        It "Should return empty <name> property" -TestCases @(
+            @{ Name = "IncludeRules" }
+            @{ Name = "ExcludeRules" }
+            @{ Name = "Severity" }
+            @{ Name = "RuleArguments" }
+        ) {
+            ${settings}.${Name}.Count | Should -Be 0
         }
     }
 
@@ -90,15 +93,18 @@ Describe "Settings Class" {
                               -ArgumentList ([System.IO.Path]::Combine($project1Root, "ExplicitSettings.psd1"))
         }
 
-        It "Should return 2 IncludeRules" {
-            $settings.IncludeRules.Count | Should -Be 3
+        $expectedNumberOfIncludeRules = 3
+        It "Should return $expectedNumberOfIncludeRules IncludeRules" {
+            $settings.IncludeRules.Count | Should -Be $expectedNumberOfIncludeRules
+        }
+        
+        $expectedNumberOfExcludeRules = 3
+        It "Should return $expectedNumberOfExcludeRules ExcludeRules" {
+            $settings.ExcludeRules.Count | Should -Be $expectedNumberOfExcludeRules
         }
 
-        It "Should return 2 ExcludeRules" {
-            $settings.ExcludeRules.Count | Should -Be 3
-        }
-
-        It "Should return 1 rule argument" {
+        $expectedNumberOfRuleArguments = 3
+        It "Should return $expectedNumberOfRuleArguments rule argument" {
             $settings.RuleArguments.Count | Should -Be 3
         }
 

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -77,7 +77,7 @@ Describe "Settings Class" {
             $settings.RuleArguments["PSAvoidUsingCmdletAliases"]["WhiteList"][1] | Should -Be "cp"
         }
 
-        It "Should -Be case insensitive" {
+        It "Should Be case insensitive" {
             $settings.RuleArguments["psAvoidUsingCmdletAliases"]["whiteList"].Count | Should -Be 2
             $settings.RuleArguments["psAvoidUsingCmdletAliases"]["whiteList"][0] | Should -Be "cd"
             $settings.RuleArguments["psAvoidUsingCmdletAliases"]["whiteList"][1] | Should -Be "cp"
@@ -165,7 +165,7 @@ Describe "Settings Class" {
                 $settings."$paramName" | Should -Be $false
             }
 
-            It "Should -Throw if a non-boolean value is given" {
+            It "Should Throw if a non-boolean value is given" {
                 $settingsHashtable = @{}
                 $settingsHashtable.Add($paramName, "some random string")
 

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -165,7 +165,7 @@ Describe "Settings Class" {
                 $settings."$paramName" | Should -Be $false
             }
 
-            It "Should Throw if a non-boolean value is given" {
+            It "Should throw if a non-boolean value is given" {
                 $settingsHashtable = @{}
                 $settingsHashtable.Add($paramName, "some random string")
 

--- a/Tests/Engine/SettingsTest/Issue828/Issue828.tests.ps1
+++ b/Tests/Engine/SettingsTest/Issue828/Issue828.tests.ps1
@@ -22,6 +22,6 @@ Describe "Issue 828: No NullReferenceExceptionin AlignAssignmentStatement rule w
             Set-Location $initialLocation
         }
         
-        $cmdletThrewError | Should Be $false
+        $cmdletThrewError | Should -Be $false
     }
 }

--- a/Tests/Engine/TextEdit.tests.ps1
+++ b/Tests/Engine/TextEdit.tests.ps1
@@ -6,11 +6,11 @@ Describe "TextEdit Class" {
     Context "Object construction" {
         It "creates the object with correct properties" {
             $correctionExtent = New-Object -TypeName $type -ArgumentList 1, 2, 3, 4, "get-childitem"
-			$correctionExtent.StartLineNumber | Should Be 1
-            $correctionExtent.EndLineNumber | Should Be 3
-            $correctionExtent.StartColumnNumber | Should Be 2
-            $correctionExtent.EndColumnNumber | Should be 4
-            $correctionExtent.Text | Should Be "get-childitem"
+			$correctionExtent.StartLineNumber | Should -Be 1
+            $correctionExtent.EndLineNumber | Should -Be 3
+            $correctionExtent.StartColumnNumber | Should -Be 2
+            $correctionExtent.EndColumnNumber | Should -Be 4
+            $correctionExtent.Text | Should -Be "get-childitem"
         }
 
         It "throws if end line number is less than start line number" {

--- a/Tests/Engine/TextEdit.tests.ps1
+++ b/Tests/Engine/TextEdit.tests.ps1
@@ -16,13 +16,13 @@ Describe "TextEdit Class" {
         It "throws if end line number is less than start line number" {
             $text = "Get-ChildItem"
             {New-Object -TypeName $type -ArgumentList @(2, 1, 1, ($text.Length + 1), $text)} |
-                Should Throw
+                Should -Throw
         }
 
         It "throws if end column number is less than start column number for same line" {
             $text = "start-process"
             {New-Object -TypeName $type -ArgumentList @(1, 2, 1, 1, $text)} |
-                    Should Throw
+                    Should -Throw
             }
         }
     }

--- a/Tests/Engine/TextEdit.tests.ps1
+++ b/Tests/Engine/TextEdit.tests.ps1
@@ -6,7 +6,7 @@ Describe "TextEdit Class" {
     Context "Object construction" {
         It "creates the object with correct properties" {
             $correctionExtent = New-Object -TypeName $type -ArgumentList 1, 2, 3, 4, "get-childitem"
-			$correctionExtent.StartLineNumber | Should -Be 1
+            $correctionExtent.StartLineNumber | Should -Be 1
             $correctionExtent.EndLineNumber | Should -Be 3
             $correctionExtent.StartColumnNumber | Should -Be 2
             $correctionExtent.EndColumnNumber | Should -Be 4

--- a/Tests/PSScriptAnalyzerTestHelper.psm1
+++ b/Tests/PSScriptAnalyzerTestHelper.psm1
@@ -45,10 +45,10 @@ Function Test-CorrectionExtentFromContent {
     )
 
 	$corrections = $diagnosticRecord.SuggestedCorrections
-	$corrections.Count | Should Be $correctionsCount
-	$corrections[0].Text | Should Be $correctionText
+	$corrections.Count | Should -Be $correctionsCount
+	$corrections[0].Text | Should -Be $correctionText
 	Get-ExtentTextFromContent $corrections[0] $rawContent | `
-		       Should Be $violationText
+		       Should -Be $violationText
 }
 
 Function Test-PSEditionCoreCLR

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -26,14 +26,14 @@ $hashtable = @{
 }
 '@
 
-            # Expected output after correction should be the following
+            # Expected output after correction Should -Be the following
             # $hashtable = @{
             #     property1       = "value"
             #     anotherProperty = "another value"
             # }
 
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
             Test-CorrectionExtentFromContent $def $violations 1 ' ' '       '
         }
 
@@ -45,14 +45,14 @@ $hashtable = @{
 }
 '@
 
-            # Expected output should be the following
+            # Expected output Should -Be the following
             # $hashtable = @{
             #     property1       = "value"
             #     anotherProperty = "another value"
             # }
 
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
             Test-CorrectionExtentFromContent $def $violations 1 '              ' '       '
         }
 
@@ -60,7 +60,7 @@ $hashtable = @{
             $def = @'
 $x = @{ }
 '@
-            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Get-Count | Should Be 0
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Get-Count | Should -Be 0
 
         }
     }
@@ -85,7 +85,7 @@ Configuration MyDscConfiguration {
     }
 }
 '@
-            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Get-Count | Should Be 2
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Get-Count | Should -Be 2
         }
     }
 
@@ -118,7 +118,7 @@ Configuration Sample_ChangeDescriptionAndPermissions
                 # SilentlyContinue
                 Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings -ErrorAction SilentlyContinue |
                     Get-Count |
-                    Should Be 4
+                    Should -Be 4
             }
         }
     }

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -26,7 +26,7 @@ $hashtable = @{
 }
 '@
 
-            # Expected output after correction Should -Be the following
+            # Expected output after correction Should Be the following
             # $hashtable = @{
             #     property1       = "value"
             #     anotherProperty = "another value"

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -26,7 +26,7 @@ $hashtable = @{
 }
 '@
 
-            # Expected output after correction Should Be the following
+            # Expected output after correction should be the following
             # $hashtable = @{
             #     property1       = "value"
             #     anotherProperty = "another value"
@@ -45,7 +45,7 @@ $hashtable = @{
 }
 '@
 
-            # Expected output Should -Be the following
+            # Expected output should be the following
             # $hashtable = @{
             #     property1       = "value"
             #     anotherProperty = "another value"

--- a/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
+++ b/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
@@ -26,29 +26,29 @@ Describe "AvoidAssignmentToAutomaticVariables" {
             param ($VariableName)
 
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "`$${VariableName} = 'foo'" | Where-Object { $_.RuleName -eq $ruleName }
-            $warnings.Count | Should Be 1
-            $warnings.Severity | Should Be $readOnlyVariableSeverity
+            $warnings.Count | Should -Be 1
+            $warnings.Severity | Should -Be $readOnlyVariableSeverity
         }
 
         It "Using Variable '<VariableName>' as parameter name produces warning of severity error" -TestCases $testCases_ReadOnlyVariables {
             param ($VariableName)
 
             [System.Array] $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "function foo{Param(`$$VariableName)}" | Where-Object {$_.RuleName -eq $ruleName }
-            $warnings.Count | Should Be 1
-            $warnings.Severity | Should Be $readOnlyVariableSeverity
+            $warnings.Count | Should -Be 1
+            $warnings.Severity | Should -Be $readOnlyVariableSeverity
         }
 
         It "Using Variable '<VariableName>' as parameter name in param block produces warning of severity error" -TestCases $testCases_ReadOnlyVariables {
             param ($VariableName)
 
             [System.Array] $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "function foo(`$$VariableName){}" | Where-Object {$_.RuleName -eq $ruleName }
-            $warnings.Count | Should Be 1
-            $warnings.Severity | Should Be $readOnlyVariableSeverity
+            $warnings.Count | Should -Be 1
+            $warnings.Severity | Should -Be $readOnlyVariableSeverity
         }
 
         It "Does not flag parameter attributes" {
             [System.Array] $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'function foo{Param([Parameter(Mandatory=$true)]$param1)}' | Where-Object { $_.RuleName -eq $ruleName }
-            $warnings.Count | Should Be 0
+            $warnings.Count | Should -Be 0
         }
 
         It "Setting Variable '<VariableName>' throws exception to verify the variables is read-only" -TestCases $testCases_ReadOnlyVariables {
@@ -65,7 +65,7 @@ Describe "AvoidAssignmentToAutomaticVariables" {
                 }
                 catch
                 {
-                    $_.FullyQualifiedErrorId | Should Be 'VariableNotWritable,Microsoft.PowerShell.Commands.SetVariableCommand'
+                    $_.FullyQualifiedErrorId | Should -Be 'VariableNotWritable,Microsoft.PowerShell.Commands.SetVariableCommand'
                 }
             }
         }

--- a/Tests/Rules/AvoidConvertToSecureStringWithPlainText.tests.ps1
+++ b/Tests/Rules/AvoidConvertToSecureStringWithPlainText.tests.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module PSScriptAnalyzer
 Set-Alias ctss ConvertTo-SecureString
-$violationMessage = "File 'AvoidConvertToSecureStringWithPlainText.ps1' uses ConvertTo-SecureString with plaintext. This will expose secure information. Encrypted standard strings Should -Be used instead."
+$violationMessage = "File 'AvoidConvertToSecureStringWithPlainText.ps1' uses ConvertTo-SecureString with plaintext. This will expose secure information. Encrypted standard strings Should be used instead."
 $violationName = "PSAvoidUsingConvertToSecureStringWithPlainText"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidConvertToSecureStringWithPlainText.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidConvertToSecureStringWithPlainText.tests.ps1
+++ b/Tests/Rules/AvoidConvertToSecureStringWithPlainText.tests.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module PSScriptAnalyzer
 Set-Alias ctss ConvertTo-SecureString
-$violationMessage = "File 'AvoidConvertToSecureStringWithPlainText.ps1' uses ConvertTo-SecureString with plaintext. This will expose secure information. Encrypted standard strings Should be used instead."
+$violationMessage = "File 'AvoidConvertToSecureStringWithPlainText.ps1' uses ConvertTo-SecureString with plaintext. This will expose secure information. Encrypted standard strings should be used instead."
 $violationName = "PSAvoidUsingConvertToSecureStringWithPlainText"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidConvertToSecureStringWithPlainText.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidConvertToSecureStringWithPlainText.tests.ps1
+++ b/Tests/Rules/AvoidConvertToSecureStringWithPlainText.tests.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module PSScriptAnalyzer
 Set-Alias ctss ConvertTo-SecureString
-$violationMessage = "File 'AvoidConvertToSecureStringWithPlainText.ps1' uses ConvertTo-SecureString with plaintext. This will expose secure information. Encrypted standard strings should be used instead."
+$violationMessage = "File 'AvoidConvertToSecureStringWithPlainText.ps1' uses ConvertTo-SecureString with plaintext. This will expose secure information. Encrypted standard strings Should -Be used instead."
 $violationName = "PSAvoidUsingConvertToSecureStringWithPlainText"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidConvertToSecureStringWithPlainText.ps1 | Where-Object {$_.RuleName -eq $violationName}
@@ -9,7 +9,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidConvertToSecureStringWithP
 Describe "AvoidConvertToSecureStringWithPlainText" {
     Context "When there are violations" {
         It "has 3 ConvertTo-SecureString violations" {
-            $violations.Count | Should Be 3
+            $violations.Count | Should -Be 3
         }
 
         It "has the correct description message" {
@@ -19,7 +19,7 @@ Describe "AvoidConvertToSecureStringWithPlainText" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidConvertToSecureStringWithPlainText.tests.ps1
+++ b/Tests/Rules/AvoidConvertToSecureStringWithPlainText.tests.ps1
@@ -13,7 +13,7 @@ Describe "AvoidConvertToSecureStringWithPlainText" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/AvoidDefaultTrueValueSwitchParameter.tests.ps1
+++ b/Tests/Rules/AvoidDefaultTrueValueSwitchParameter.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidDefaultTrueValueSwitchPara
 Describe "AvoidDefaultTrueValueSwitchParameter" {
     Context "When there are violations" {
         It "has 2 avoid using switch parameter default to true violation" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "AvoidDefaultTrueValueSwitchParameter" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidDefaultTrueValueSwitchParameter.tests.ps1
+++ b/Tests/Rules/AvoidDefaultTrueValueSwitchParameter.tests.ps1
@@ -12,7 +12,7 @@ Describe "AvoidDefaultTrueValueSwitchParameter" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/AvoidDefaultValueForMandatoryParameter.tests.ps1
+++ b/Tests/Rules/AvoidDefaultValueForMandatoryParameter.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer "$directory\AvoidDefaultValueForMandatoryP
 Describe "AvoidDefaultValueForMandatoryParameter" {
     Context "When there are violations" {
         It "has 1 provide default value for mandatory parameter violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "AvoidDefaultValueForMandatoryParameter" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidDefaultValueForMandatoryParameter.tests.ps1
+++ b/Tests/Rules/AvoidDefaultValueForMandatoryParameter.tests.ps1
@@ -12,7 +12,7 @@ Describe "AvoidDefaultValueForMandatoryParameter" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/AvoidEmptyCatchBlock.tests.ps1
+++ b/Tests/Rules/AvoidEmptyCatchBlock.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidEmptyCatchBlockNoViolation
 Describe "UseDeclaredVarsMoreThanAssignments" {
     Context "When there are violations" {
         It "has 2 avoid using empty Catch block violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -19,7 +19,7 @@ Describe "UseDeclaredVarsMoreThanAssignments" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidEmptyCatchBlock.tests.ps1
+++ b/Tests/Rules/AvoidEmptyCatchBlock.tests.ps1
@@ -12,7 +12,7 @@ Describe "UseDeclaredVarsMoreThanAssignments" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
 
     }

--- a/Tests/Rules/AvoidGlobalAliases.tests.ps1
+++ b/Tests/Rules/AvoidGlobalAliases.tests.ps1
@@ -12,7 +12,7 @@ $IsV3OrV4 = (Test-PSVersionV3) -or (Test-PSVersionV4)
 Describe "$violationName " {
     Context "When there are violations" {
         It "Has 4 avoid global alias violations" -Skip:$IsV3OrV4 {
-            $violations.Count | Should Be 4
+            $violations.Count | Should -Be 4
         }
 
         It "Has the correct description message" -Skip:$IsV3OrV4 {
@@ -22,7 +22,7 @@ Describe "$violationName " {
 
     Context "When there are no violations" {
         It "Returns no violations" -Skip:$IsV3OrV4 {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidGlobalAliases.tests.ps1
+++ b/Tests/Rules/AvoidGlobalAliases.tests.ps1
@@ -16,7 +16,7 @@ Describe "$violationName " {
         }
 
         It "Has the correct description message" -Skip:$IsV3OrV4 {
-            $violations[0].Message | Should Match $AvoidGlobalAliasesError
+            $violations[0].Message | Should -Match $AvoidGlobalAliasesError
         }
     }
 

--- a/Tests/Rules/AvoidGlobalFunctions.tests.ps1
+++ b/Tests/Rules/AvoidGlobalFunctions.tests.ps1
@@ -11,7 +11,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidGlobalFunctionsNoViolation
 Describe "$violationName " {
     Context "When there are violations" {
         It "Has 1 avoid global function violations" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "Has the correct description message" {
@@ -22,7 +22,7 @@ Describe "$violationName " {
 
     Context "When there are no violations" {
         It "Returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidGlobalFunctions.tests.ps1
+++ b/Tests/Rules/AvoidGlobalFunctions.tests.ps1
@@ -15,7 +15,7 @@ Describe "$violationName " {
         }
 
         It "Has the correct description message" {
-            $violations[0].Message | Should Match $functionErroMessage
+            $violations[0].Message | Should -Match $functionErroMessage
         }
 
     }

--- a/Tests/Rules/AvoidGlobalOrUnitializedVars.tests.ps1
+++ b/Tests/Rules/AvoidGlobalOrUnitializedVars.tests.ps1
@@ -26,13 +26,13 @@ $noGlobalViolations = $noViolations | Where-Object {$_.RuleName -eq $globalName}
 Describe "AvoidGlobalVars" {
     Context "When there are violations" {
         It "has 1 avoid using global variable violation" {
-            $globalViolations.Count | Should Be 1
+            $globalViolations.Count | Should -Be 1
         }
 
         <#
         # PSAvoidUninitializedVariable rule has been deprecated
         It "has 4 violations for dsc resources (not counting the variables in parameters)" {
-            $dscResourceViolations.Count | Should Be 4
+            $dscResourceViolations.Count | Should -Be 4
         }
         #>
 
@@ -44,7 +44,7 @@ Describe "AvoidGlobalVars" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noGlobalViolations.Count | Should Be 0
+            $noGlobalViolations.Count | Should -Be 0
         }
     }
 
@@ -57,7 +57,7 @@ if ($global:lastexitcode -ne 0)
 }
 '@
             $local:violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -IncludeRule $globalName
-            $local:violations.Count | Should Be 0
+            $local:violations.Count | Should -Be 0
         }
     }
 }
@@ -67,7 +67,7 @@ if ($global:lastexitcode -ne 0)
 Describe "AvoidUnitializedVars" {
     Context "When there are violations" {
         It "has 5 avoid using unitialized variable violations" {
-            $nonInitializedViolations.Count | Should Be 5
+            $nonInitializedViolations.Count | Should -Be 5
         }
 
         It "has the correct description message" {
@@ -77,7 +77,7 @@ Describe "AvoidUnitializedVars" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noUninitializedViolations.Count | Should Be 0
+            $noUninitializedViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidGlobalOrUnitializedVars.tests.ps1
+++ b/Tests/Rules/AvoidGlobalOrUnitializedVars.tests.ps1
@@ -38,7 +38,7 @@ Describe "AvoidGlobalVars" {
 
 
         It "has the correct description message" {
-            $globalViolations[0].Message | Should Match $globalMessage
+            $globalViolations[0].Message | Should -Match $globalMessage
         }
     }
 
@@ -71,7 +71,7 @@ Describe "AvoidUnitializedVars" {
         }
 
         It "has the correct description message" {
-            $nonInitializedViolations[0].Message | Should Match $nonInitializedMessage
+            $nonInitializedViolations[0].Message | Should -Match $nonInitializedMessage
         }
     }
 

--- a/Tests/Rules/AvoidGlobalOrUnitializedVarsNoViolations.ps1
+++ b/Tests/Rules/AvoidGlobalOrUnitializedVarsNoViolations.ps1
@@ -33,7 +33,7 @@ stop-process 12,23 -ErrorVariable ev -ErrorAction SilentlyContinue
 if($null -ne $ev)
 {
     Write-host $ev[0]
-    # no error should be raised here
+    # no error Should -Be raised here
     Invoke-Command {$b}
 }
 
@@ -44,7 +44,8 @@ function Test-PreferenceVariable
 {
 
    if (-not $PSBoundParameters.ContainsKey('Verbose')) {
-       $VerbosePreference = $PSCmdlet.GetVariableValue('VerbosePreference') -as 
+       $VerbosePreference = $PSCmdlet.GetVariableValue('VerbosePreference') -as 
+
         [System.Management.Automation.ActionPreference]
         }
 

--- a/Tests/Rules/AvoidGlobalOrUnitializedVarsNoViolations.ps1
+++ b/Tests/Rules/AvoidGlobalOrUnitializedVarsNoViolations.ps1
@@ -33,7 +33,7 @@ stop-process 12,23 -ErrorVariable ev -ErrorAction SilentlyContinue
 if($null -ne $ev)
 {
     Write-host $ev[0]
-    # no error Should -Be raised here
+    # no error should be raised here
     Invoke-Command {$b}
 }
 
@@ -44,8 +44,7 @@ function Test-PreferenceVariable
 {
 
    if (-not $PSBoundParameters.ContainsKey('Verbose')) {
-       $VerbosePreference = $PSCmdlet.GetVariableValue('VerbosePreference') -as 
-
+       $VerbosePreference = $PSCmdlet.GetVariableValue('VerbosePreference') -as 
         [System.Management.Automation.ActionPreference]
         }
 

--- a/Tests/Rules/AvoidInvokingEmptyMembers.tests.ps1
+++ b/Tests/Rules/AvoidInvokingEmptyMembers.tests.ps1
@@ -9,7 +9,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidInvokingEmptyMembersNonVio
 Describe "AvoidInvokingEmptyMembers" {
     Context "When there are violations" {
         It "has one InvokeEmptyMember violations" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -19,7 +19,7 @@ Describe "AvoidInvokingEmptyMembers" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidInvokingEmptyMembers.tests.ps1
+++ b/Tests/Rules/AvoidInvokingEmptyMembers.tests.ps1
@@ -13,7 +13,7 @@ Describe "AvoidInvokingEmptyMembers" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/AvoidNullOrEmptyHelpMessageAttribute.tests.ps1
+++ b/Tests/Rules/AvoidNullOrEmptyHelpMessageAttribute.tests.ps1
@@ -12,7 +12,7 @@ Describe "AvoidNullOrEmptyHelpMessageAttribute" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/AvoidNullOrEmptyHelpMessageAttribute.tests.ps1
+++ b/Tests/Rules/AvoidNullOrEmptyHelpMessageAttribute.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer "$directory\AvoidNullOrEmptyHelpMessageAtt
 Describe "AvoidNullOrEmptyHelpMessageAttribute" {
     Context "When there are violations" {
         It "detects the violations" {
-            $violations.Count | Should Be 6
+            $violations.Count | Should -Be 6
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "AvoidNullOrEmptyHelpMessageAttribute" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidPositionalParameters.tests.ps1
+++ b/Tests/Rules/AvoidPositionalParameters.tests.ps1
@@ -9,7 +9,7 @@ $noViolationsDSC = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $director
 Describe "AvoidPositionalParameters" {
     Context "When there are violations" {
         It "has 1 avoid positional parameters violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -20,11 +20,11 @@ Describe "AvoidPositionalParameters" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
         
         It "returns no violations for DSC configuration" {
-            $noViolationsDSC.Count | Should Be 0
+            $noViolationsDSC.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidPositionalParameters.tests.ps1
+++ b/Tests/Rules/AvoidPositionalParameters.tests.ps1
@@ -13,7 +13,7 @@ Describe "AvoidPositionalParameters" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
 
     }

--- a/Tests/Rules/AvoidReservedParams.tests.ps1
+++ b/Tests/Rules/AvoidReservedParams.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {
 Describe "AvoidReservedParams" {
     Context "When there are violations" {
         It "has 1 avoid reserved parameters violations" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -19,7 +19,7 @@ Describe "AvoidReservedParams" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidReservedParams.tests.ps1
+++ b/Tests/Rules/AvoidReservedParams.tests.ps1
@@ -12,7 +12,7 @@ Describe "AvoidReservedParams" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
 
     }

--- a/Tests/Rules/AvoidShouldContinueWithoutForce.tests.ps1
+++ b/Tests/Rules/AvoidShouldContinueWithoutForce.tests.ps1
@@ -12,7 +12,7 @@ Describe "AvoidShouldContinueWithoutForce" {
         }
 
         It "has the correct description message" {
-            $violations[1].Message | Should Match $violationMessage
+            $violations[1].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/AvoidShouldContinueWithoutForce.tests.ps1
+++ b/Tests/Rules/AvoidShouldContinueWithoutForce.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {
 Describe "AvoidShouldContinueWithoutForce" {
     Context "When there are violations" {
         It "has 2 avoid ShouldContinue without boolean Force parameter violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "AvoidShouldContinueWithoutForce" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
+++ b/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
@@ -52,7 +52,7 @@ ModuleVersion = '1.0.0.0'
 
     Context "When an .psd1 file doesn't contain a hashtable" {
         It "does not throw exception" {
-            {Invoke-ScriptAnalyzer -Path $noHashtableFilepath -IncludeRule $missingMemberRuleName} | Should -Not Throw
+            {Invoke-ScriptAnalyzer -Path $noHashtableFilepath -IncludeRule $missingMemberRuleName} | Should -Not -Throw
         }
     }
 

--- a/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
+++ b/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
@@ -21,7 +21,7 @@ Describe "MissingRequiredFieldModuleManifest" {
 
     Context "When there are violations" {
         It "has 1 missing required field module manifest violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -30,7 +30,7 @@ Describe "MissingRequiredFieldModuleManifest" {
 
         $numExpectedCorrections = 1
         It "has $numExpectedCorrections suggested corrections" {
-            $violations.SuggestedCorrections.Count | Should Be $numExpectedCorrections
+            $violations.SuggestedCorrections.Count | Should -Be $numExpectedCorrections
         }
 
     # On Linux, mismatch in line endings cause this to fail
@@ -46,7 +46,7 @@ ModuleVersion = '1.0.0.0'
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 
@@ -59,32 +59,32 @@ ModuleVersion = '1.0.0.0'
     Context "Validate the contents of a .psd1 file" {
         It "detects a valid module manifest file" {
             $filepath = Join-Path $directory "TestManifest/ManifestGood.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should Be $true
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should -Be $true
         }
 
         It "detects a .psd1 file which is not module manifest" {
             $filepath = Join-Path $directory "TestManifest/PowerShellDataFile.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should Be $false
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should -Be $false
         }
 
         It "detects valid module manifest file for PSv5" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv5.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should Be $true
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should -Be $true
         }
 
         It "does not validate PSv5 module manifest file for PSv3 check" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv5.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should Be $false
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should -Be $false
         }
 
         It "detects valid module manifest file for PSv4" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv4.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"4.0.0") | Should Be $true
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"4.0.0") | Should -Be $true
         }
 
         It "detects valid module manifest file for PSv3" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv3.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should Be $true
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should -Be $true
         }
     }
 
@@ -94,7 +94,7 @@ ModuleVersion = '1.0.0.0'
                 -Path "$directory/TestManifest/PowerShellDataFile.psd1" `
                 -IncludeRule "PSMissingModuleManifestField" `
                 -OutVariable ruleViolation
-            $ruleViolation.Count | Should Be 0
+            $ruleViolation.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
+++ b/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
@@ -40,7 +40,7 @@ Describe "MissingRequiredFieldModuleManifest" {
 ModuleVersion = '1.0.0.0'
 '@
             $violations[0].SuggestedCorrections[0].Text | Should -Match $expectedText
-            Get-ExtentText $violations[0].SuggestedCorrections[0] $violationFilepath | Should -Match ""
+            Get-ExtentText $violations[0].SuggestedCorrections[0] $violationFilepath | Should -BeNullOrEmpty
     }
 }
 

--- a/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
+++ b/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
@@ -52,7 +52,7 @@ ModuleVersion = '1.0.0.0'
 
     Context "When an .psd1 file doesn't contain a hashtable" {
         It "does not throw exception" {
-            {Invoke-ScriptAnalyzer -Path $noHashtableFilepath -IncludeRule $missingMemberRuleName} | Should Not Throw
+            {Invoke-ScriptAnalyzer -Path $noHashtableFilepath -IncludeRule $missingMemberRuleName} | Should -Not Throw
         }
     }
 

--- a/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
+++ b/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
@@ -25,7 +25,7 @@ Describe "MissingRequiredFieldModuleManifest" {
         }
 
         It "has the correct description message" {
-            $violations.Message | Should Match $missingMessage
+            $violations.Message | Should -Match $missingMessage
         }
 
         $numExpectedCorrections = 1
@@ -39,8 +39,8 @@ Describe "MissingRequiredFieldModuleManifest" {
 # Version number of this module.
 ModuleVersion = '1.0.0.0'
 '@
-            $violations[0].SuggestedCorrections[0].Text | Should Match $expectedText
-            Get-ExtentText $violations[0].SuggestedCorrections[0] $violationFilepath | Should Match ""
+            $violations[0].SuggestedCorrections[0].Text | Should -Match $expectedText
+            Get-ExtentText $violations[0].SuggestedCorrections[0] $violationFilepath | Should -Match ""
     }
 }
 

--- a/Tests/Rules/AvoidUserNameAndPasswordParams.tests.ps1
+++ b/Tests/Rules/AvoidUserNameAndPasswordParams.tests.ps1
@@ -9,25 +9,25 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUserNameAndPasswordParamsN
 Describe "AvoidUserNameAndPasswordParams" {
     Context "When there are violations" {
         It "has 1 avoid username and password parameter violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct violation message" {
-            $violations[0].Message | Should Be $violationMessage
+            $violations[0].Message | Should -Be $violationMessage
         }
 
 	It "has correct extent" {
 	   $expectedExtent = '$password, $username'
-	   $violations[0].Extent.Text | Should Be $expectedExtent
+	   $violations[0].Extent.Text | Should -Be $expectedExtent
 
 	   $expectedExtent = '$username, $password'
-	   $violations[1].Extent.Text | Should Be $expectedExtent
+	   $violations[1].Extent.Text | Should -Be $expectedExtent
 	}
     }
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUsingAlias.tests.ps1
+++ b/Tests/Rules/AvoidUsingAlias.tests.ps1
@@ -12,7 +12,7 @@ Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 Describe "AvoidUsingAlias" {
     Context "When there are violations" {
         It "has 2 Avoid Using Alias Cmdlets violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -21,10 +21,10 @@ Describe "AvoidUsingAlias" {
 
         It "suggests correction" {
             Test-CorrectionExtent $violationFilepath $violations[0] 1 'iex' 'Invoke-Expression'
-            $violations[0].SuggestedCorrections[0].Description | Should Be 'Replace iex with Invoke-Expression'
+            $violations[0].SuggestedCorrections[0].Description | Should -Be 'Replace iex with Invoke-Expression'
 
             Test-CorrectionExtent $violationFilepath $violations[1] 1 'cls' 'Clear-Host'
-            $violations[1].SuggestedCorrections[0].Description | Should Be 'Replace cls with Clear-Host'
+            $violations[1].SuggestedCorrections[0].Description | Should -Be 'Replace cls with Clear-Host'
         }
     }
 
@@ -34,13 +34,13 @@ Describe "AvoidUsingAlias" {
 gci -Path C:\
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $target -IncludeRule $violationName
-            $violations[0].Extent.Text | Should Be "gci"
+            $violations[0].Extent.Text | Should -Be "gci"
         }
     }
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
 
         It "should return no violation for assignment statement-like command in dsc configuration" -skip:($IsLinux -or $IsMacOS) {
@@ -56,7 +56,7 @@ Configuration MyDscConfiguration {
 '@
             Invoke-ScriptAnalyzer -ScriptDefinition $target -IncludeRule $violationName | `
                 Get-Count | `
-                Should Be 0
+                Should -Be 0
         }
     }
 
@@ -81,19 +81,19 @@ Configuration MyDscConfiguration {
                 }
             }
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $whiteListTestScriptDef -Settings $settings -IncludeRule $violationName
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "honors the whitelist provided through settings file" {
             # even though join-path returns string, if we do not use tostring, then invoke-scriptanalyzer cannot cast it to string type
             $settingsFilePath = (Join-Path $directory (Join-Path 'TestSettings' 'AvoidAliasSettings.psd1')).ToString()
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $whiteListTestScriptDef -Settings $settingsFilePath -IncludeRule $violationName
-            $violations.Count | Should be 1
+            $violations.Count | Should -Be 1
         }
 
         It "honors the whitelist in a case-insensitive manner" {
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition "CD" -Settings $settings -IncludeRule $violationName
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUsingAlias.tests.ps1
+++ b/Tests/Rules/AvoidUsingAlias.tests.ps1
@@ -16,7 +16,7 @@ Describe "AvoidUsingAlias" {
         }
 
         It "has the correct description message" {
-            $violations[1].Message | Should Match $violationMessage
+            $violations[1].Message | Should -Match $violationMessage
         }
 
         It "suggests correction" {

--- a/Tests/Rules/AvoidUsingComputerNameHardcoded.tests.ps1
+++ b/Tests/Rules/AvoidUsingComputerNameHardcoded.tests.ps1
@@ -12,7 +12,7 @@ Describe "AvoidUsingComputerNameHardcoded" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
 
     }

--- a/Tests/Rules/AvoidUsingComputerNameHardcoded.tests.ps1
+++ b/Tests/Rules/AvoidUsingComputerNameHardcoded.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUsingComputerNameHardcoded
 Describe "AvoidUsingComputerNameHardcoded" {
     Context "When there are violations" {
         It "has 2 avoid using ComputerName hardcoded violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -19,7 +19,7 @@ Describe "AvoidUsingComputerNameHardcoded" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUsingDeprecatedManifestFields.tests.ps1
+++ b/Tests/Rules/AvoidUsingDeprecatedManifestFields.tests.ps1
@@ -8,17 +8,17 @@ $noViolations2 = Invoke-ScriptAnalyzer "$directory\TestGoodModule\TestDeprecated
 Describe "AvoidUsingDeprecatedManifestFields" {
     Context "When there are violations" {
         It "has 1 violations" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
     }
 
     Context "When there are no violations" {
         It "returns no violations if no deprecated fields are used" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
 
         It "returns no violations if deprecated fields are used but psVersion is less than 3.0" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 
@@ -28,7 +28,7 @@ Describe "AvoidUsingDeprecatedManifestFields" {
                 -Path "$directory/TestManifest/PowerShellDataFile.psd1" `
                 -IncludeRule "PSAvoidUsingDeprecatedManifestFields" `
                 -OutVariable ruleViolation
-            $ruleViolation.Count | Should Be 0
+            $ruleViolation.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUsingInvokeExpression.tests.ps1
+++ b/Tests/Rules/AvoidUsingInvokeExpression.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidConvertToSecureStringWithP
 Describe "AvoidUsingInvokeExpression" {
     Context "When there are violations" {
         It "has 2 Avoid Using Invoke-Expression violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "AvoidUsingInvokeExpression" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUsingInvokeExpression.tests.ps1
+++ b/Tests/Rules/AvoidUsingInvokeExpression.tests.ps1
@@ -12,7 +12,7 @@ Describe "AvoidUsingInvokeExpression" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/AvoidUsingPlainTextForPassword.tests.ps1
+++ b/Tests/Rules/AvoidUsingPlainTextForPassword.tests.ps1
@@ -11,12 +11,12 @@ Describe "AvoidUsingPlainTextForPassword" {
     Context "When there are violations" {
     $expectedNumViolations = 7
         It "has $expectedNumViolations violations" {
-            $violations.Count | Should Be $expectedNumViolations
+            $violations.Count | Should -Be $expectedNumViolations
         }
 
 	It "suggests corrections" {
 	    Test-CorrectionExtent $violationFilepath $violations[0] 1 '$passphrases' '[SecureString] $passphrases'
-	    $violations[0].SuggestedCorrections[0].Description | Should Be 'Set $passphrases type to SecureString'
+	    $violations[0].SuggestedCorrections[0].Description | Should -Be 'Set $passphrases type to SecureString'
 
 	    Test-CorrectionExtent $violationFilepath $violations[1] 1 '$passwordparam' '[SecureString] $passwordparam'
 	    Test-CorrectionExtent $violationFilepath $violations[2] 1 '$credential' '[SecureString] $credential'
@@ -33,7 +33,7 @@ Describe "AvoidUsingPlainTextForPassword" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUsingPlainTextForPassword.tests.ps1
+++ b/Tests/Rules/AvoidUsingPlainTextForPassword.tests.ps1
@@ -27,7 +27,7 @@ Describe "AvoidUsingPlainTextForPassword" {
 	}
 
         It "has the correct violation message" {
-            $violations[3].Message | Should Match $violationMessage
+            $violations[3].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/AvoidUsingReservedCharNames.tests.ps1
+++ b/Tests/Rules/AvoidUsingReservedCharNames.tests.ps1
@@ -12,7 +12,7 @@ Describe "Avoid Using Reserved Char" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $reservedCharMessage
+            $violations[0].Message | Should -Match $reservedCharMessage
         }
     }
 

--- a/Tests/Rules/AvoidUsingReservedCharNames.tests.ps1
+++ b/Tests/Rules/AvoidUsingReservedCharNames.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {
 Describe "Avoid Using Reserved Char" {
     Context "When there are violations" {
         It "has 1 Reserved Char Violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "Avoid Using Reserved Char" {
 
     Context "When there are no violations" {
         It "has no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUsingWMICmdlet.tests.ps1
+++ b/Tests/Rules/AvoidUsingWMICmdlet.tests.ps1
@@ -8,17 +8,17 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUsingWMICmdletNoViolations
 Describe "AvoidUsingWMICmdlet" {
     Context "Script contains references to WMI cmdlets - Violation" {
         It "Have 5 WMI cmdlet Violations" {
-            $violations.Count | Should Be 5
+            $violations.Count | Should -Be 5
         }
 
         It "has the correct description message for WMI rule violation" {
-            $violations[0].Message | Should Be $violationMessage            
+            $violations[0].Message | Should -Be $violationMessage            
         }
     }
 
     Context "Script contains no calls to WMI cmdlet - No violation" {
         It "results in no rule violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUsingWriteHost.tests.ps1
+++ b/Tests/Rules/AvoidUsingWriteHost.tests.ps1
@@ -9,7 +9,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUsingWriteHostNoViolations
 Describe "AvoidUsingWriteHost" {
     Context "When there are violations" {
         It "has 4 Write-Host violations" {
-            $violations.Count | Should Be 4
+            $violations.Count | Should -Be 4
         }
 
         It "has the correct description message for Write-Host" {
@@ -19,7 +19,7 @@ Describe "AvoidUsingWriteHost" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/AvoidUsingWriteHost.tests.ps1
+++ b/Tests/Rules/AvoidUsingWriteHost.tests.ps1
@@ -13,7 +13,7 @@ Describe "AvoidUsingWriteHost" {
         }
 
         It "has the correct description message for Write-Host" {
-            $violations[0].Message | Should Match $writeHostMessage
+            $violations[0].Message | Should -Match $writeHostMessage
         }
     }
 

--- a/Tests/Rules/DSCResourceModule/DSCResources/BadDscResource/BadDscResource.psm1
+++ b/Tests/Rules/DSCResourceModule/DSCResources/BadDscResource/BadDscResource.psm1
@@ -27,7 +27,7 @@ class FileResource
     [string]$Path
 
     <#
-        This property indicates if the settings Should -Be present or absent
+        This property indicates if the settings should be present or absent
         on the system. For present, the resource ensures the file pointed
         to by $Path exists. For absent, it ensures the file point to by
         $Path does not exist.
@@ -160,7 +160,7 @@ class FileResource
         }
         elseif( $item.PSProvider.Name -ne "FileSystem")
         {
-            throw "Path $($location) is not a file path."
+            will show the custom rules when given a glob "Path $($location) is not a file path."
         }
         elseif($item.PSIsContainer)
         {

--- a/Tests/Rules/DSCResourceModule/DSCResources/BadDscResource/BadDscResource.psm1
+++ b/Tests/Rules/DSCResourceModule/DSCResources/BadDscResource/BadDscResource.psm1
@@ -27,7 +27,7 @@ class FileResource
     [string]$Path
 
     <#
-        This property indicates if the settings should be present or absent
+        This property indicates if the settings Should -Be present or absent
         on the system. For present, the resource ensures the file pointed
         to by $Path exists. For absent, it ensures the file point to by
         $Path does not exist.

--- a/Tests/Rules/DSCResourceModule/DSCResources/BadDscResource/BadDscResource.psm1
+++ b/Tests/Rules/DSCResourceModule/DSCResources/BadDscResource/BadDscResource.psm1
@@ -160,7 +160,7 @@ class FileResource
         }
         elseif( $item.PSProvider.Name -ne "FileSystem")
         {
-            will show the custom rules when given a glob "Path $($location) is not a file path."
+            throw "Path $($location) is not a file path."
         }
         elseif($item.PSIsContainer)
         {

--- a/Tests/Rules/DSCResourceModule/DSCResources/MyDscResource/MyDscResource.psm1
+++ b/Tests/Rules/DSCResourceModule/DSCResources/MyDscResource/MyDscResource.psm1
@@ -27,7 +27,7 @@ class FileResource
     [string]$Path
 
     <#
-        This property indicates if the settings should be present or absent
+        This property indicates if the settings Should -Be present or absent
         on the system. For present, the resource ensures the file pointed
         to by $Path exists. For absent, it ensures the file point to by
         $Path does not exist.

--- a/Tests/Rules/DSCResourceModule/DSCResources/MyDscResource/MyDscResource.psm1
+++ b/Tests/Rules/DSCResourceModule/DSCResources/MyDscResource/MyDscResource.psm1
@@ -27,7 +27,7 @@ class FileResource
     [string]$Path
 
     <#
-        This property indicates if the settings Should -Be present or absent
+        This property indicates if the settings should be present or absent
         on the system. For present, the resource ensures the file pointed
         to by $Path exists. For absent, it ensures the file point to by
         $Path does not exist.

--- a/Tests/Rules/DscExamplesPresent.tests.ps1
+++ b/Tests/Rules/DscExamplesPresent.tests.ps1
@@ -16,7 +16,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
         $violationMessage = "No examples found for resource 'FileResource'"
 
         It "has 1 missing examples violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -31,7 +31,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
         $noViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $classResourcePath | Where-Object {$_.RuleName -eq $ruleName}
 
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
 
         Remove-Item -Path $examplesPath -Recurse -Force
@@ -50,7 +50,7 @@ Describe "DscExamplesPresent rule in regular (non-class) based resource" {
         $violationMessage = "No examples found for resource 'MSFT_WaitForAll'"
 
         It "has 1 missing examples violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -65,7 +65,7 @@ Describe "DscExamplesPresent rule in regular (non-class) based resource" {
         $noViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $resourcePath | Where-Object {$_.RuleName -eq $ruleName}
 
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
 
         Remove-Item -Path $examplesPath -Recurse -Force

--- a/Tests/Rules/DscExamplesPresent.tests.ps1
+++ b/Tests/Rules/DscExamplesPresent.tests.ps1
@@ -20,7 +20,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 
@@ -54,7 +54,7 @@ Describe "DscExamplesPresent rule in regular (non-class) based resource" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/DscTestsPresent.tests.ps1
+++ b/Tests/Rules/DscTestsPresent.tests.ps1
@@ -16,11 +16,11 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
         $violationMessage = "No tests found for resource 'FileResource'"
 
         It "has 1 missing test violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Be $violationMessage
+            $violations[0].Message | Should -Be $violationMessage
         }
     }
 
@@ -31,7 +31,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
         $noViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $classResourcePath | Where-Object {$_.RuleName -eq $ruleName}
 
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
 
         Remove-Item -Path $testsPath -Recurse -Force
@@ -50,11 +50,11 @@ Describe "DscTestsPresent rule in regular (non-class) based resource" {
         $violationMessage = "No tests found for resource 'MSFT_WaitForAll'"
 
         It "has 1 missing tests violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Be $violationMessage
+            $violations[0].Message | Should -Be $violationMessage
         }
     }
 
@@ -65,7 +65,7 @@ Describe "DscTestsPresent rule in regular (non-class) based resource" {
         $noViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $resourcePath | Where-Object {$_.RuleName -eq $ruleName}
 
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
 
         Remove-Item -Path $testsPath -Recurse -Force

--- a/Tests/Rules/MisleadingBacktick.tests.ps1
+++ b/Tests/Rules/MisleadingBacktick.tests.ps1
@@ -9,7 +9,7 @@ Import-Module (Join-Path $directory "PSScriptAnalyzerTestHelper.psm1")
 Describe "Avoid Misleading Backticks" {
     Context "When there are violations" {
         It "has 5 misleading backtick violations" {
-            $violations.Count | Should Be 5
+            $violations.Count | Should -Be 5
         }
 	
 	It "suggests correction" {
@@ -23,7 +23,7 @@ Describe "Avoid Misleading Backticks" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/PSCredentialType.tests.ps1
+++ b/Tests/Rules/PSCredentialType.tests.ps1
@@ -15,11 +15,11 @@ Describe "PSCredentialType" {
             $expectedViolations = 2
         }
         It ("has {0} PSCredential type violation" -f $expectedViolations) {
-            $violations.Count | Should Be $expectedViolations
+            $violations.Count | Should -Be $expectedViolations
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Be $violationMessage
+            $violations[0].Message | Should -Be $violationMessage
         }
 
         It "detects attributes on the same line without space" {
@@ -33,14 +33,14 @@ function Get-Credential
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule $violationName
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
     }
 
     Context ("When there are no violations") {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/PSScriptAnalyzerTestHelper.psm1
+++ b/Tests/Rules/PSScriptAnalyzerTestHelper.psm1
@@ -22,10 +22,10 @@ Function Test-CorrectionExtent
 		[string] $correctionText
 	)
 	$corrections = $diagnosticRecord.SuggestedCorrections
-	$corrections.Count | Should Be $correctionsCount
-	$corrections[0].Text | Should Be $correctionText
+	$corrections.Count | Should -Be $correctionsCount
+	$corrections[0].Text | Should -Be $correctionText
 	Get-ExtentText $corrections[0] $violationFilepath | `
-		       Should Be $violationText
+		       Should -Be $violationText
 }
 
 

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -130,7 +130,7 @@ $x = if ($true) { "blah" } else { "blah blah" }
         }
     }
 
-    Context "When a close brace Should -Be followed by a new line" {
+    Context "When a close brace should be followed by a new line" {
         BeforeAll {
             $ruleConfiguration.'NoEmptyLineBefore' = $false
             $ruleConfiguration.'IgnoreOneLineBlock' = $false

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -32,11 +32,11 @@ function foo {
         }
 
         It "Should find a violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "Should mark the right extent" {
-            $violations[0].Extent.Text | Should Be "}"
+            $violations[0].Extent.Text | Should -Be "}"
         }
     }
 
@@ -55,11 +55,11 @@ function foo {
         }
 
         It "Should find a violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "Should mark the right extent" {
-            $violations[0].Extent.Text | Should Be "}"
+            $violations[0].Extent.Text | Should -Be "}"
         }
     }
 
@@ -75,7 +75,7 @@ $hashtable = @{a = 1; b = 2}
         }
 
         It "Should not find a violation" {
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 
@@ -93,7 +93,7 @@ $hashtable = @{
         }
 
         It "Should find a violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
     }
 
@@ -107,7 +107,7 @@ Get-Process * | % { "blah" }
         }
 
         It "Should not find a violation" {
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
         It "Should ignore violations for one line if statement" {
@@ -116,7 +116,7 @@ $x = if ($true) { "blah" } else { "blah blah" }
 '@
             $ruleConfiguration.'IgnoreOneLineBlock' = $true
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
         It "Should ignore violations for one line if statement even if NewLineAfter is true" {
@@ -126,11 +126,11 @@ $x = if ($true) { "blah" } else { "blah blah" }
             $ruleConfiguration.'IgnoreOneLineBlock' = $true
             $ruleConfiguration.'NewLineAfter' = $true
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 
-    Context "When a close brace should be followed by a new line" {
+    Context "When a close brace Should -Be followed by a new line" {
         BeforeAll {
             $ruleConfiguration.'NoEmptyLineBefore' = $false
             $ruleConfiguration.'IgnoreOneLineBlock' = $false
@@ -146,7 +146,7 @@ if (Test-Path "blah") {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
             $params = @{
                 RawContent       = $def
                 DiagnosticRecord = $violations[0]
@@ -166,7 +166,7 @@ if (Test-Path "blah") {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
             $params = @{
                 RawContent       = $def
                 DiagnosticRecord = $violations[0]
@@ -187,7 +187,7 @@ try {
 
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
             $params = @{
                 RawContent       = $def
                 DiagnosticRecord = $violations[0]
@@ -207,7 +207,7 @@ Some-Command -Param1 @{
     }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
         It "Should not find a violation for a close brace followed by parameter in a command expression" {
@@ -217,7 +217,7 @@ Some-Command -Param1 @{
 } -Param2
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 
@@ -238,7 +238,7 @@ else {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "Should correct violation by cuddling the else branch statement" {
@@ -257,7 +257,7 @@ if ($true) {
     $false
 }
 '@
-            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
         }
 
         It "Should correct violation if the close brace and following keyword are apart by less than a space" {
@@ -275,7 +275,7 @@ if ($true) {
     $false
 }
 '@
-            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
         }
 
         It "Should correct violation if the close brace and following keyword are apart by more than a space" {
@@ -293,7 +293,7 @@ if ($true) {
     $false
 }
 '@
-            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
         }
 
         It "Should correct violations in an if-else-elseif block" {
@@ -319,7 +319,7 @@ if ($x -eq 1) {
     "3"
 }
 '@
-            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
         }
 
         It "Should correct violations in a try-catch-finally block" {
@@ -343,7 +343,7 @@ try {
     "finally"
 }
 '@
-            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
         }
 
         It "Should not find violations when a script has two close braces in succession" {
@@ -357,7 +357,7 @@ if ($true) {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/PlaceOpenBrace.tests.ps1
+++ b/Tests/Rules/PlaceOpenBrace.tests.ps1
@@ -27,11 +27,11 @@ function foo ($param1)
         }
 
         It "Should find a violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "Should mark only the open brace" {
-            $violations[0].Extent.Text | Should Be '{'
+            $violations[0].Extent.Text | Should -Be '{'
         }
     }
 
@@ -49,7 +49,7 @@ switch ($x) {
         }
 
         It "Should not find a violation" {
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 
@@ -71,15 +71,15 @@ Get-Process | % { "blah" }
         }
 
         It "Should find a violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "Should mark only the open brace" {
-            $violations[0].Extent.Text | Should Be '{'
+            $violations[0].Extent.Text | Should -Be '{'
         }
 
         It "Should ignore violations for a command element" {
-            $violationsShouldIgnore.Count | Should Be 0
+            $violationsShouldIgnore.Count | Should -Be 0
         }
 
         It "Should ignore violations for one line if statement" {
@@ -88,7 +88,7 @@ $x = if ($true) { "blah" } else { "blah blah" }
 '@
             $ruleConfiguration.'IgnoreOneLineBlock' = $true
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 
@@ -104,11 +104,11 @@ function foo { }
         }
 
         It "Should find a violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "Should mark only the open brace" {
-            $violations[0].Extent.Text | Should Be '{'
+            $violations[0].Extent.Text | Should -Be '{'
         }
     }
 }

--- a/Tests/Rules/PossibleIncorrectComparisonWithNull.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectComparisonWithNull.tests.ps1
@@ -12,7 +12,7 @@ Describe "PossibleIncorrectComparisonWithNull" {
         }
 
         It "has the correct description message" {
-            $violations.Message | Should Match $violationMessage
+            $violations.Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/PossibleIncorrectComparisonWithNull.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectComparisonWithNull.tests.ps1
@@ -1,5 +1,5 @@
 ﻿Import-Module PSScriptAnalyzer 
-$violationMessage = [regex]::Escape('$null should be on the left side of equality comparisons.')
+$violationMessage = [regex]::Escape('$null Should -Be on the left side of equality comparisons.')
 $violationName = "PSPossibleIncorrectComparisonWithNull"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\PossibleIncorrectComparisonWithNull.ps1 | Where-Object {$_.RuleName -eq $violationName}
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\PossibleIncorrectComparisonWith
 Describe "PossibleIncorrectComparisonWithNull" {
     Context "When there are violations" {
         It "has 4 possible incorrect comparison with null violation" {
-            $violations.Count | Should Be 4
+            $violations.Count | Should -Be 4
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "PossibleIncorrectComparisonWithNull" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/PossibleIncorrectComparisonWithNull.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectComparisonWithNull.tests.ps1
@@ -1,5 +1,5 @@
 ﻿Import-Module PSScriptAnalyzer 
-$violationMessage = [regex]::Escape('$null Should -Be on the left side of equality comparisons.')
+$violationMessage = [regex]::Escape('$null should be on the left side of equality comparisons.')
 $violationName = "PSPossibleIncorrectComparisonWithNull"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\PossibleIncorrectComparisonWithNull.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
@@ -5,59 +5,59 @@ Describe "PossibleIncorrectUsageOfAssignmentOperator" {
     Context "When there are violations" {
         It "assignment inside if statement causes warning" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a=$b){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 1
+            $warnings.Count | Should -Be 1
         }
 
         It "assignment inside if statement causes warning when when wrapped in command expression" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a=($b)){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 1
+            $warnings.Count | Should -Be 1
         }
 
         It "assignment inside if statement causes warning when wrapped in expression" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a="$b"){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 1
+            $warnings.Count | Should -Be 1
         }
 
         It "assignment inside elseif statement causes warning" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a -eq $b){}elseif($a = $b){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 1
+            $warnings.Count | Should -Be 1
         }
 
         It "double equals inside if statement causes warning" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a == $b){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 1
+            $warnings.Count | Should -Be 1
         }
 
         It "double equals inside if statement causes warning when wrapping it in command expresion" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a == ($b)){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 1
+            $warnings.Count | Should -Be 1
         }
 
         It "double equals inside if statement causes warning when wrapped in expression" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a == "$b"){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 1
+            $warnings.Count | Should -Be 1
         }
     }
 
     Context "When there are no violations" {
         It "returns no violations when there is no equality operator" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a -eq $b){$a=$b}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 0
+            $warnings.Count | Should -Be 0
         }
 
         It "returns no violations when there is an evaluation on the RHS" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = Get-ChildItem){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 0
+            $warnings.Count | Should -Be 0
         }
 
         It "returns no violations when there is an evaluation on the RHS wrapped in an expression" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = (Get-ChildItem)){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 0
+            $warnings.Count | Should -Be 0
         }
 
         It "returns no violations when there is an evaluation on the RHS wrapped in an expression and also includes a variable" {
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'if ($a = (Get-ChildItem $b)){}' | Where-Object {$_.RuleName -eq $ruleName}
-            $warnings.Count | Should Be 0
+            $warnings.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/ProvideCommentHelp.tests.ps1
+++ b/Tests/Rules/ProvideCommentHelp.tests.ps1
@@ -31,25 +31,25 @@ function Test-Correction {
     param($scriptDef, $expectedCorrection, $settings)
 
     $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -Settings $settings
-    $violations.Count | Should Be 1
+    $violations.Count | Should -Be 1
 
     # We split the lines because appveyor checks out files with "\n" endings
     # on windows, which results in inconsistent line endings between corrections
     # and result.
     $resultLines = $violations[0].SuggestedCorrections[0].Text -split "\r?\n"
     $expectedLines = $expectedCorrection -split "\r?\n"
-    $resultLines.Count | Should Be $expectedLines.Count
+    $resultLines.Count | Should -Be $expectedLines.Count
     for ($i = 0; $i -lt $resultLines.Count; $i++) {
         $resultLine = $resultLines[$i]
         $expectedLine = $expectedLines[$i]
-        $resultLine | Should Be $expectedLine
+        $resultLine | Should -Be $expectedLine
     }
 }
 
 Describe "ProvideCommentHelp" {
     Context "When there are violations" {
         It "has 2 provide comment help violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -57,7 +57,7 @@ Describe "ProvideCommentHelp" {
         }
 
         It "has extent that includes only the function name" {
-            $violations[1].Extent.Text | Should Be "Comment"
+            $violations[1].Extent.Text | Should -Be "Comment"
         }
 
         It "should find violations in functions that are not exported" {
@@ -66,7 +66,7 @@ function foo {
 }
 '@
 
-            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Get-Count | Should Be 1
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Get-Count | Should -Be 1
         }
         It "should return a help snippet correction with 0 parameters" {
             $def = @'
@@ -334,14 +334,14 @@ $s$s$s$s
 
         if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
             It "Does not count violation in DSC class" {
-                $dscViolations.Count | Should Be 0
+                $dscViolations.Count | Should -Be 0
             }
         }
     }
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/ProvideCommentHelp.tests.ps1
+++ b/Tests/Rules/ProvideCommentHelp.tests.ps1
@@ -53,7 +53,7 @@ Describe "ProvideCommentHelp" {
         }
 
         It "has the correct description message" {
-            $violations[1].Message | Should Match $violationMessage
+            $violations[1].Message | Should -Match $violationMessage
         }
 
         It "has extent that includes only the function name" {

--- a/Tests/Rules/ReturnCorrectTypesForDSCFunctions.tests.ps1
+++ b/Tests/Rules/ReturnCorrectTypesForDSCFunctions.tests.ps1
@@ -16,7 +16,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0')
 Describe "ReturnCorrectTypesForDSCFunctions" {
     Context "When there are violations" {
         It "has 5 return correct types for DSC functions violations" {
-            $violations.Count | Should Be 5
+            $violations.Count | Should -Be 5
         }
 
         It "has the correct description message" {
@@ -26,7 +26,7 @@ Describe "ReturnCorrectTypesForDSCFunctions" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }
@@ -35,7 +35,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
  Describe "StandardDSCFunctionsInClass" {
     Context "When there are violations" {
         It "has 4 return correct types for DSC functions violations" {
-            $classViolations.Count | Should Be 4
+            $classViolations.Count | Should -Be 4
         }
 
         It "has the correct description message" {
@@ -45,7 +45,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noClassViolations.Count | Should Be 0
+            $noClassViolations.Count | Should -Be 0
         }
     }
  }

--- a/Tests/Rules/ReturnCorrectTypesForDSCFunctions.tests.ps1
+++ b/Tests/Rules/ReturnCorrectTypesForDSCFunctions.tests.ps1
@@ -20,7 +20,7 @@ Describe "ReturnCorrectTypesForDSCFunctions" {
         }
 
         It "has the correct description message" {
-            $violations[2].Message | Should Match $violationMessageDSCResource
+            $violations[2].Message | Should -Match $violationMessageDSCResource
         }
     }
 
@@ -39,7 +39,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
         }
 
         It "has the correct description message" {
-            $classViolations[3].Message | Should Match $violationMessageDSCClass
+            $classViolations[3].Message | Should -Match $violationMessageDSCClass
         }
     }
 

--- a/Tests/Rules/UseBOMForUnicodeEncodedFile.tests.ps1
+++ b/Tests/Rules/UseBOMForUnicodeEncodedFile.tests.ps1
@@ -15,7 +15,7 @@ Describe "UseBOMForUnicodeEncodedFile" {
         }
 
         It "has the correct description message for BOM Absent - UTF16 Encoded file" {
-            $violationsOne[0].Message | Should Match $violationMessageOne
+            $violationsOne[0].Message | Should -Match $violationMessageOne
         }
 
         It "has 1 rule violation for BOM Absent - Unknown Encoded file" {
@@ -23,7 +23,7 @@ Describe "UseBOMForUnicodeEncodedFile" {
         }
 
         It "has the correct description message for BOM Absent - Unknown Encoded file" {
-            $violationsTwo[0].Message | Should Match $violationMessageTwo
+            $violationsTwo[0].Message | Should -Match $violationMessageTwo
         }
 
     }

--- a/Tests/Rules/UseBOMForUnicodeEncodedFile.tests.ps1
+++ b/Tests/Rules/UseBOMForUnicodeEncodedFile.tests.ps1
@@ -11,7 +11,7 @@ $noViolationsTwo = Invoke-ScriptAnalyzer "$directory\TestFiles\BOMAbsent_ASCIIEn
 Describe "UseBOMForUnicodeEncodedFile" {
     Context "When there are violations" {
         It "has 1 rule violation for BOM Absent - UTF16 Encoded file" {
-            $violationsOne.Count | Should Be 1
+            $violationsOne.Count | Should -Be 1
         }
 
         It "has the correct description message for BOM Absent - UTF16 Encoded file" {
@@ -19,7 +19,7 @@ Describe "UseBOMForUnicodeEncodedFile" {
         }
 
         It "has 1 rule violation for BOM Absent - Unknown Encoded file" {
-            $violationsTwo.Count | Should Be 1
+            $violationsTwo.Count | Should -Be 1
         }
 
         It "has the correct description message for BOM Absent - Unknown Encoded file" {
@@ -30,11 +30,11 @@ Describe "UseBOMForUnicodeEncodedFile" {
 
     Context "When there are no violations" {
         It "returns no violations for BOM Present - UTF16 Encoded File" {
-            $noViolationsOne.Count | Should Be 0
+            $noViolationsOne.Count | Should -Be 0
         }
 
         It "returns no violations for BOM Absent - ASCII Encoded File" {
-            $noViolationsTwo.Count | Should Be 0
+            $noViolationsTwo.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/UseCmdletCorrectly.tests.ps1
+++ b/Tests/Rules/UseCmdletCorrectly.tests.ps1
@@ -8,7 +8,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {
 Describe "UseCmdletCorrectly" {
     Context "When there are violations" {
         It "has 1 Use Cmdlet Correctly violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -18,7 +18,7 @@ Describe "UseCmdletCorrectly" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/UseCmdletCorrectly.tests.ps1
+++ b/Tests/Rules/UseCmdletCorrectly.tests.ps1
@@ -12,7 +12,7 @@ Describe "UseCmdletCorrectly" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/UseCompatibleCmdlets.tests.ps1
+++ b/Tests/Rules/UseCompatibleCmdlets.tests.ps1
@@ -12,7 +12,7 @@ Describe "UseCompatibleCmdlets" {
             $violationFilePath = Join-Path $ruleTestDirectory 'ScriptWithViolation.ps1'
             $settingsFilePath =  [System.IO.Path]::Combine($ruleTestDirectory, 'PSScriptAnalyzerSettings.psd1');
             $diagnosticRecords = Invoke-ScriptAnalyzer -Path $violationFilePath -IncludeRule $ruleName -Settings $settingsFilePath
-            $diagnosticRecords.Count | Should Be 1
+            $diagnosticRecords.Count | Should -Be 1
         }
     }
 
@@ -29,7 +29,7 @@ Describe "UseCompatibleCmdlets" {
             It ("found {0} violations for '{1}'" -f $expectedViolations, $command) {
                 Invoke-ScriptAnalyzer -ScriptDefinition $command -IncludeRule $ruleName -Settings $settings | `
                     Get-Count | `
-                    Should Be $expectedViolations
+                    Should -Be $expectedViolations
             }
         }
     }

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -33,7 +33,7 @@ Describe "UseConsistentIndentation" {
         }
 
         It "Should detect a violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
     }
 
@@ -49,7 +49,7 @@ function foo ($param1)
         }
 
         It "Should find a violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
     }
 
@@ -66,7 +66,7 @@ b = 2
         }
 
         It "Should find violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
     }
 
@@ -82,7 +82,7 @@ $array = @(
         }
 
         It "Should find violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
     }
 
@@ -103,7 +103,7 @@ $param3
         }
 
         It "Should find violations" {
-            $violations.Count | Should Be 4
+            $violations.Count | Should -Be 4
         }
     }
 
@@ -119,7 +119,7 @@ function foo {
         }
 
         It "Should not find a violations" {
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 
@@ -130,7 +130,7 @@ get-process |
 where-object {$_.Name -match 'powershell'}
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "Should not find a violation if a pipleline element is indented correctly" {
@@ -139,7 +139,7 @@ get-process |
     where-object {$_.Name -match 'powershell'}
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
         It "Should ignore comment in the pipleline" {
@@ -150,7 +150,7 @@ select Name,Id |
        format-list
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 3
+            $violations.Count | Should -Be 3
         }
 
         It "Should indent properly after line continuation (backtick) character" {
@@ -159,7 +159,7 @@ $x = "this " + `
 "Should be indented properly"
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
             $params = @{
                 RawContent       = $def
                 DiagnosticRecord = $violations[0]
@@ -200,7 +200,7 @@ ${t}${t}anotherProperty = "another value"
 ${t}}
 }
 "@
-            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should Be $expected
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
         }
     }
 }

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -41,21 +41,21 @@ if ($true){}
             $def = @'
 if($true) {}
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
         It "Should not find violation if an open brace follows a foreach member invocation" {
             $def = @'
 (1..5).foreach{$_}
 '@
-            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
         It "Should not find violation if an open brace follows a where member invocation" {
             $def = @'
 (1..5).where{$_}
 '@
-            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
     }
@@ -82,7 +82,7 @@ function foo($param1) {
 
 }
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
         It "Should not find a violation in a param block" {
@@ -91,7 +91,7 @@ function foo() {
     param( )
 }
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
         It "Should not find a violation in a nested open paren" {
@@ -100,14 +100,14 @@ function foo($param) {
     ((Get-Process))
 }
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
         It "Should not find a violation on a method call" {
             $def = @'
 $x.foo("bar")
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
     }
 
@@ -157,21 +157,21 @@ $x = @"
 "abc"
 "@
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
         It "Should not find violation if there are whitespaces of size 1 around an assignment operator for here string" {
             $def = @'
 $x = 1
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
         It "Should not find violation if there are no whitespaces around DotDot operator" {
             $def = @'
 1..5
 '@
-            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
         It "Should not find violation if a binary operator is followed by new line" {
@@ -179,7 +179,7 @@ $x = 1
 $x = $true -and
             $false
 '@
-            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
     }
@@ -204,7 +204,7 @@ $x = @(1,2)
             $def = @'
 $x = @(1, 2)
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
     }
 
@@ -228,7 +228,7 @@ $x = @{a=1;b=2}
             $def = @'
 $x = @{a=1; b=2}
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
         It "Should not find a violation if a new-line follows a semi-colon" {
@@ -238,14 +238,14 @@ $x = @{
     b=2
 }
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
         It "Should not find a violation if a end of input follows a semi-colon" {
             $def = @'
 $x = "abc";
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should Be $null
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
 

--- a/Tests/Rules/UseDSCResourceFunctions.tests.ps1
+++ b/Tests/Rules/UseDSCResourceFunctions.tests.ps1
@@ -20,7 +20,7 @@ Describe "StandardDSCFunctionsInResource" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 
@@ -39,7 +39,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
         }
 
         It "has the correct description message" {
-            $classViolations[0].Message | Should Match $classViolationMessage
+            $classViolations[0].Message | Should -Match $classViolationMessage
         }
     }
 

--- a/Tests/Rules/UseDSCResourceFunctions.tests.ps1
+++ b/Tests/Rules/UseDSCResourceFunctions.tests.ps1
@@ -16,7 +16,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0')
 Describe "StandardDSCFunctionsInResource" {
     Context "When there are violations" {
         It "has 1 missing standard DSC functions violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -26,7 +26,7 @@ Describe "StandardDSCFunctionsInResource" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }
@@ -35,7 +35,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
  Describe "StandardDSCFunctionsInClass" {
     Context "When there are violations" {
         It "has 1 missing standard DSC functions violation" {
-            $classViolations.Count | Should Be 1
+            $classViolations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -45,7 +45,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noClassViolations.Count | Should Be 0
+            $noClassViolations.Count | Should -Be 0
         }
     }
  }

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -12,7 +12,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\UseDeclaredVarsMoreThanAssignme
 Describe "UseDeclaredVarsMoreThanAssignments" {
     Context "When there are violations" {
         It "has 2 use declared vars more than assignments violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -35,43 +35,43 @@ function MyFunc2() {
 '@
             Invoke-ScriptAnalyzer -ScriptDefinition $target -IncludeRule $violationName | `
             Get-Count | `
-            Should Be 1
+            Should -Be 1
         }
 
         It "flags strongly typed variables" {
             Invoke-ScriptAnalyzer -ScriptDefinition '[string]$s=''mystring''' -IncludeRule $violationName  | `
             Get-Count | `
-            Should Be 1
+            Should -Be 1
         }
 
         It "does not flag `$InformationPreference variable" {
             Invoke-ScriptAnalyzer -ScriptDefinition '$InformationPreference=Stop' -IncludeRule $violationName  | `
             Get-Count | `
-            Should Be 0
+            Should -Be 0
         }
 
         It "does not flag `$PSModuleAutoLoadingPreference variable" {
             Invoke-ScriptAnalyzer -ScriptDefinition '$PSModuleAutoLoadingPreference=None' -IncludeRule $violationName | `
             Get-Count | `
-            Should Be 0
+            Should -Be 0
         }
 
         It "flags a variable that is defined twice but never used" {
             Invoke-ScriptAnalyzer -ScriptDefinition '$myvar=1;$myvar=2' -IncludeRule $violationName | `
             Get-Count | `
-            Should Be 1
+            Should -Be 1
         }
 
         It "does not flag a variable that is defined twice but gets assigned to another variable and flags the other variable instead" {
             $results = Invoke-ScriptAnalyzer -ScriptDefinition '$myvar=1;$myvar=2;$mySecondvar=$myvar' -IncludeRule $violationName
-            $results | Get-Count | Should Be 1
-            $results[0].Extent | Should Be '$mySecondvar'
+            $results | Get-Count | Should -Be 1
+            $results[0].Extent | Should -Be '$mySecondvar'
         }
     }
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -16,7 +16,7 @@ Describe "UseDeclaredVarsMoreThanAssignments" {
         }
 
         It "has the correct description message" {
-            $violations[1].Message | Should Match $violationMessage
+            $violations[1].Message | Should -Match $violationMessage
         }
 
         It "flags the variable in the correct scope" {

--- a/Tests/Rules/UseIdenticalMandatoryParametersForDSC.tests.ps1
+++ b/Tests/Rules/UseIdenticalMandatoryParametersForDSC.tests.ps1
@@ -15,11 +15,11 @@ Describe "UseIdenticalMandatoryParametersForDSC" {
         }
 
         It "Should find a violations" -skip:($IsLinux -or $IsMacOS) {
-            $violations.Count | Should Be 5
+            $violations.Count | Should -Be 5
         }
 
         It "Should mark only the function name" -skip:($IsLinux -or $IsMacOS) {
-            $violations[0].Extent.Text | Should Be 'Get-TargetResource'
+            $violations[0].Extent.Text | Should -Be 'Get-TargetResource'
         }
     }
 
@@ -30,7 +30,7 @@ Describe "UseIdenticalMandatoryParametersForDSC" {
 
         # todo add a test to check one violation per function
         It "Should find a violations" -pending {
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/UseIdenticalParametersDSC.tests.ps1
+++ b/Tests/Rules/UseIdenticalParametersDSC.tests.ps1
@@ -14,7 +14,7 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0')
 Describe "UseIdenticalParametersDSC" {
     Context "When there are violations" {
         It "has 1 Use Identical Parameters For DSC violations" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -24,14 +24,14 @@ Describe "UseIdenticalParametersDSC" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
 
         if ($PSVersionTable.PSVersion -ge [Version]'5.0.0')
         {
 
             It "returns no violations for DSC Classes" {
-                $noClassViolations.Count | Should Be 0
+                $noClassViolations.Count | Should -Be 0
             }
         }
     }

--- a/Tests/Rules/UseIdenticalParametersDSC.tests.ps1
+++ b/Tests/Rules/UseIdenticalParametersDSC.tests.ps1
@@ -18,7 +18,7 @@ Describe "UseIdenticalParametersDSC" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/UseLiteralInitializerForHashtable.tests.ps1
+++ b/Tests/Rules/UseLiteralInitializerForHashtable.tests.ps1
@@ -11,7 +11,7 @@ Describe "UseLiteralInitlializerForHashtable" {
             $htable4 = new-object collections.hashtable
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $violationScriptDef -IncludeRule $ruleName
-            $violations.Count | Should Be 4
+            $violations.Count | Should -Be 4
         }
 
         It "does not detect violation if arguments given to new-object contain ignore case string comparer" {
@@ -22,7 +22,7 @@ Describe "UseLiteralInitlializerForHashtable" {
             $htable4 = new-object -Typename hashtable [system.stringcomparer]::ordinalignorecase
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $violationScriptDef -IncludeRule $ruleName
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
         It "suggests correction" {
@@ -30,7 +30,7 @@ Describe "UseLiteralInitlializerForHashtable" {
             $htable1 = new-object hashtable
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $violationScriptDef -IncludeRule $ruleName
-            $violations[0].SuggestedCorrections[0].Text | Should Be '@{}'
+            $violations[0].SuggestedCorrections[0].Text | Should -Be '@{}'
         }
     }
 
@@ -43,7 +43,7 @@ Describe "UseLiteralInitlializerForHashtable" {
             $htable4 = [collections.hashtable]::new()
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $violationScriptDef -IncludeRule $ruleName
-            $violations.Count | Should Be 4
+            $violations.Count | Should -Be 4
         }
 
         It "does not detect violation if arguments given to [hashtable]::new contain ignore case string comparer" {
@@ -52,7 +52,7 @@ Describe "UseLiteralInitlializerForHashtable" {
             $htable2 = [hashtable]::new(10, [system.stringcomparer]::ordinalignorecase)
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $violationScriptDef -IncludeRule $ruleName
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
         It "suggests correction" {
@@ -60,7 +60,7 @@ Describe "UseLiteralInitlializerForHashtable" {
             $htable1 = [hashtable]::new()
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $violationScriptDef -IncludeRule $ruleName
-            $violations[0].SuggestedCorrections[0].Text | Should Be '@{}'
+            $violations[0].SuggestedCorrections[0].Text | Should -Be '@{}'
         }
 
     }

--- a/Tests/Rules/UseOutputTypeCorrectly.tests.ps1
+++ b/Tests/Rules/UseOutputTypeCorrectly.tests.ps1
@@ -14,7 +14,7 @@ $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {
 Describe "UseOutputTypeCorrectly" {
     Context "When there are violations" {
         It "has 2 Use OutputType Correctly violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -23,14 +23,14 @@ Describe "UseOutputTypeCorrectly" {
 
         if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
             It "Does not count violation in DSC class" {
-                $dscViolations.Count | Should Be 0
+                $dscViolations.Count | Should -Be 0
             }
         }
     }
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/UseOutputTypeCorrectly.tests.ps1
+++ b/Tests/Rules/UseOutputTypeCorrectly.tests.ps1
@@ -18,7 +18,7 @@ Describe "UseOutputTypeCorrectly" {
         }
 
         It "has the correct description message" {
-            $violations[1].Message | Should Match $violationMessage
+            $violations[1].Message | Should -Match $violationMessage
         }
 
         if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {

--- a/Tests/Rules/UseShouldProcessCorrectly.tests.ps1
+++ b/Tests/Rules/UseShouldProcessCorrectly.tests.ps1
@@ -13,7 +13,7 @@ $IsV3OrV4 = (Test-PSVersionV3) -or (Test-PSVersionV4)
 Describe "UseShouldProcessCorrectly" {
     Context "When there are violations" {
         It "has 3 should process violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -24,7 +24,7 @@ Describe "UseShouldProcessCorrectly" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 
@@ -57,7 +57,7 @@ function Bar
 Foo
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
         It "finds violation if downstream function does not declare SupportsShouldProcess" {
@@ -85,7 +85,7 @@ function Bar
 Foo
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "finds violation for 2 level downstream calls" {
@@ -118,7 +118,7 @@ function Bar
 Foo
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
     }
 
@@ -143,7 +143,7 @@ function Foo
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 
@@ -160,7 +160,7 @@ function Remove-Foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
         It "finds no violation when caller does not declare SupportsShouldProcess and callee is a cmdlet with ShouldProcess" {
@@ -174,7 +174,7 @@ function Remove-Foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
         # Install-Module is present by default only on PSv5 and above
@@ -189,7 +189,7 @@ function Install-Foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
         It "finds no violation when caller does not declare SupportsShouldProcess and callee is a function with ShouldProcess" {
@@ -202,7 +202,7 @@ function Install-Foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
        It "finds no violation for a function with self reference" {
@@ -226,7 +226,7 @@ function Install-ModuleWithDeps {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
 
        # Install-Module is present by default only on PSv5 and above
@@ -251,7 +251,7 @@ function Install-ModuleWithDeps {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations.Count | Should Be 0
+            $violations.Count | Should -Be 0
         }
     }
 
@@ -265,7 +265,7 @@ function Foo
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations[0].Extent.Text | Should Be 'SupportsShouldProcess'
+            $violations[0].Extent.Text | Should -Be 'SupportsShouldProcess'
         }
 
         It "should mark only the ShouldProcess call" {
@@ -277,7 +277,7 @@ function Foo
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule PSShouldProcess
-            $violations[0].Extent.Text | Should Be 'ShouldProcess'
+            $violations[0].Extent.Text | Should -Be 'ShouldProcess'
         }
     }
 }

--- a/Tests/Rules/UseShouldProcessCorrectly.tests.ps1
+++ b/Tests/Rules/UseShouldProcessCorrectly.tests.ps1
@@ -17,7 +17,7 @@ Describe "UseShouldProcessCorrectly" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
 
     }

--- a/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
+++ b/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
@@ -16,7 +16,7 @@ Function New-{0} () {{ }}
             $scriptDef = $scriptDefinitionGeneric -f $verb
             It ('finds "{0}" verb in function name' -f $verb) {
                 $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -IncludeRule $violationName
-                $violations.Count | Should Be 1
+                $violations.Count | Should -Be 1
             }
         }
 
@@ -26,7 +26,7 @@ Function New-{0} () {{ }}
     Context "When there are violations" {
     	$numViolations = 5
         It ("has {0} violations where ShouldProcess is not supported" -f $numViolations) {
-            $violations.Count | Should Be $numViolations
+            $violations.Count | Should -Be $numViolations
         }
 
         It "has the correct description message" {
@@ -34,13 +34,13 @@ Function New-{0} () {{ }}
         }
 
         It "has the correct extent" {
-        $violations[0].Extent.Text | Should Be "Set-MyObject"
+        $violations[0].Extent.Text | Should -Be "Set-MyObject"
         }
     }
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
+++ b/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
@@ -30,7 +30,7 @@ Function New-{0} () {{ }}
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
 
         It "has the correct extent" {

--- a/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
+++ b/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
@@ -3,7 +3,7 @@ $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
 
-$nounViolationMessage = "The cmdlet 'Verb-Files' uses a plural noun. A singular noun Should Be used instead."
+$nounViolationMessage = "The cmdlet 'Verb-Files' uses a plural noun. A singular noun should be used instead."
 $verbViolationMessage = "The cmdlet 'Verb-Files' uses an unapproved verb."
 $nounViolationName = "PSUseSingularNouns"
 $verbViolationName = "PSUseApprovedVerbs"

--- a/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
+++ b/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
@@ -3,7 +3,7 @@ $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
 
-$nounViolationMessage = "The cmdlet 'Verb-Files' uses a plural noun. A singular noun Should -Be used instead."
+$nounViolationMessage = "The cmdlet 'Verb-Files' uses a plural noun. A singular noun Should Be used instead."
 $verbViolationMessage = "The cmdlet 'Verb-Files' uses an unapproved verb."
 $nounViolationName = "PSUseSingularNouns"
 $verbViolationName = "PSUseApprovedVerbs"

--- a/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
+++ b/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
@@ -24,7 +24,7 @@ if (-not (Test-PSEditionCoreCLR))
             }
 
             It "has the correct description message" {
-                $nounViolations[0].Message | Should Match $nounViolationMessage
+                $nounViolations[0].Message | Should -Match $nounViolationMessage
             }
 
             It "has the correct extent" {
@@ -63,7 +63,7 @@ Describe "UseApprovedVerbs" {
         }
 
         It "has the correct description message" {
-            $verbViolations[0].Message | Should Match $verbViolationMessage
+            $verbViolations[0].Message | Should -Match $verbViolationMessage
         }
 
         It "has the correct extent" {

--- a/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
+++ b/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
@@ -3,7 +3,7 @@ $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
 
-$nounViolationMessage = "The cmdlet 'Verb-Files' uses a plural noun. A singular noun should be used instead."
+$nounViolationMessage = "The cmdlet 'Verb-Files' uses a plural noun. A singular noun Should -Be used instead."
 $verbViolationMessage = "The cmdlet 'Verb-Files' uses an unapproved verb."
 $nounViolationName = "PSUseSingularNouns"
 $verbViolationName = "PSUseApprovedVerbs"
@@ -20,7 +20,7 @@ if (-not (Test-PSEditionCoreCLR))
     Describe "UseSingularNouns" {
         Context "When there are violations" {
             It "has a cmdlet singular noun violation" {
-                $nounViolations.Count | Should Be 1
+                $nounViolations.Count | Should -Be 1
             }
 
             It "has the correct description message" {
@@ -28,7 +28,7 @@ if (-not (Test-PSEditionCoreCLR))
             }
 
             It "has the correct extent" {
-            $nounViolations[0].Extent.Text | Should be "Verb-Files"
+            $nounViolations[0].Extent.Text | Should -Be "Verb-Files"
             }
         }
 
@@ -44,13 +44,13 @@ Function Add-SomeData
                 Invoke-ScriptAnalyzer -ScriptDefinition $nounViolationScript `
                     -IncludeRule "PSUseSingularNouns" `
                     -OutVariable violations
-                $violations.Count | Should Be 0
+                $violations.Count | Should -Be 0
             }
         }
 
         Context "When there are no violations" {
             It "returns no violations" {
-                $nounNoViolations.Count | Should Be 0
+                $nounNoViolations.Count | Should -Be 0
             }
         }
     }
@@ -59,7 +59,7 @@ Function Add-SomeData
 Describe "UseApprovedVerbs" {
     Context "When there are violations" {
         It "has an approved verb violation" {
-            $verbViolations.Count | Should Be 1
+            $verbViolations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -67,13 +67,13 @@ Describe "UseApprovedVerbs" {
         }
 
         It "has the correct extent" {
-                $verbViolations[0].Extent.Text | Should be "Verb-Files"
+                $verbViolations[0].Extent.Text | Should -Be "Verb-Files"
         }
     }
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $verbNoViolations.Count | Should Be 0
+            $verbNoViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/UseSupportsShouldProcess.tests.ps1
+++ b/Tests/Rules/UseSupportsShouldProcess.tests.ps1
@@ -33,8 +33,8 @@ $s$s$s$s$s$s$s$s
 }
 "@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
         }
 
         It "Should return valid correction text if whatif is the first parameter" {
@@ -56,8 +56,8 @@ function foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
         }
 
         It "Should return valid correction text if whatif is in the middle" {
@@ -81,8 +81,8 @@ function foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
         }
 
 
@@ -105,8 +105,8 @@ function foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
 
         }
 
@@ -130,8 +130,8 @@ $s$s$s$s$s$s$s$s
 }
 "@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
         }
 
         It "Should find violation if both Whatif and Confirm are added" {
@@ -153,8 +153,8 @@ $s$s$s$s$s$s$s$s
 }
 "@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
             # TODO Make test-correction extent take more than 1 corrections
             # or modify the rule such that it outputs only 1 correction.
             # Test-CorrectionExtentFromContent $def $violation 2 $expectedViolationText ''
@@ -180,8 +180,8 @@ $s$s$s$s$s$s$s$s
 }
 "@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
         }
 
         It "Suggests adding SupportsShouldProcess attribute, when arguments are present" {
@@ -204,8 +204,8 @@ $s$s$s$s$s$s$s$s
 }
 "@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
         }
 
         It "Suggests replacing function parameter declaration with a param block" {
@@ -224,8 +224,8 @@ function foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
         }
 
         It "Suggests replacing function parameter declaration with whatif and confirm with a param block" {
@@ -244,8 +244,8 @@ function foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
         }
 
         It "Suggests replacing function parameter declaration with non-contiguous whatif and confirm with a param block" {
@@ -264,8 +264,8 @@ function foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
         }
 
         It "Suggests setting SupportsShouldProcess to `$true" {
@@ -283,8 +283,8 @@ function foo {
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $violations.Count | Should Be 1
-            $violations[0].SuggestedCorrections[0].Text | Should Be $expectedCorrection
+            $violations.Count | Should -Be 1
+            $violations[0].SuggestedCorrections[0].Text | Should -Be $expectedCorrection
         }
 
 

--- a/Tests/Rules/UseToExportFieldsInManifest.tests.ps1
+++ b/Tests/Rules/UseToExportFieldsInManifest.tests.ps1
@@ -31,28 +31,28 @@ Describe "UseManifestExportFields" {
     Context "Invalid manifest file" {
         It "does not process the manifest" {
             $results = Run-PSScriptAnalyzerRule $testManifestInvalidPath
-            $results | Should BeNullOrEmpty
+            $results | Should -BeNullOrEmpty
         }
     }
 
     Context "Manifest contains violations" {
         It "detects FunctionsToExport with wildcard" {
             $results = Run-PSScriptAnalyzerRule $testManifestBadFunctionsWildcardPath
-            $results.Count | Should be 1
-            $results[0].Extent.Text | Should be "'*'"
+            $results.Count | Should -Be 1
+            $results[0].Extent.Text | Should -Be "'*'"
         }
 
         It "suggests corrections for FunctionsToExport with wildcard" {
             $violations = Run-PSScriptAnalyzerRule $testManifestBadFunctionsWildcardPath
             $violationFilepath = Join-path $testManifestPath $testManifestBadFunctionsWildcardPath
             Test-CorrectionExtent $violationFilepath $violations[0] 1 "'*'" "@('Get-Bar', 'Get-Foo')"
-            $violations[0].SuggestedCorrections[0].Description | Should Be "Replace '*' with @('Get-Bar', 'Get-Foo')"
+            $violations[0].SuggestedCorrections[0].Description | Should -Be "Replace '*' with @('Get-Bar', 'Get-Foo')"
         }
 
         It "detects FunctionsToExport with null" {
             $results = Run-PSScriptAnalyzerRule $testManifestBadFunctionsNullPath
-            $results.Count | Should be 1
-            $results[0].Extent.Text | Should be '$null'
+            $results.Count | Should -Be 1
+            $results[0].Extent.Text | Should -Be '$null'
         }
 
         It "suggests corrections for FunctionsToExport with null and line wrapping" {
@@ -65,22 +65,22 @@ Describe "UseManifestExportFields" {
         It "detects array element containing wildcard" {
 	    # if more than two elements contain wildcard we can show only the first one as of now.
             $results = Run-PSScriptAnalyzerRule $testManifestBadFunctionsWildcardInArrayPath
-            $results.Count | Should be 2
-			($results | Where-Object {$_.Message -match "FunctionsToExport"}).Extent.Text | Should be "'Get-*'"
-            ($results | Where-Object {$_.Message -match "CmdletsToExport"}).Extent.Text | Should be "'Update-*'"
+            $results.Count | Should -Be 2
+			($results | Where-Object {$_.Message -match "FunctionsToExport"}).Extent.Text | Should -Be "'Get-*'"
+            ($results | Where-Object {$_.Message -match "CmdletsToExport"}).Extent.Text | Should -Be "'Update-*'"
 
         }
 
         It "detects CmdletsToExport with wildcard" {
             $results = Run-PSScriptAnalyzerRule $testManifestBadCmdletsWildcardPath
-            $results.Count | Should be 1
-            $results[0].Extent.Text | Should be "'*'"
+            $results.Count | Should -Be 1
+            $results[0].Extent.Text | Should -Be "'*'"
         }
 
         It "detects AliasesToExport with wildcard" {
             $results = Run-PSScriptAnalyzerRule $testManifestBadAliasesWildcardPath
-            $results.Count | Should be 1
-            $results[0].Extent.Text | Should be "'*'"
+            $results.Count | Should -Be 1
+            $results[0].Extent.Text | Should -Be "'*'"
         }
 
         It "suggests corrections for AliasesToExport with wildcard" -pending:($IsLinux -or $IsMacOS) {
@@ -91,14 +91,14 @@ Describe "UseManifestExportFields" {
 
         It "detects all the *ToExport violations" {
             $results = Run-PSScriptAnalyzerRule $testManifestBadAllPath
-            $results.Count | Should be 3
+            $results.Count | Should -Be 3
         }
     }
 
     Context "Manifest contains no violations" {
         It "detects all the *ToExport fields explicitly stating lists" {
             $results = Run-PSScriptAnalyzerRule $testManifestGoodPath
-            $results.Count | Should be 0
+            $results.Count | Should -Be 0
         }
     }
 
@@ -108,7 +108,7 @@ Describe "UseManifestExportFields" {
                 -Path "$directory/TestManifest/PowerShellDataFile.psd1" `
                 -IncludeRule "PSUseToExportFieldsInManifest" `
                 -OutVariable ruleViolation
-            $ruleViolation.Count | Should Be 0
+            $ruleViolation.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/UseUTF8EncodingForHelpFile.tests.ps1
+++ b/Tests/Rules/UseUTF8EncodingForHelpFile.tests.ps1
@@ -9,7 +9,7 @@ $notHelpFileViolations = Invoke-ScriptAnalyzer $directory\utf16.txt | Where-Obje
 Describe "UseUTF8EncodingForHelpFile" {
     Context "When there are violations" {
         It "has 1 avoid use utf8 encoding violation" {
-            $violations.Count | Should Be 1
+            $violations.Count | Should -Be 1
         }
 
         It "has the correct description message" {
@@ -20,11 +20,11 @@ Describe "UseUTF8EncodingForHelpFile" {
 
     Context "When there are no violations" {
         It "returns no violations for correct utf8 help file" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
 
         It "returns no violations for utf16 file that is not a help file" {
-            $notHelpFileViolations.Count | Should Be 0
+            $notHelpFileViolations.Count | Should -Be 0
         }
     }
 }

--- a/Tests/Rules/UseUTF8EncodingForHelpFile.tests.ps1
+++ b/Tests/Rules/UseUTF8EncodingForHelpFile.tests.ps1
@@ -13,7 +13,7 @@ Describe "UseUTF8EncodingForHelpFile" {
         }
 
         It "has the correct description message" {
-            $violations[0].Message | Should Match $violationMessage
+            $violations[0].Message | Should -Match $violationMessage
         }
 
     }

--- a/Tests/Rules/UseVerboseMessageInDSCResource.Tests.ps1
+++ b/Tests/Rules/UseVerboseMessageInDSCResource.Tests.ps1
@@ -14,7 +14,7 @@ Describe "UseVerboseMessageInDSCResource" {
         }
 
         It "has the correct description message" {
-            $violations[1].Message | Should Match $violationMessage
+            $violations[1].Message | Should -Match $violationMessage
         }
     }
 

--- a/Tests/Rules/UseVerboseMessageInDSCResource.Tests.ps1
+++ b/Tests/Rules/UseVerboseMessageInDSCResource.Tests.ps1
@@ -10,7 +10,7 @@ $noClassViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $direct
 Describe "UseVerboseMessageInDSCResource" {
     Context "When there are violations" {
         It "has 2 Verbose Message violations" {
-            $violations.Count | Should Be 2
+            $violations.Count | Should -Be 2
         }
 
         It "has the correct description message" {
@@ -20,7 +20,7 @@ Describe "UseVerboseMessageInDSCResource" {
 
     Context "When there are no violations" {
         It "returns no violations" {
-            $noViolations.Count | Should Be 0
+            $noViolations.Count | Should -Be 0
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,9 @@ install:
         $requiredPesterVersion = '4.1.1'
         $pester = Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq $requiredPesterVersion }
         $pester
-        if ($null -eq $pester) # WMF 4 build does not have pester
+        if ($null -eq $pester)
         {
-            nuget install Pester -Version 4.1.1 -source https://www.powershellgallery.com/api/v2 -outputDirectory "$Env:ProgramFiles\WindowsPowerShell\Modules\." -ExcludeVersion
+            Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser
         }
     - ps: |
         # the legacy WMF4 image only has the old preview SDKs of dotnet
@@ -37,8 +37,7 @@ install:
 build_script:
     - ps: |
         $PSVersionTable
-        Get-Module Pester -ListAvailable
-        Get-Command Invoke-Pester
+        (Get-Command Invoke-Pester).Version
         Push-Location C:\projects\psscriptanalyzer
         dotnet --version
         # Test build using netstandard to test whether APIs are being called that are not available in .Net Core. Remove output afterwards.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,9 +46,9 @@ install:
 build_script:
     - ps: |
         $PSVersionTable
-        (Get-Command Invoke-Pester).Version
+        Write-Verbose "Pester version: $((Get-Command Invoke-Pester).Version)" -Verbose
+        Write-Verbose ".NET SDK version: $(dotnet --version)" -Verbose
         Push-Location C:\projects\psscriptanalyzer
-        dotnet --version
         # Test build using netstandard to test whether APIs are being called that are not available in .Net Core. Remove output afterwards.
         .\buildCoreClr.ps1 -Framework netstandard1.6 -Configuration Release -Build
         git clean -dfx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ install:
 build_script:
     - ps: |
         $PSVersionTable
+        Get-Module Pester -ListAvailable
         Push-Location C:\projects\psscriptanalyzer
         dotnet --version
         # Test build using netstandard to test whether APIs are being called that are not available in .Net Core. Remove output afterwards.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
         $pester
         if ($null -eq $pester)
         {
-            if ($null -eq (Get-Command Install-Module))
+            if ($null -eq (Get-Module -ListAvailable PowershellGet))
             {
                 # WMF 4 image build
                 nuget install Pester -Version $requiredPesterVersion -source https://www.powershellgallery.com/api/v2 -outputDirectory "$Env:ProgramFiles\WindowsPowerShell\Modules\." -ExcludeVersion

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,16 @@ install:
         $pester
         if ($null -eq $pester)
         {
-            Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser
+            if ($null -eq (Get-Command Install-Module))
+            {
+                # WMF 4 image build
+                nuget install Pester -Version $requiredPesterVersion -source https://www.powershellgallery.com/api/v2 -outputDirectory "$Env:ProgramFiles\WindowsPowerShell\Modules\." -ExcludeVersion
+            }
+            else
+            {
+                # Visual Studio 2017 build (has already Pester v3, therefore a different installation mechanism is needed to make it also use the new version 4)
+                Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser
+            }
         }
     - ps: |
         # the legacy WMF4 image only has the old preview SDKs of dotnet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ build_script:
     - ps: |
         $PSVersionTable
         Get-Module Pester -ListAvailable
+        Get-Command Invoke-Pester
         Push-Location C:\projects\psscriptanalyzer
         dotnet --version
         # Test build using netstandard to test whether APIs are being called that are not available in .Net Core. Remove output afterwards.


### PR DESCRIPTION
## PR Summary

Closes #890
 - Fix Pester v4 installation that did not work for `VS 2017` image (got installed but was still using v3)
 - Change assertion operators to Pester 4 syntax by pre-pending the dash (`-`) to `Be`, `Not`, `Throw`, and `Match` operators (by going through all operators in the documentation of Pester's `Should` documentation.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] NA User facing documentation needed
- [x] Change is not breaking
- [ ] NA Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress : 
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
