### PR TITLE
Finalise new -ReportSummary switch

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -461,7 +461,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 
                 if (ReportSummary.IsPresent)
                 {
-                    logger.LogObject($"{DiagnosticSeverity.Error} : {errorCount} \t {DiagnosticSeverity.Warning} : {warningCount} \t {DiagnosticSeverity.Information} : {infoCount}", this);
+                    Host.UI.WriteLine($"{DiagnosticSeverity.Error} : {errorCount} \t {DiagnosticSeverity.Warning} : {warningCount} \t {DiagnosticSeverity.Information} : {infoCount}");
                 }
             }
 

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -464,15 +464,20 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                     var numberOfRuleViolations = infoCount + warningCount + errorCount;
                     if (numberOfRuleViolations == 0)
                     {
-                        Host.UI.WriteLine(foregroundColor: ConsoleColor.Green, backgroundColor: Host.UI.RawUI.BackgroundColor,
-                                          value: "0 rule violations found.");
+                        Host.UI.WriteLine("0 rule violations found.");
                     }
                     else
                     {
-                        var foregroundConsoleColor = warningCount + errorCount == 0 ? ConsoleColor.Yellow : ConsoleColor.Red;
                         var pluralS = numberOfRuleViolations > 1 ? "s" : string.Empty;
-                        Host.UI.WriteLine(foregroundColor: foregroundConsoleColor, backgroundColor: Host.UI.RawUI.BackgroundColor,
-                            value: $"{numberOfRuleViolations} rule violation{pluralS} found.    Severity distribution:  {DiagnosticSeverity.Error} = {errorCount}, {DiagnosticSeverity.Warning} = {warningCount}, {DiagnosticSeverity.Information} = {infoCount}");
+                        var message = $"{numberOfRuleViolations} rule violation{pluralS} found.    Severity distribution:  {DiagnosticSeverity.Error} = {errorCount}, {DiagnosticSeverity.Warning} = {warningCount}, {DiagnosticSeverity.Information} = {infoCount}";
+                        if (warningCount + errorCount == 0)
+                        {
+                            Host.UI.WriteWarningLine(message);
+                        }
+                        else
+                        {
+                            Host.UI.WriteErrorLine(message);
+                        }
                     }
                 }
             }

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -246,7 +246,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 
 #endif
         /// <summary>
-        ///      If true, reports an additional single line summary of issue counts.
+        /// Write a summary of rule violations to the host, which might be undesirable in some cases, therefore this switch is optional.
         /// </summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter ReportSummary
@@ -461,7 +461,19 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 
                 if (ReportSummary.IsPresent)
                 {
-                    Host.UI.WriteLine($"{DiagnosticSeverity.Error} : {errorCount} \t {DiagnosticSeverity.Warning} : {warningCount} \t {DiagnosticSeverity.Information} : {infoCount}");
+                    var numberOfRuleViolations = infoCount + warningCount + errorCount;
+                    if (numberOfRuleViolations == 0)
+                    {
+                        Host.UI.WriteLine(foregroundColor: ConsoleColor.Green, backgroundColor: Host.UI.RawUI.BackgroundColor,
+                                          value: "0 rule violations found.");
+                    }
+                    else
+                    {
+                        var foregroundConsoleColor = warningCount + errorCount == 0 ? ConsoleColor.Yellow : ConsoleColor.Red;
+                        var pluralS = numberOfRuleViolations > 1 ? "s" : string.Empty;
+                        Host.UI.WriteLine(foregroundColor: foregroundConsoleColor, backgroundColor: Host.UI.RawUI.BackgroundColor,
+                            value: $"{numberOfRuleViolations} rule violation{pluralS} found.    Severity distribution:  {DiagnosticSeverity.Error} = {errorCount}, {DiagnosticSeverity.Warning} = {warningCount}, {DiagnosticSeverity.Information} = {infoCount}");
+                    }
                 }
             }
 

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -472,11 +472,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                         var message = $"{numberOfRuleViolations} rule violation{pluralS} found.    Severity distribution:  {DiagnosticSeverity.Error} = {errorCount}, {DiagnosticSeverity.Warning} = {warningCount}, {DiagnosticSeverity.Information} = {infoCount}";
                         if (warningCount + errorCount == 0)
                         {
-                            Host.UI.WriteWarningLine(message);
+                            ConsoleHostHelper.DisplayMessageUsingSystemProperties(Host, "WarningForegroundColor", "WarningBackgroundColor", message);
                         }
                         else
                         {
-                            Host.UI.WriteErrorLine(message);
+                            ConsoleHostHelper.DisplayMessageUsingSystemProperties(Host, "ErrorForegroundColor", "ErrorBackgroundColor", message);
                         }
                     }
                 }

--- a/Engine/Generic/ConsoleHostHelper.cs
+++ b/Engine/Generic/ConsoleHostHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Management.Automation.Host;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
+{
+    internal static class ConsoleHostHelper
+    {
+        internal static void DisplayMessageUsingSystemProperties(PSHost psHost, string foregroundColorPropertyName, string backgroundPropertyName, string message)
+        {
+            var gotForegroundColor = TryGetPrivateDataConsoleColor(psHost, foregroundColorPropertyName, out ConsoleColor foregroundColor);
+            var gotBackgroundColor = TryGetPrivateDataConsoleColor(psHost, backgroundPropertyName, out ConsoleColor backgroundColor);
+            if (gotForegroundColor && gotBackgroundColor)
+            {
+                psHost.UI.WriteLine(foregroundColor: foregroundColor, backgroundColor: backgroundColor, value: message);
+            }
+            else
+            {
+                psHost.UI.WriteLine(message);
+            }
+        }
+
+        internal static bool TryGetPrivateDataConsoleColor(PSHost psHost, string propertyName, out ConsoleColor consoleColor)
+        {
+            consoleColor = default(ConsoleColor);
+            var property = psHost.PrivateData.Properties[propertyName];
+            if (property == null)
+            {
+                return false;
+            }
+
+            try
+            {
+                consoleColor = (ConsoleColor)Enum.Parse(typeof(ConsoleColor), property.Value.ToString(), true);
+            }
+            catch (InvalidCastException)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/Engine/Generic/ConsoleHostHelper.cs
+++ b/Engine/Generic/ConsoleHostHelper.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Management.Automation.Host;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
@@ -19,7 +22,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             }
         }
 
-        internal static bool TryGetPrivateDataConsoleColor(PSHost psHost, string propertyName, out ConsoleColor consoleColor)
+        private static bool TryGetPrivateDataConsoleColor(PSHost psHost, string propertyName, out ConsoleColor consoleColor)
         {
             consoleColor = default(ConsoleColor);
             var property = psHost.PrivateData.Properties[propertyName];

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -509,11 +509,11 @@ Describe "Test -EnableExit Switch" {
         $reportSummaryFor1Warning = '*1 rule violation found.    Severity distribution:  Error = 0, Warning = 1, Information = 0*'
         It "prints the correct report summary using the -NoReportSummary switch" {
             $result = powershell -command 'Invoke-Scriptanalyzer -ScriptDefinition gci -ReportSummary'
-            "$result" | Should BeLike $reportSummaryFor1Warning 
+            "$result" | Should -BeLike $reportSummaryFor1Warning 
         }
         It "does not print the report summary when not using -NoReportSummary switch" {
             $result = powershell -command 'Invoke-Scriptanalyzer -ScriptDefinition gci'
-            "$result" | Should Not BeLike $reportSummaryFor1Warning 
+            "$result" | Should -Not -BeLike $reportSummaryFor1Warning 
         }
     }
 }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -503,4 +503,16 @@ Describe "Test -EnableExit Switch" {
         powershell -Command 'Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit'
         $LASTEXITCODE  | Should Be 1
     }
+
+    Describe "-ReportSummary switch" {
+        $reportSummaryFor1Warning = '*1 rule violation found.    Severity distribution:  Error = 0, Warning = 1, Information = 0*'
+        It "prints the correct report summary using the -NoReportSummary switch" {
+            $result = powershell -command 'Invoke-Scriptanalyzer -ScriptDefinition gci -ReportSummary'
+            "$result" | Should BeLike $reportSummaryFor1Warning 
+        }
+        It "does not print the report summary when not using -NoReportSummary switch" {
+            $result = powershell -command 'Invoke-Scriptanalyzer -ScriptDefinition gci'
+            "$result" | Should Not BeLike $reportSummaryFor1Warning 
+        }
+    }
 }

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -106,7 +106,8 @@ function Invoke-ScriptAnalyzer {
     {
         if ($null -ne $results)
         {
-            Write-Host "$($results.Count) rule violations found.    Severity distribution:  Error = 1, Warning = 3, Information  = 5" -ForegroundColor Red # This is not the exact message that it would print but close enough
+			 # This is not the exact message that it would print but close enough
+            Write-Host "$($results.Count) rule violations found.    Severity distribution:  Error = 1, Warning = 3, Information  = 5" -ForegroundColor Red
         }
         else
         {

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -54,7 +54,10 @@ function Invoke-ScriptAnalyzer {
         [switch] $Fix,
 		
         [Parameter(Mandatory = $false)]
-        [switch] $EnableExit
+		[switch] $EnableExit,
+		
+		[Parameter(Mandatory = $false)]
+        [switch] $ReportSummary
 	)	
 
     if ($null -eq $CustomRulePath)
@@ -98,6 +101,11 @@ function Invoke-ScriptAnalyzer {
 	}
 	
 	$results
+
+	if ($ReportSummary.IsPresent -and $null -ne $results)
+    {
+        Write-Host "Found $results.Count warnings" # This is not the exact message that it would print but close enough
+    }
 	
     if ($EnableExit.IsPresent -and $null -ne $results)
     {

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -52,13 +52,13 @@ function Invoke-ScriptAnalyzer {
 
         [Parameter(Mandatory = $false)]
         [switch] $Fix,
+
+        [Parameter(Mandatory = $false)]
+        [switch] $EnableExit,
 		
         [Parameter(Mandatory = $false)]
-		[switch] $EnableExit,
-		
-		[Parameter(Mandatory = $false)]
         [switch] $ReportSummary
-	)	
+    )
 
     if ($null -eq $CustomRulePath)
     {

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -102,9 +102,16 @@ function Invoke-ScriptAnalyzer {
 	
 	$results
 
-	if ($ReportSummary.IsPresent -and $null -ne $results)
+    if ($ReportSummary.IsPresent)
     {
-        Write-Host "Found $results.Count warnings" # This is not the exact message that it would print but close enough
+        if ($null -ne $results)
+        {
+            Write-Host "$($results.Count) rule violations found.    Severity distribution:  Error = 1, Warning = 3, Information  = 5" -ForegroundColor Red # This is not the exact message that it would print but close enough
+        }
+        else
+        {
+            Write-Host '0 rule violations found.' -ForegroundColor Green
+        }
     }
 	
     if ($EnableExit.IsPresent -and $null -ne $results)

--- a/docs/markdown/Invoke-ScriptAnalyzer.md
+++ b/docs/markdown/Invoke-ScriptAnalyzer.md
@@ -12,14 +12,14 @@ Evaluates a script or module based on selected best practice rules
 ### UNNAMED_PARAMETER_SET_1
 ```
 Invoke-ScriptAnalyzer [-Path] <String> [-CustomRulePath <String>] [-RecurseCustomRulePath]
- [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-Fix] [-EnableExit]
+ [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-Fix] [-EnableExit] [-ReportSummary]
  [-Settings <String>]
 ```
 
 ### UNNAMED_PARAMETER_SET_2
 ```
 Invoke-ScriptAnalyzer [-ScriptDefinition] <String> [-CustomRulePath <String>] [-RecurseCustomRulePath]
- [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-EnableExit]
+ [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-EnableExit] [-ReportSummary]
  [-Settings <String>]
 ```
 
@@ -419,6 +419,21 @@ Accept wildcard characters: False
 
 ### -EnableExit
 Exits PowerShell and returns an exit code equal to the number of error records. This can be useful in CI systems.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReportSummary
+Writes a report summary of the found warnings to the host.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
## PR Summary

Fixes #857 and closes #868 

This is the tweak of the new `ReportSummary` of PR #868 by @StingyJack that:
- fixes the CI failures by adding the markdown documentation of the new `-ReportSummary` switch and adapting the library test function mock for consistency
- add tests for it
- tweak report summary with colour and wording.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] User facing documentation needed: Added help to cmdlet description
- [x] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [ ] This PR is ready to merge and is not work in progress. It is ready but we need to merge PR 892 with the fix for Pester v4 in the `Visual Studio 2017` image first
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
