### PR TITLE
Fix parsing the -Settings object as a path when the path object originates from an expression

### DIFF
--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -703,6 +703,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     {
                         settingsMode = SettingsMode.Hashtable;
                     }
+                    else // if the provided object is wrapped in multiple expressions then it might not be resolved yet at this stage -> try using the File type as a last resort and best guess.
+                    {
+                        settingsMode = SettingsMode.File;
+                    }
                 }
             }
 

--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -202,13 +202,25 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                 case SettingsMode.Preset:
                 case SettingsMode.File:
-                    var resolvedPath = getResolvedProviderPathFromPSPathDelegate(settingsFound.ToString(), out ProviderInfo providerInfo).Single();
-                    settingsFound = resolvedPath;
-                    outputWriter?.WriteVerbose(
-                        String.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.SettingsUsingFile,
-                            resolvedPath));
+                    var userProvidedSettingsString = settingsFound.ToString();
+                    try
+                    {
+                        var resolvedPath = getResolvedProviderPathFromPSPathDelegate(userProvidedSettingsString, out ProviderInfo providerInfo).Single();
+                        settingsFound = resolvedPath;
+                        outputWriter?.WriteVerbose(
+                            String.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.SettingsUsingFile,
+                                resolvedPath));
+                    }
+                    catch
+                    {
+                        outputWriter?.WriteVerbose(
+                            String.Format(
+                                CultureInfo.CurrentCulture,
+                                Strings.SettingsCannotFindFile,
+                                userProvidedSettingsString));
+                    }
                     break;
 
                 case SettingsMode.Hashtable:
@@ -218,20 +230,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                             Strings.SettingsUsingHashtable));
                     break;
 
-                default: // case SettingsMode.None
+                default:
                     outputWriter?.WriteVerbose(
                         String.Format(
                             CultureInfo.CurrentCulture,
-                            Strings.SettingsCannotFindFile));
-                    break;
+                            Strings.SettingsObjectCouldNotBResolved));
+                    return null;
             }
 
-            if (settingsMode != SettingsMode.None)
-            {
-                return new Settings(settingsFound);
-            }
-
-            return null;
+            return new Settings(settingsFound);
         }
 
         /// <summary>

--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -710,9 +710,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     {
                         settingsMode = SettingsMode.Hashtable;
                     }
-                    else // if the provided object is wrapped in multiple expressions then it might not be resolved yet at this stage -> try using the File type as a last resort and best guess.
+                    else // if the provided argument is wrapped in an expressions then PowerShell resolves it but it will be of type PSObject and we have to operate then on the BaseObject
                     {
-                        settingsMode = SettingsMode.File;
+                        if (settingsFound is PSObject settingsFoundPSObject)
+                        {
+                            if (settingsFoundPSObject.BaseObject is String)
+                            {
+                                settingsMode = SettingsMode.File;
+                            }
+                        }
                     }
                 }
             }

--- a/Engine/Strings.Designer.cs
+++ b/Engine/Strings.Designer.cs
@@ -458,7 +458,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot find a settings file..
+        ///   Looks up a localized string similar to Cannot resolve settings file path &apos;{0}&apos;..
         /// </summary>
         internal static string SettingsCannotFindFile {
             get {
@@ -508,6 +508,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         internal static string SettingsNotProvided {
             get {
                 return ResourceManager.GetString("SettingsNotProvided", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Settings object could not be resolved..
+        /// </summary>
+        internal static string SettingsObjectCouldNotBResolved {
+            get {
+                return ResourceManager.GetString("SettingsObjectCouldNotBResolved", resourceCulture);
             }
         }
         

--- a/Engine/Strings.resx
+++ b/Engine/Strings.resx
@@ -268,7 +268,7 @@
     <value>Using settings hashtable.</value>
   </data>
   <data name="SettingsCannotFindFile" xml:space="preserve">
-    <value>Cannot find a settings file.</value>
+    <value>Cannot resolve settings file path '{0}'.</value>
   </data>
   <data name="SettingsNotParsable" xml:space="preserve">
     <value>Cannot parse settings. Will abort the invocation.</value>
@@ -320,5 +320,8 @@
   </data>
   <data name="PositionRefPosLessThanInputPos" xml:space="preserve">
     <value>Input position should be less than that of the invoking object.</value>
+  </data>
+  <data name="SettingsObjectCouldNotBResolved" xml:space="preserve">
+    <value>Settings object could not be resolved.</value>
   </data>
 </root>

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -387,25 +387,23 @@ Describe "Test CustomizedRulePath" {
         Context "When used from settings file" {
             It "Should process relative settings path" {
                 try {
-                    $initialLocation = Get-Location
-                    Set-Location $PSScriptRoot
+                    Push-Location $PSScriptRoot
                     $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Settings .\SettingsTest\..\SettingsTest\Project1\PSScriptAnalyzerSettings.psd1
                     $warnings.Count | Should -Be 1
                 }
                 finally {
-                    Set-Location $initialLocation
+                    Pop-Location
                 }
             }
 
-            It "Should process relative settings path even when settings path object is an expression" {
+            It "Should process relative settings path even when settings path object is not resolved to a string yet" {
                 try {
-                    $initialLocation = Get-Location
-                    Set-Location $PSScriptRoot
+                    Push-Location $PSScriptRoot
                     $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Settings (Join-Path (Get-Location).Path '.\SettingsTest\..\SettingsTest\Project1\PSScriptAnalyzerSettings.psd1')
                     $warnings.Count | Should -Be 1
                 }
                 finally {
-                    Set-Location $initialLocation
+                    Pop-Location
                 }
             }
 

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -397,6 +397,18 @@ Describe "Test CustomizedRulePath" {
                 }
             }
 
+            It "Should process relative settings path even when settings path object is an expression" {
+                try {
+                    $initialLocation = Get-Location
+                    Set-Location $PSScriptRoot
+                    $warnings = Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Settings (Join-Path (Get-Location).Path '.\SettingsTest\..\SettingsTest\Project1\PSScriptAnalyzerSettings.psd1')
+                    $warnings.Count | Should -Be 1
+                }
+                finally {
+                    Set-Location $initialLocation
+                }
+            }
+
             It "Should use the CustomRulePath parameter" {
                 $settings = @{
                     CustomRulePath        = "$directory\CommunityAnalyzerRules"


### PR DESCRIPTION
## PR Summary

Fixes #914

The referenced bug has been found independently of the recent improvement of supporting relative paths and is also independent of it.
The code which determines the type of setting object (path/hashtable) needed tweaking, see referenced issue.
If the passed in object comes from an expression that evaluates to a string, it needs to be casted to PSObject first and then the check needs to be on the BaseObject property whether it is of type string.
Error handling also got improved to not proceed if the settings type could not be determined instead of continuing.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [NA] User facing documentation needed
- [x] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
