### PR TITLE
Update from Pester 4.1.1 to 4.3.1 and use new -BeTrue and -BeFalse operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For adding/removing resource strings in the `*.resx` files, it is recommended to
 #### Tests
 Pester-based ScriptAnalyzer Tests are located in `path/to/PSScriptAnalyzer/Tests` folder.
 
-* Ensure Pester 4.1.1 is installed on the machine
+* Ensure [Pester 4.3.1](https://www.powershellgallery.com/packages/Pester/4.3.1) is installed
 * Copy `path/to/PSScriptAnalyzer/out/PSScriptAnalyzer` to a folder in `PSModulePath`
 * Go the Tests folder in your local repository
 * Run Engine Tests:

--- a/Tests/Engine/Extensions.tests.ps1
+++ b/Tests/Engine/Extensions.tests.ps1
@@ -118,7 +118,7 @@ Describe "AttributeAst extension methods" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0]
             $extNamespace::IsCmdletBindingAttributeAst($funcDefnAst.Body.ParamBlock.Attributes[0]) |
-                Should -Be $true
+                Should BeTrue
         }
     }
 
@@ -145,7 +145,7 @@ Describe "NamedAttributeArgumentAst" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
-            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -Be $true
+            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should BeTrue
             $expressionAst | Should -Be $null
         }
 
@@ -156,7 +156,7 @@ Describe "NamedAttributeArgumentAst" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
-            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -Be $true
+            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should BeTrue
             $expressionAst | Should -Not -Be $null
         }
 
@@ -167,7 +167,7 @@ Describe "NamedAttributeArgumentAst" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
-            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -Be $false
+            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should BeFalse
             $expressionAst | Should -Not -Be $null
 
         }

--- a/Tests/Engine/Extensions.tests.ps1
+++ b/Tests/Engine/Extensions.tests.ps1
@@ -118,7 +118,7 @@ Describe "AttributeAst extension methods" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0]
             $extNamespace::IsCmdletBindingAttributeAst($funcDefnAst.Body.ParamBlock.Attributes[0]) |
-                Should BeTrue
+                Should -BeTrue
         }
     }
 
@@ -145,7 +145,7 @@ Describe "NamedAttributeArgumentAst" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
-            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should BeTrue
+            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -BeTrue
             $expressionAst | Should -Be $null
         }
 
@@ -156,7 +156,7 @@ Describe "NamedAttributeArgumentAst" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
-            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should BeTrue
+            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -BeTrue
             $expressionAst | Should -Not -Be $null
         }
 
@@ -167,7 +167,7 @@ Describe "NamedAttributeArgumentAst" {
                     param($param1, $param2)
                 }}.Ast.EndBlock.Statements[0].Body.ParamBlock.Attributes[0].NamedArguments[0]
             $expressionAst = $null
-            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should BeFalse
+            $extNamespace::GetValue($attrAst, [ref]$expressionAst) | Should -BeFalse
             $expressionAst | Should -Not -Be $null
 
         }

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -14,7 +14,7 @@ Describe "Test available parameters" {
     $params = $sa.Parameters
     Context "Name parameter" {
         It "has a RuleName parameter" {
-            $params.ContainsKey("Name") | Should BeTrue
+            $params.ContainsKey("Name") | Should -BeTrue
         }
 
         It "accepts string" {
@@ -24,7 +24,7 @@ Describe "Test available parameters" {
 
     Context "RuleExtension parameters" {
         It "has a RuleExtension parameter" {
-            $params.ContainsKey("CustomRulePath") | Should BeTrue
+            $params.ContainsKey("CustomRulePath") | Should -BeTrue
         }
 
         It "accepts string array" {
@@ -32,7 +32,7 @@ Describe "Test available parameters" {
         }
 
 		It "takes CustomizedRulePath parameter as an alias of CustomRulePath parameter" {
-			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should BeTrue
+			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should -BeTrue
 		}
     }
 

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -14,7 +14,7 @@ Describe "Test available parameters" {
     $params = $sa.Parameters
     Context "Name parameter" {
         It "has a RuleName parameter" {
-            $params.ContainsKey("Name") | Should -Be $true
+            $params.ContainsKey("Name") | Should BeTrue
         }
 
         It "accepts string" {
@@ -24,7 +24,7 @@ Describe "Test available parameters" {
 
     Context "RuleExtension parameters" {
         It "has a RuleExtension parameter" {
-            $params.ContainsKey("CustomRulePath") | Should -Be $true
+            $params.ContainsKey("CustomRulePath") | Should BeTrue
         }
 
         It "accepts string array" {
@@ -32,7 +32,7 @@ Describe "Test available parameters" {
         }
 
 		It "takes CustomizedRulePath parameter as an alias of CustomRulePath parameter" {
-			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should -Be $true
+			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should BeTrue
 		}
     }
 

--- a/Tests/Engine/Helper.tests.ps1
+++ b/Tests/Engine/Helper.tests.ps1
@@ -20,12 +20,12 @@ Describe "Test Directed Graph" {
         It "correctly adds the edges" {
             $digraph.GetOutDegree('v1') | Should -Be 2
             $neighbors = $digraph.GetNeighbors('v1')
-            $neighbors -contains 'v2' | Should -Be $true
-            $neighbors -contains 'v5' | Should -Be $true
+            $neighbors -contains 'v2' | Should BeTrue
+            $neighbors -contains 'v5' | Should BeTrue
         }
 
         It "finds the connection" {
-            $digraph.IsConnected('v1', 'v4') | Should -Be $true
+            $digraph.IsConnected('v1', 'v4') | Should BeTrue
         }
     }
 }

--- a/Tests/Engine/Helper.tests.ps1
+++ b/Tests/Engine/Helper.tests.ps1
@@ -20,12 +20,12 @@ Describe "Test Directed Graph" {
         It "correctly adds the edges" {
             $digraph.GetOutDegree('v1') | Should -Be 2
             $neighbors = $digraph.GetNeighbors('v1')
-            $neighbors -contains 'v2' | Should BeTrue
-            $neighbors -contains 'v5' | Should BeTrue
+            $neighbors -contains 'v2' | Should -BeTrue
+            $neighbors -contains 'v5' | Should -BeTrue
         }
 
         It "finds the connection" {
-            $digraph.IsConnected('v1', 'v4') | Should BeTrue
+            $digraph.IsConnected('v1', 'v4') | Should -BeTrue
         }
     }
 }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -21,7 +21,7 @@ Describe "Test available parameters" {
     $params = $sa.Parameters
     Context "Path parameter" {
         It "has a Path parameter" {
-            $params.ContainsKey("Path") | Should -Be $true
+            $params.ContainsKey("Path") | Should BeTrue
         }
 
         It "accepts string" {
@@ -31,7 +31,7 @@ Describe "Test available parameters" {
 
     Context "Path parameter" {
         It "has a ScriptDefinition parameter" {
-            $params.ContainsKey("ScriptDefinition") | Should -Be $true
+            $params.ContainsKey("ScriptDefinition") | Should BeTrue
         }
 
         It "accepts string" {
@@ -41,7 +41,7 @@ Describe "Test available parameters" {
 
     Context "CustomRulePath parameters" {
         It "has a CustomRulePath parameter" {
-            $params.ContainsKey("CustomRulePath") | Should -Be $true
+            $params.ContainsKey("CustomRulePath") | Should BeTrue
         }
 
         It "accepts a string array" {
@@ -49,13 +49,13 @@ Describe "Test available parameters" {
         }
 
 		It "has a CustomizedRulePath alias"{
-			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should -Be $true
+			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should BeTrue
 		}
     }
 
     Context "IncludeRule parameters" {
         It "has an IncludeRule parameter" {
-            $params.ContainsKey("IncludeRule") | Should -Be $true
+            $params.ContainsKey("IncludeRule") | Should BeTrue
         }
 
         It "accepts string array" {
@@ -65,7 +65,7 @@ Describe "Test available parameters" {
 
     Context "Severity parameters" {
         It "has a severity parameters" {
-            $params.ContainsKey("Severity") | Should -Be $true
+            $params.ContainsKey("Severity") | Should BeTrue
         }
 
         It "accepts string array" {
@@ -77,7 +77,7 @@ Describe "Test available parameters" {
     {
         Context "SaveDscDependency parameter" {
             It "has the parameter" {
-                $params.ContainsKey("SaveDscDependency") | Should -Be $true
+                $params.ContainsKey("SaveDscDependency") | Should BeTrue
             }
 
             It "is a switch parameter" {
@@ -100,7 +100,7 @@ Describe "Test available parameters" {
                 }
             }
 
-            $hasFile | Should -Be $true
+            $hasFile | Should BeTrue
         }
 
         It "Has ScriptDefinition parameter set" {
@@ -112,7 +112,7 @@ Describe "Test available parameters" {
                 }
             }
 
-            $hasFile | Should -Be $true
+            $hasFile | Should BeTrue
         }
 
     }
@@ -132,7 +132,7 @@ Describe "Test Path" {
         It "Has the same effect as without Path parameter" {
             $withPath = Invoke-ScriptAnalyzer $directory\TestScript.ps1
             $withoutPath = Invoke-ScriptAnalyzer -Path $directory\TestScript.ps1
-            $withPath.Count -eq $withoutPath.Count | Should -Be $true
+            $withPath.Count -eq $withoutPath.Count | Should BeTrue
         }
 
         It "Does not run rules on script with more than 10 parser errors" {
@@ -199,7 +199,7 @@ Describe "Test Path" {
         $withPathWithDirectory = Invoke-ScriptAnalyzer -Recurse -Path $directory\RecursionDirectoryTest
 
         It "Has the same count as without Path parameter"{
-            $withoutPathWithDirectory.Count -eq $withPathWithDirectory.Count | Should -Be $true
+            $withoutPathWithDirectory.Count -eq $withPathWithDirectory.Count | Should BeTrue
         }
 
         It "Analyzes all the files" {
@@ -209,7 +209,7 @@ Describe "Test Path" {
             Write-Output $globalVarsViolation.Count
             Write-Output $clearHostViolation.Count
             Write-Output $writeHostViolation.Count
-            $globalVarsViolation.Count -eq 1 -and $writeHostViolation.Count -eq 1 | Should -Be $true
+            $globalVarsViolation.Count -eq 1 -and $writeHostViolation.Count -eq 1 | Should BeTrue
         }
     }
 }
@@ -231,7 +231,7 @@ Describe "Test ExcludeRule" {
         It "does not exclude any rules" {
             $noExclude = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1
             $withExclude = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -ExcludeRule "This is a wrong rule"
-            $withExclude.Count -eq $noExclude.Count | Should -Be $true
+            $withExclude.Count -eq $noExclude.Count | Should BeTrue
         }
     }
 

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -21,7 +21,7 @@ Describe "Test available parameters" {
     $params = $sa.Parameters
     Context "Path parameter" {
         It "has a Path parameter" {
-            $params.ContainsKey("Path") | Should BeTrue
+            $params.ContainsKey("Path") | Should -BeTrue
         }
 
         It "accepts string" {
@@ -31,7 +31,7 @@ Describe "Test available parameters" {
 
     Context "Path parameter" {
         It "has a ScriptDefinition parameter" {
-            $params.ContainsKey("ScriptDefinition") | Should BeTrue
+            $params.ContainsKey("ScriptDefinition") | Should -BeTrue
         }
 
         It "accepts string" {
@@ -41,7 +41,7 @@ Describe "Test available parameters" {
 
     Context "CustomRulePath parameters" {
         It "has a CustomRulePath parameter" {
-            $params.ContainsKey("CustomRulePath") | Should BeTrue
+            $params.ContainsKey("CustomRulePath") | Should -BeTrue
         }
 
         It "accepts a string array" {
@@ -49,13 +49,13 @@ Describe "Test available parameters" {
         }
 
 		It "has a CustomizedRulePath alias"{
-			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should BeTrue
+			$params.CustomRulePath.Aliases.Contains("CustomizedRulePath") | Should -BeTrue
 		}
     }
 
     Context "IncludeRule parameters" {
         It "has an IncludeRule parameter" {
-            $params.ContainsKey("IncludeRule") | Should BeTrue
+            $params.ContainsKey("IncludeRule") | Should -BeTrue
         }
 
         It "accepts string array" {
@@ -65,7 +65,7 @@ Describe "Test available parameters" {
 
     Context "Severity parameters" {
         It "has a severity parameters" {
-            $params.ContainsKey("Severity") | Should BeTrue
+            $params.ContainsKey("Severity") | Should -BeTrue
         }
 
         It "accepts string array" {
@@ -77,7 +77,7 @@ Describe "Test available parameters" {
     {
         Context "SaveDscDependency parameter" {
             It "has the parameter" {
-                $params.ContainsKey("SaveDscDependency") | Should BeTrue
+                $params.ContainsKey("SaveDscDependency") | Should -BeTrue
             }
 
             It "is a switch parameter" {
@@ -100,7 +100,7 @@ Describe "Test available parameters" {
                 }
             }
 
-            $hasFile | Should BeTrue
+            $hasFile | Should -BeTrue
         }
 
         It "Has ScriptDefinition parameter set" {
@@ -112,7 +112,7 @@ Describe "Test available parameters" {
                 }
             }
 
-            $hasFile | Should BeTrue
+            $hasFile | Should -BeTrue
         }
 
     }
@@ -132,7 +132,7 @@ Describe "Test Path" {
         It "Has the same effect as without Path parameter" {
             $withPath = Invoke-ScriptAnalyzer $directory\TestScript.ps1
             $withoutPath = Invoke-ScriptAnalyzer -Path $directory\TestScript.ps1
-            $withPath.Count -eq $withoutPath.Count | Should BeTrue
+            $withPath.Count -eq $withoutPath.Count | Should -BeTrue
         }
 
         It "Does not run rules on script with more than 10 parser errors" {
@@ -199,7 +199,7 @@ Describe "Test Path" {
         $withPathWithDirectory = Invoke-ScriptAnalyzer -Recurse -Path $directory\RecursionDirectoryTest
 
         It "Has the same count as without Path parameter"{
-            $withoutPathWithDirectory.Count -eq $withPathWithDirectory.Count | Should BeTrue
+            $withoutPathWithDirectory.Count -eq $withPathWithDirectory.Count | Should -BeTrue
         }
 
         It "Analyzes all the files" {
@@ -209,7 +209,7 @@ Describe "Test Path" {
             Write-Output $globalVarsViolation.Count
             Write-Output $clearHostViolation.Count
             Write-Output $writeHostViolation.Count
-            $globalVarsViolation.Count -eq 1 -and $writeHostViolation.Count -eq 1 | Should BeTrue
+            $globalVarsViolation.Count -eq 1 -and $writeHostViolation.Count -eq 1 | Should -BeTrue
         }
     }
 }
@@ -231,7 +231,7 @@ Describe "Test ExcludeRule" {
         It "does not exclude any rules" {
             $noExclude = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1
             $withExclude = Invoke-ScriptAnalyzer $directory\..\Rules\BadCmdlet.ps1 -ExcludeRule "This is a wrong rule"
-            $withExclude.Count -eq $noExclude.Count | Should BeTrue
+            $withExclude.Count -eq $noExclude.Count | Should -BeTrue
         }
     }
 

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -33,8 +33,8 @@ Enter the version of the module to test. This parameter is optional. If you
 omit it, the test runs on the latest version of the module in $env:PSModulePath.
 
 .EXAMPLE
-.\Module.Help.Tests.ps1 -ModuleName Pester -RequiredVersion 4.1.1
-This command runs the tests on the commands in Pester 4.1.1.
+.\Module.Help.Tests.ps1 -ModuleName Pester -RequiredVersion 4.3.1
+This command runs the tests on the commands in Pester 4.3.1.
 
 .EXAMPLE
 .\Module.Help.Tests.ps1 -ModuleName Pester
@@ -63,7 +63,7 @@ Param
 	$RequiredVersion
 )
 
-# #Requires -Module @{ModuleName = 'Pester'; ModuleVersion = '4.1.1'}
+# #Requires -Module @{ModuleName = 'Pester'; ModuleVersion = '4.3.1'}
 
 <#
 .SYNOPSIS

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -310,7 +310,7 @@ foreach ($command in $commands) {
 				}
 				# Shouldn't find extra parameters in help.
 				It "finds help parameter in code: $helpParm" {
-					$helpParm -in $parameterNames | Should BeTrue
+					$helpParm -in $parameterNames | Should -BeTrue
 				}
 			}
 		}

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -310,7 +310,7 @@ foreach ($command in $commands) {
 				}
 				# Shouldn't find extra parameters in help.
 				It "finds help parameter in code: $helpParm" {
-					$helpParm -in $parameterNames | Should -Be $true
+					$helpParm -in $parameterNames | Should BeTrue
 				}
 			}
 		}

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -111,7 +111,7 @@ Describe "Settings Class" {
         }
 
         It "Should parse boolean type argument" {
-            $settings.RuleArguments["PSUseConsistentIndentation"]["Enable"] | Should -Be $true
+            $settings.RuleArguments["PSUseConsistentIndentation"]["Enable"] | Should BeTrue
         }
 
         It "Should parse int type argument" {
@@ -162,7 +162,7 @@ Describe "Settings Class" {
                 $settingsHashtable.Add($paramName, $true)
 
                 $settings = New-Object -TypeName $settingsTypeName -ArgumentList $settingsHashtable
-                $settings."$paramName" | Should -Be $true
+                $settings."$paramName" | Should BeTrue
             }
 
             It "Should correctly set the value if a boolean is given - false" {
@@ -170,7 +170,7 @@ Describe "Settings Class" {
                 $settingsHashtable.Add($paramName, $false)
 
                 $settings = New-Object -TypeName $settingsTypeName -ArgumentList $settingsHashtable
-                $settings."$paramName" | Should -Be $false
+                $settings."$paramName" | Should BeFalse
             }
 
             It "Should throw if a non-boolean value is given" {
@@ -183,7 +183,7 @@ Describe "Settings Class" {
             It "Should detect the parameter in a settings file" {
                 $settings = New-Object -TypeName $settingsTypeName `
                     -ArgumentList ([System.IO.Path]::Combine($project1Root, "CustomRulePathSettings.psd1"))
-                $settings."$paramName" | Should -Be $true
+                $settings."$paramName" | Should BeTrue
             }
         }
     }

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -111,7 +111,7 @@ Describe "Settings Class" {
         }
 
         It "Should parse boolean type argument" {
-            $settings.RuleArguments["PSUseConsistentIndentation"]["Enable"] | Should BeTrue
+            $settings.RuleArguments["PSUseConsistentIndentation"]["Enable"] | Should -BeTrue
         }
 
         It "Should parse int type argument" {
@@ -162,7 +162,7 @@ Describe "Settings Class" {
                 $settingsHashtable.Add($paramName, $true)
 
                 $settings = New-Object -TypeName $settingsTypeName -ArgumentList $settingsHashtable
-                $settings."$paramName" | Should BeTrue
+                $settings."$paramName" | Should -BeTrue
             }
 
             It "Should correctly set the value if a boolean is given - false" {
@@ -170,7 +170,7 @@ Describe "Settings Class" {
                 $settingsHashtable.Add($paramName, $false)
 
                 $settings = New-Object -TypeName $settingsTypeName -ArgumentList $settingsHashtable
-                $settings."$paramName" | Should BeFalse
+                $settings."$paramName" | Should -BeFalse
             }
 
             It "Should throw if a non-boolean value is given" {
@@ -183,7 +183,7 @@ Describe "Settings Class" {
             It "Should detect the parameter in a settings file" {
                 $settings = New-Object -TypeName $settingsTypeName `
                     -ArgumentList ([System.IO.Path]::Combine($project1Root, "CustomRulePathSettings.psd1"))
-                $settings."$paramName" | Should BeTrue
+                $settings."$paramName" | Should -BeTrue
             }
         }
     }

--- a/Tests/Engine/SettingsTest/Issue828/Issue828.tests.ps1
+++ b/Tests/Engine/SettingsTest/Issue828/Issue828.tests.ps1
@@ -22,6 +22,6 @@ Describe "Issue 828: No NullReferenceExceptionin AlignAssignmentStatement rule w
             Set-Location $initialLocation
         }
         
-        $cmdletThrewError | Should BeFalse
+        $cmdletThrewError | Should -BeFalse
     }
 }

--- a/Tests/Engine/SettingsTest/Issue828/Issue828.tests.ps1
+++ b/Tests/Engine/SettingsTest/Issue828/Issue828.tests.ps1
@@ -22,6 +22,6 @@ Describe "Issue 828: No NullReferenceExceptionin AlignAssignmentStatement rule w
             Set-Location $initialLocation
         }
         
-        $cmdletThrewError | Should -Be $false
+        $cmdletThrewError | Should BeFalse
     }
 }

--- a/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
+++ b/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
@@ -59,32 +59,32 @@ ModuleVersion = '1.0.0.0'
     Context "Validate the contents of a .psd1 file" {
         It "detects a valid module manifest file" {
             $filepath = Join-Path $directory "TestManifest/ManifestGood.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should BeTrue
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should -BeTrue
         }
 
         It "detects a .psd1 file which is not module manifest" {
             $filepath = Join-Path $directory "TestManifest/PowerShellDataFile.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should BeFalse
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should -BeFalse
         }
 
         It "detects valid module manifest file for PSv5" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv5.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should BeTrue
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should -BeTrue
         }
 
         It "does not validate PSv5 module manifest file for PSv3 check" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv5.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should BeFalse
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should -BeFalse
         }
 
         It "detects valid module manifest file for PSv4" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv4.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"4.0.0") | Should BeTrue
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"4.0.0") | Should -BeTrue
         }
 
         It "detects valid module manifest file for PSv3" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv3.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should BeTrue
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should -BeTrue
         }
     }
 

--- a/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
+++ b/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
@@ -52,39 +52,39 @@ ModuleVersion = '1.0.0.0'
 
     Context "When an .psd1 file doesn't contain a hashtable" {
         It "does not throw exception" {
-            {Invoke-ScriptAnalyzer -Path $noHashtableFilepath -IncludeRule $missingMemberRuleName} | Should -Not -Throw
+            Invoke-ScriptAnalyzer -Path $noHashtableFilepath -IncludeRule $missingMemberRuleName
         }
     }
 
     Context "Validate the contents of a .psd1 file" {
         It "detects a valid module manifest file" {
             $filepath = Join-Path $directory "TestManifest/ManifestGood.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should -Be $true
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should BeTrue
         }
 
         It "detects a .psd1 file which is not module manifest" {
             $filepath = Join-Path $directory "TestManifest/PowerShellDataFile.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should -Be $false
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should BeFalse
         }
 
         It "detects valid module manifest file for PSv5" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv5.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should -Be $true
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"5.0.0") | Should BeTrue
         }
 
         It "does not validate PSv5 module manifest file for PSv3 check" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv5.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should -Be $false
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should BeFalse
         }
 
         It "detects valid module manifest file for PSv4" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv4.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"4.0.0") | Should -Be $true
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"4.0.0") | Should BeTrue
         }
 
         It "detects valid module manifest file for PSv3" {
             $filepath = Join-Path $directory "TestManifest/ManifestGoodPsv3.psd1"
-            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should -Be $true
+            [Microsoft.Windows.PowerShell.ScriptAnalyzer.Helper]::IsModuleManifest($filepath, [version]"3.0.0") | Should BeTrue
         }
     }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ cache:
 install:
     - ps: nuget install platyPS -Version 0.9.0 -source https://www.powershellgallery.com/api/v2 -outputDirectory "$Env:ProgramFiles\WindowsPowerShell\Modules\." -ExcludeVersion
     - ps: |
-        $requiredPesterVersion = '4.1.1'
+        $requiredPesterVersion = '4.3.1'
         $pester = Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq $requiredPesterVersion }
         $pester
         if ($null -eq $pester)

--- a/build.ps1
+++ b/build.ps1
@@ -132,7 +132,7 @@ if ($Install)
 
 if ($Test)
 {
-    Import-Module -Name Pester -MinimumVersion 4.1.1 -ErrorAction Stop
+    Import-Module -Name Pester -MinimumVersion 4.3.1 -ErrorAction Stop
     Function GetTestRunnerScriptContent($testPath)
     {
         $x = @"


### PR DESCRIPTION
## PR Summary

Pester released 2 new versions this week with new assertion operators.
- Update Pester from version 4.1.1 to 4.3.1
- Convert calls to `Should -Be $true` to new operator `Should BeTrue` and similar for `Should BeFalse` that were added in 4.2
- `Should -Not -Throw` got officially deprecated in 4.2 -> remove assertion because when an exception is thrown, it automatically means that the test should not pass as recommended in the Pester release notes
- Existing count assertion are not converted to the new `-HaveCount` operator (yet) because existing tests need adaption (and I also suspect a bug in the new operator I raised the first issue [here](https://github.com/pester/Pester/issues/1000)). This also keeps the diff relatively small.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [NA] User facing documentation needed
- [x] Change is not breaking
- [NA] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
