### PR TITLE
Add macos detection to New-CommandDataFile

### DIFF
--- a/Utils/New-CommandDataFile.ps1
+++ b/Utils/New-CommandDataFile.ps1
@@ -60,10 +60,6 @@ Function Get-CmdletDataFileName
         {
             $os = 'macos'
         }
-        elseif ($IsOSX)
-        {
-            $os = 'osx'
-        }
         # else it is windows, which is already set
     }
     $sb = New-Object 'System.Text.StringBuilder'

--- a/Utils/New-CommandDataFile.ps1
+++ b/Utils/New-CommandDataFile.ps1
@@ -56,6 +56,10 @@ Function Get-CmdletDataFileName
         {
             $os = 'linux'
         }
+        elseif ($IsMacOS)
+        {
+            $os = 'macos'
+        }
         elseif ($IsOSX)
         {
             $os = 'osx'


### PR DESCRIPTION
## PR Summary

Add MacOS Detection as `$os` in PSCore v6.0.0-beta.7 and higher are getting incorrectly set as `windows` in the Get-CmdletDataFileName function

More details: https://github.com/PowerShell/PowerShell/blob/master/docs/BREAKINGCHANGES.md#rename-isosx-to-ismacos-4700

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [NA] User facing documentation needed
- [x] Change is not breaking
- [NA] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
