### PR TITLE
Make UseDeclaredVarsMoreThanAssignments not flag drive qualified variables

### DIFF
--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -141,10 +141,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 if (assignmentVarAst != null)
                 {
-                    // Ignore if variable is global or environment variable or scope is function
+                    // Ignore if variable is global or environment variable or scope is drive qualified variable
                     if (!Helper.Instance.IsVariableGlobalOrEnvironment(assignmentVarAst, scriptBlockAst)
                         && !assignmentVarAst.VariablePath.IsScript
-                        && !string.Equals(assignmentVarAst.VariablePath.DriveName, "function", StringComparison.OrdinalIgnoreCase))
+                        && assignmentVarAst.VariablePath.DriveName == null)
                     {
                         string variableName = Helper.Instance.VariableNameWithoutScope(assignmentVarAst.VariablePath);
 

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -83,5 +83,10 @@ function MyFunc2() {
             $results = Invoke-ScriptAnalyzer -ScriptDefinition '$list | ForEach-Object { $array += $c }' | Where-Object { $_.RuleName -eq $violationName }
             $results.Count | Should -Be 0
         }
+
+        It "Does not flag drive qualified variables such as env" {
+            $results = Invoke-ScriptAnalyzer -ScriptDefinition '$env:foo = 1; function foo($env:bar = 42)'
+            $results.Count | Should -Be 0
+        }
     }
 }

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -85,7 +85,7 @@ function MyFunc2() {
         }
 
         It "Does not flag drive qualified variables such as env" {
-            $results = Invoke-ScriptAnalyzer -ScriptDefinition '$env:foo = 1; function foo($env:bar = 42)'
+            $results = Invoke-ScriptAnalyzer -ScriptDefinition '$env:foo = 1; function foo(){ $env:bar = 42 }'
             $results.Count | Should -Be 0
         }
     }


### PR DESCRIPTION
## PR Summary

Fixes #631

The rule used to rely only on the SSA of the Helper class to determine if a variable was an environment variable, but SSA does not work well within function defitions.
Also, the rule only excluded the function PSDrive.
This PR changes it to not flag on any drive qualified variables at all.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
