### PR TITLE
Do not trigger UseShouldProcessForStateChangingFunctions rule for workflows

### DIFF
--- a/Rules/UseShouldProcessForStateChangingFunctions.cs
+++ b/Rules/UseShouldProcessForStateChangingFunctions.cs
@@ -1,26 +1,17 @@
-﻿// Copyright (c) Microsoft Corporation.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 using System;
 using System.Collections.Generic;
 #if !CORECLR
 using System.ComponentModel.Composition;
 #endif
-using System.Management.Automation;
 using System.Management.Automation.Language;
 using System.Globalization;
-using System.Linq;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
-{   
+{
     /// <summary>
     /// UseShouldProcessForStateChangingFunctions: Analyzes the ast to check if ShouldProcess is included in Advanced functions if the Verb of the function could change system state.
     /// </summary>
@@ -61,7 +52,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         private bool IsStateChangingFunctionWithNoShouldProcessAttribute(Ast ast)
         {
             var funcDefAst = ast as FunctionDefinitionAst;
-            if (funcDefAst == null)
+            // SupportsShouldProcess is not supported in workflows
+            if (funcDefAst == null || funcDefAst.IsWorkflow)
             {
                 return false;
             }

--- a/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
+++ b/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
@@ -43,7 +43,7 @@ Function New-{0} () {{ }}
             $noViolations.Count | Should -Be 0
         }
 
-        It "Workflows should not trigger a warning because they do not allow SupportsShouldProcess" {
+        It "Workflows should not trigger a warning because they do not allow SupportsShouldProcess" -Skip:$IsCoreCLR {
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'workflow Set-Something {[CmdletBinding()]Param($Param1)}' | Where-Object {
                 $_.RuleName -eq 'PSUseShouldProcessForStateChangingFunctions' }
             $violations.Count | Should -Be 0

--- a/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
+++ b/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
@@ -43,7 +43,7 @@ Function New-{0} () {{ }}
             $noViolations.Count | Should -Be 0
         }
 
-        It "Workflows do no trigger a warning because they do not allow SupportsShouldProcess" {
+        It "Workflows should not trigger a warning because they do not allow SupportsShouldProcess" {
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'workflow Set-Something {[CmdletBinding()]Param($Param1)}' | Where-Object {
                 $_.RuleName -eq 'PSUseShouldProcessForStateChangingFunctions' }
             $violations.Count | Should -Be 0

--- a/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
+++ b/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
@@ -42,5 +42,11 @@ Function New-{0} () {{ }}
         It "returns no violations" {
             $noViolations.Count | Should -Be 0
         }
+
+        It "Workflows do no trigger a warning because they do not allow SupportsShouldProcess" {
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'workflow Set-Something {[CmdletBinding()]Param($Param1)}' | Where-Object {
+                $_.RuleName -eq 'PSUseShouldProcessForStateChangingFunctions' }
+            $violations.Count | Should -Be 0
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

Fixes #922

Workflows do not allow SupportsShouldProcess (the parser does not even allow it), therefore do not trigger UseShouldProcessForStateChangingFunctions
As part of this I also update the copyright header and tidied up unused using statements.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] User facing documentation needed
- [x] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
