### PR TITLE
Allow relative settings path

### DIFF
--- a/Engine/Commands/InvokeFormatterCommand.cs
+++ b/Engine/Commands/InvokeFormatterCommand.cs
@@ -1,18 +1,8 @@
-//
-// Copyright (c) Microsoft Corporation.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using System;
 using System.Globalization;
-using System.Linq;
 using System.Management.Automation;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
@@ -91,7 +81,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             this.range = Range == null ? null : new Range(Range[0], Range[1], Range[2], Range[3]);
             try
             {
-                inputSettings = PSSASettings.Create(Settings, this.MyInvocation.PSScriptRoot, this);
+                inputSettings = PSSASettings.Create(Settings, this.MyInvocation.PSScriptRoot, this, GetResolvedProviderPathFromPSPath);
             }
             catch (Exception e)
             {

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -293,9 +293,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             var combIncludeDefaultRules = IncludeDefaultRules.IsPresent;
             try
             {
+                var currentWorkingDirectory = CurrentProviderLocation("FileSystem").ProviderPath;
                 var settingsObj = PSSASettings.Create(
                     settings,
-                    processedPaths == null || processedPaths.Count == 0 ? null : processedPaths[0],
+                    processedPaths == null || processedPaths.Count == 0 ? currentWorkingDirectory : processedPaths[0],
                     this);
                 if (settingsObj != null)
                 {

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -1,32 +1,16 @@
-﻿//
-// Copyright (c) Microsoft Corporation.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
-using System.Text.RegularExpressions;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System;
-using System.ComponentModel;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Management.Automation;
-using System.Management.Automation.Language;
-using System.IO;
-using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
-using System.Threading.Tasks;
-using System.Collections.Concurrent;
-using System.Threading;
 using System.Management.Automation.Runspaces;
-using System.Collections;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 {
@@ -293,11 +277,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             var combIncludeDefaultRules = IncludeDefaultRules.IsPresent;
             try
             {
-                var currentWorkingDirectory = CurrentProviderLocation("FileSystem").ProviderPath;
                 var settingsObj = PSSASettings.Create(
                     settings,
-                    processedPaths == null || processedPaths.Count == 0 ? currentWorkingDirectory : processedPaths[0],
-                    this);
+                    processedPaths == null || processedPaths.Count == 0 ? null : processedPaths[0],
+                    this, GetResolvedProviderPathFromPSPath);
                 if (settingsObj != null)
                 {
                     ScriptAnalyzer.Instance.UpdateSettings(settingsObj);

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -280,7 +280,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                 var settingsObj = PSSASettings.Create(
                     settings,
                     processedPaths == null || processedPaths.Count == 0 ? null : processedPaths[0],
-                    this, GetResolvedProviderPathFromPSPath);
+                    this,
+                    GetResolvedProviderPathFromPSPath);
                 if (settingsObj != null)
                 {
                     ScriptAnalyzer.Instance.UpdateSettings(settingsObj);

--- a/Engine/Generic/PathResolver.cs
+++ b/Engine/Generic/PathResolver.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
+{
+    internal static class PathResolver
+    {
+        /// <summary>
+        /// A shim around the GetResolvedProviderPathFromPSPath method from PSCmdlet to resolve relative path including wildcard support.
+        /// </summary>
+        /// <typeparam name="string"></typeparam>
+        /// <typeparam name="ProviderInfo"></typeparam>
+        /// <typeparam name="GetResolvedProviderPathFromPSPathDelegate"></typeparam>
+        /// <param name="input"></param>
+        /// <param name="output"></param>
+        /// <returns></returns>
+        internal delegate GetResolvedProviderPathFromPSPathDelegate GetResolvedProviderPathFromPSPath<in @string, ProviderInfo, out GetResolvedProviderPathFromPSPathDelegate>(@string input, out ProviderInfo output);
+    }
+}

--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -206,11 +206,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                 case SettingsMode.Preset:
                 case SettingsMode.File:
+                    settingsFound = Path.Combine(cwd, settingsFound.ToString());
                     outputWriter?.WriteVerbose(
                         String.Format(
                             CultureInfo.CurrentCulture,
                             Strings.SettingsUsingFile,
-                            (string)settingsFound));
+                            settingsFound.ToString()));
                     break;
 
                 case SettingsMode.Hashtable:

--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -1,21 +1,15 @@
-//
-// Copyright (c) Microsoft Corporation.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
-//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Reflection;
 
@@ -183,8 +177,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// <param name="settingsObj">An input object of type Hashtable or string.</param>
         /// <param name="cwd">The path in which to search for a settings file.</param>
         /// <param name="outputWriter">An output writer.</param>
+        /// <param name="getResolvedProviderPathFromPSPathDelegate">The GetResolvedProviderPathFromPSPath method from PSCmdlet to resolve relative path including wildcard support.</param>
         /// <returns>An object of Settings type.</returns>
-        public static Settings Create(object settingsObj, string cwd, IOutputWriter outputWriter)
+        internal static Settings Create(object settingsObj, string cwd, IOutputWriter outputWriter,
+            PathResolver.GetResolvedProviderPathFromPSPath<string, ProviderInfo, Collection<string>> getResolvedProviderPathFromPSPathDelegate)
         {
             object settingsFound;
             var settingsMode = FindSettingsMode(settingsObj, cwd, out settingsFound);
@@ -206,12 +202,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                 case SettingsMode.Preset:
                 case SettingsMode.File:
-                    settingsFound = Path.Combine(cwd, settingsFound.ToString());
+                    var resolvedPath = getResolvedProviderPathFromPSPathDelegate(settingsFound.ToString(), out ProviderInfo providerInfo).Single();
+                    //var resolvedPath  = pathResolver(settingsFound.ToString());
+                    settingsFound = resolvedPath;
                     outputWriter?.WriteVerbose(
                         String.Format(
                             CultureInfo.CurrentCulture,
                             Strings.SettingsUsingFile,
-                            settingsFound.ToString()));
+                            resolvedPath));
                     break;
 
                 case SettingsMode.Hashtable:

--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -203,7 +203,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 case SettingsMode.Preset:
                 case SettingsMode.File:
                     var resolvedPath = getResolvedProviderPathFromPSPathDelegate(settingsFound.ToString(), out ProviderInfo providerInfo).Single();
-                    //var resolvedPath  = pathResolver(settingsFound.ToString());
                     settingsFound = resolvedPath;
                     outputWriter?.WriteVerbose(
                         String.Format(

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -385,6 +385,18 @@ Describe "Test CustomizedRulePath" {
     if (!$testingLibraryUsage)
     {
         Context "When used from settings file" {
+            It "Should process relative settings path" {
+                try {
+                    $initialLocation = Get-Location
+                    Set-Location $PSScriptRoot
+                    $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Settings .\SettingsTest\..\SettingsTest\Project1\PSScriptAnalyzerSettings.psd1
+                    $warnings.Count | Should -Be 1
+                }
+                finally {
+                    Set-Location $initialLocation
+                }
+            }
+
             It "Should use the CustomRulePath parameter" {
                 $settings = @{
                     CustomRulePath        = "$directory\CommunityAnalyzerRules"


### PR DESCRIPTION
## PR Summary

Fixes #908 to make it possible to specify a relative path for the `-Settings` paramater.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [NA] User facing documentation needed
- [x] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
