### PR TITLE
WIP: restore GetCommandInfo to non-obsolete status

### DIFF
--- a/Rules/AvoidPositionalParameters.cs
+++ b/Rules/AvoidPositionalParameters.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // MSDN: CommandAst.GetCommandName Method
                 if (cmdAst.GetCommandName() == null) continue;
                 
-                if (Helper.Instance.GetCommandInfoLegacy(cmdAst.GetCommandName()) != null
+                if (Helper.Instance.GetCommandInfo(cmdAst.GetCommandName()) != null
                     && Helper.Instance.PositionalParameterUsed(cmdAst, true))
                 {
                     PipelineAst parent = cmdAst.Parent as PipelineAst;

--- a/Rules/UseCmdletCorrectly.cs
+++ b/Rules/UseCmdletCorrectly.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             #region Compares parameter list and mandatory parameter list.
 
-            cmdInfo = Helper.Instance.GetCommandInfoLegacy(cmdAst.GetCommandName());
+            cmdInfo = Helper.Instance.GetCommandInfo(cmdAst.GetCommandName());
             if (cmdInfo == null || (cmdInfo.CommandType != System.Management.Automation.CommandTypes.Cmdlet))
             {
                 return true;

--- a/Rules/UseShouldProcessCorrectly.cs
+++ b/Rules/UseShouldProcessCorrectly.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return false;
             }
 
-            var cmdInfo = Helper.Instance.GetCommandInfoLegacy(cmdName);
+            var cmdInfo = Helper.Instance.GetCommandInfo(cmdName);
             if (cmdInfo == null)
             {
                 return false;

--- a/Tests/Rules/AvoidPositionalParameters.ps1
+++ b/Tests/Rules/AvoidPositionalParameters.ps1
@@ -1,2 +1,0 @@
-﻿# give it 3 positional parameters
-Get-Command "abc" 4 4.3

--- a/Tests/Rules/AvoidPositionalParameters.tests.ps1
+++ b/Tests/Rules/AvoidPositionalParameters.tests.ps1
@@ -1,21 +1,18 @@
 ﻿Import-Module PSScriptAnalyzer
-$violationMessage = "Cmdlet 'Get-Command' has positional parameter. Please use named parameters instead of positional parameters when calling a command."
-$violationName = "PSAvoidUsingPositionalParameters"
-$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
-$violations = Invoke-ScriptAnalyzer $directory\AvoidPositionalParameters.ps1 | Where-Object {$_.RuleName -eq $violationName}
-$noViolations = Invoke-ScriptAnalyzer $directory\AvoidPositionalParametersNoViolations.ps1 | Where-Object {$_.RuleName -eq $violationName}
-$noViolationsDSC = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $directory\serviceconfigdisabled.ps1 | Where-Object {$_.RuleName -eq $violationName}
 
 Describe "AvoidPositionalParameters" {
+    BeforeAll {
+        $directory = $PSScriptRoot
+        $violationName = "PSAvoidUsingPositionalParameters"
+        $violation = Invoke-ScriptAnalyzer -ScriptDefinition 'Get-Command "abc" 4 4.3'
+        $noViolations = Invoke-ScriptAnalyzer $directory\AvoidPositionalParametersNoViolations.ps1 | Where-Object {$_.RuleName -eq $violationName}
+        $noViolationsDSC = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $directory\serviceconfigdisabled.ps1 | Where-Object {$_.RuleName -eq $violationName}
+    }
     Context "When there are violations" {
         It "has 1 avoid positional parameters violation" {
-            $violations.Count | Should -Be 1
+            @($violation).Count | Should -Be 1
+            $violation.RuleName | Should -Be $violationName
         }
-
-        It "has the correct description message" {
-            $violations[0].Message | Should -Match $violationMessage
-        }
-
     }
 
     Context "When there are no violations" {

--- a/Tests/Rules/UseCmdletCorrectly.ps1
+++ b/Tests/Rules/UseCmdletCorrectly.ps1
@@ -1,5 +1,0 @@
-﻿Write-Warning
-Wrong-Cmd
-Write-Verbose -Message "Write Verbose"
-Write-Verbose "Warning" -OutVariable $test
-Write-Verbose "Warning" | PipeLineCmdlet

--- a/Tests/Rules/UseCmdletCorrectly.tests.ps1
+++ b/Tests/Rules/UseCmdletCorrectly.tests.ps1
@@ -1,23 +1,18 @@
-﻿Import-Module -Verbose PSScriptAnalyzer
-$violationMessage = "Cmdlet 'Write-Warning' may be used incorrectly. Please check that all mandatory parameters are supplied."
-$violationName = "PSUseCmdletCorrectly"
-$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
-$violations = Invoke-ScriptAnalyzer $directory\UseCmdletCorrectly.ps1 | Where-Object {$_.RuleName -eq $violationName}
-$noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {$_.RuleName -eq $violationName}
-
+﻿
 Describe "UseCmdletCorrectly" {
     Context "When there are violations" {
         It "has 1 Use Cmdlet Correctly violation" {
-            $violations.Count | Should -Be 1
-        }
-
-        It "has the correct description message" {
-            $violations[0].Message | Should -Match $violationMessage
+            $violationName = "PSUseCmdletCorrectly"
+            $violation = Invoke-ScriptAnalyzer -ScriptDefinition 'Write-Warning;Write-Warning -Message "a warning"'
+            $violation.Count | Should -Be 1
+            $violation.RuleName | Should -Be $violationName
         }
     }
 
     Context "When there are no violations" {
         It "returns no violations" {
+            $directory = $PSScriptRoot
+            $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 
             $noViolations.Count | Should -Be 0
         }
     }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,6 +38,7 @@ test_script:
   - ps:   |
             if ($env:PowerShellEdition -eq 'WindowsPowerShell') {
                 $modulePath = $env:PSModulePath.Split([System.IO.Path]::PathSeparator) | Where-Object { Test-Path $_} | Select-Object -First 1
+                if ( Test-Path "$modulePath\PSScriptAnalyzer" ) { Remove-Item -recurse -force "$modulePath\PSScriptAnalyzer" }
                 Copy-Item "${env:APPVEYOR_BUILD_FOLDER}\out\PSScriptAnalyzer" "$modulePath\" -Recurse -Force
                 $testResultsFile = ".\TestResults.xml"
                 $testScripts = "${env:APPVEYOR_BUILD_FOLDER}\Tests\Engine","${env:APPVEYOR_BUILD_FOLDER}\Tests\Rules"


### PR DESCRIPTION
Add overload for GetCommandInfo without CommandType to match general usage
Remove GetCommandInfoLegacy method

## PR Summary

GetCommandInfo had been written in a way that the command type was never used. A previous PR solved this by creating a legacy method and marking it obsolete and using a new API. This PR changes this behavior to codify what had been present in the case that no CommandType parameter was passed, which was to search all possible command types.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
