### PR TITLE
Remove redundant 'dotnet restore' tasks in build because .Net Core 2 handles it automatically

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -78,14 +78,6 @@ function Get-BuildTaskParams($project) {
     $taskParams
 }
 
-function Get-RestoreTaskParams($project) {
-    @{
-        Inputs  = "$BuildRoot/$project/$project.csproj"
-        Outputs = "$BuildRoot/$project/$project.csproj"
-        Jobs    = {dotnet restore}
-    }
-}
-
 function Get-CleanTaskParams($project) {
     @{
         Jobs = {
@@ -122,13 +114,11 @@ popd
 $projects = @("engine", "rules")
 $projects | ForEach-Object {
     Add-ProjectTask $_ build (Get-BuildTaskParams $_)
-    Add-ProjectTask $_ restore (Get-RestoreTaskParams $_)
     Add-ProjectTask $_ clean (Get-CleanTaskParams $_)
     Add-ProjectTask $_ test (Get-TestTaskParam $_) "$BuildRoot/tests"
 }
 
 task build "engine/build", "rules/build"
-task restore "engine/restore", "rules/restore"
 task clean "engine/clean", "rules/clean"
 task test "engine/test", "rules/test"
 

--- a/buildCoreClr.ps1
+++ b/buildCoreClr.ps1
@@ -1,8 +1,5 @@
 ﻿param(
-    # Automatically performs a 'dotnet restore' when being run the first time
     [switch]$Build,
-    # Restore Projects in case NuGet packages have changed
-    [switch]$Restore,
     [switch]$Uninstall,
     [switch]$Install,
 
@@ -16,19 +13,6 @@
 if ($Configuration -match "PSv3" -and $Framework -eq "netstandard1.6")
 {
     throw ("{0} configuration is not applicable to {1} framework" -f $Configuration,$Framework)
-}
-
-Function Test-DotNetRestore
-{
-    param(
-        [string] $projectPath
-    )
-    Test-Path ([System.IO.Path]::Combine($projectPath, 'obj', 'project.assets.json'))
-}
-
-function Invoke-RestoreSolution
-{
-    dotnet restore (Join-Path $PSScriptRoot .\PSScriptAnalyzer.sln)
 }
 
 Write-Progress "Building ScriptAnalyzer"
@@ -56,28 +40,14 @@ elseif ($Configuration -match 'PSv3') {
     $destinationDirBinaries = "$destinationDir\PSv3"
 }
 
-if ($Restore.IsPresent)
-{
-    Invoke-RestoreSolution
-}
-
 if ($build)
 {
 
     Write-Progress "Building Engine"
-    if (-not (Test-DotNetRestore((Join-Path $solutionDir Engine))))
-    {
-        Invoke-RestoreSolution
-    }
     Push-Location Engine\
     dotnet build Engine.csproj --framework $Framework --configuration $Configuration
     Pop-Location
 
-
-    if (-not (Test-DotNetRestore((Join-Path $solutionDir Rules))))
-    {
-        Invoke-RestoreSolution
-    }
     Write-Progress "Building for framework $Framework, configuration $Configuration"
     Push-Location Rules\
     dotnet build Rules.csproj --framework $Framework --configuration $Configuration


### PR DESCRIPTION
## PR Summary

Remove redundant 'dotnet restore' tasks in build because .Net Core 2 handles it automatically

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [NA] User facing documentation needed
- [x] Change is not breaking
- [NA] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
