### PR TITLE
Remove extraneous import-module commands in tests

### DIFF
--- a/Tests/Engine/CorrectionExtent.tests.ps1
+++ b/Tests/Engine/CorrectionExtent.tests.ps1
@@ -1,5 +1,3 @@
-Import-Module PSScriptAnalyzer
-
 Describe "Correction Extent" {
     $type = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent]
 

--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -1,13 +1,4 @@
-﻿
-# Check if PSScriptAnalyzer is already loaded so we don't
-# overwrite a test version of Invoke-ScriptAnalyzer by
-# accident
-if (!(Get-Module PSScriptAnalyzer) -and !$testingLibraryUsage)
-{
-	Import-Module PSScriptAnalyzer
-}
-
-$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
+﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
 

--- a/Tests/Engine/EditableText.tests.ps1
+++ b/Tests/Engine/EditableText.tests.ps1
@@ -1,7 +1,6 @@
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 $editableTextType = "Microsoft.Windows.PowerShell.ScriptAnalyzer.EditableText"

--- a/Tests/Engine/Extensions.tests.ps1
+++ b/Tests/Engine/Extensions.tests.ps1
@@ -1,7 +1,5 @@
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
-
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 function Get-Extent {

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -1,6 +1,4 @@
-﻿
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
-Import-Module -Verbose PSScriptAnalyzer
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
 $sa = Get-Command Get-ScriptAnalyzerRule
@@ -175,7 +173,7 @@ Describe "TestWildCard" {
     }
 
     It "filters rules based on wild card input and severity"{
-        $rules = Get-ScriptAnalyzerRule -Name PSDSC*　-Severity Information
+        $rules = Get-ScriptAnalyzerRule -Name PSDSC* -Severity Information
         $rules.Count | Should -Be 4
     }
 }

--- a/Tests/Engine/Helper.tests.ps1
+++ b/Tests/Engine/Helper.tests.ps1
@@ -1,5 +1,3 @@
-Import-Module PSScriptAnalyzer
-
 Describe "Test Directed Graph" {
     Context "When a graph is created" {
         $digraph = New-Object -TypeName 'Microsoft.Windows.PowerShell.ScriptAnalyzer.DiGraph[string]'

--- a/Tests/Engine/InvokeFormatter.tests.ps1
+++ b/Tests/Engine/InvokeFormatter.tests.ps1
@@ -1,7 +1,5 @@
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
-
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 Describe "Invoke-Formatter Cmdlet" {

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -1,15 +1,4 @@
-﻿# Check if PSScriptAnalyzer is already loaded so we don't
-# overwrite a test version of Invoke-ScriptAnalyzer by
-# accident
-if (!(Get-Module PSScriptAnalyzer) -and !$testingLibraryUsage)
-{
-	Import-Module PSScriptAnalyzer
-    $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
-    $testRootDirectory = Split-Path -Parent $directory
-    Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
-}
-
-$sa = Get-Command Invoke-ScriptAnalyzer
+﻿$sa = Get-Command Invoke-ScriptAnalyzer
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $singularNouns = "PSUseSingularNouns"
 $approvedVerb = "PSUseApprovedVerbs"

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -1,9 +1,8 @@
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
-Import-Module PSScriptAnalyzer
 
-# test is meant to verify functionality if chsarp apis are used. Hence not if psedition is CoreCLR
+# test is meant to verify functionality if csharp apis are used. Hence not if psedition is CoreCLR
 if ((Test-PSEditionCoreCLR))
 {
 	return

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -1,12 +1,4 @@
-﻿# Check if PSScriptAnalyzer is already loaded so we don't
-# overwrite a test version of Invoke-ScriptAnalyzer by
-# accident
-if (!(Get-Module PSScriptAnalyzer) -and !$testingLibraryUsage)
-{
-	Import-Module -Verbose PSScriptAnalyzer
-}
-
-$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
+﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
 

--- a/Tests/Engine/RuleSuppressionClass.tests.ps1
+++ b/Tests/Engine/RuleSuppressionClass.tests.ps1
@@ -1,11 +1,6 @@
-﻿if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
-
-# Check if PSScriptAnalyzer is already loaded so we don't
-# overwrite a test version of Invoke-ScriptAnalyzer by
-# accident
-if (!(Get-Module PSScriptAnalyzer) -and !$testingLibraryUsage)
-{
-	Import-Module -Verbose PSScriptAnalyzer
+﻿$script:skipForV3V4 = $true
+if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
+    $script:skipForV3V4 = $false
 }
 
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
@@ -15,7 +10,7 @@ $violations = Invoke-ScriptAnalyzer "$directory\RuleSuppression.ps1"
 Describe "RuleSuppressionWithoutScope" {    
 
     Context "Class" {
-        It "Does not raise violations" {
+        It "Does not raise violations" -skip:$script:skipForV3V4 {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidUsingInvokeExpression" }
             $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidUsingInvokeExpression" }
@@ -24,7 +19,7 @@ Describe "RuleSuppressionWithoutScope" {
     }
 
     Context "FunctionInClass" {
-        It "Does not raise violations" {
+        It "Does not raise violations" -skip:$script:skipForV3V4 {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidUsingCmdletAliases" }
             $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidUsingCmdletAliases" }
@@ -33,7 +28,7 @@ Describe "RuleSuppressionWithoutScope" {
     }
 
     Context "Script" {
-        It "Does not raise violations" {
+        It "Does not raise violations" -skip:$script:skipForV3V4 {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSProvideCommentHelp" }
             $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSProvideCommentHelp" }
@@ -42,7 +37,7 @@ Describe "RuleSuppressionWithoutScope" {
     }
 
     Context "RuleSuppressionID" {
-        It "Only suppress violations for that ID" {
+        It "Only suppress violations for that ID" -skip:$script:skipForV3V4 {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidDefaultValueForMandatoryParameter" }
             $suppression.Count | Should -Be 1
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidDefaultValueForMandatoryParameter" }
@@ -53,7 +48,7 @@ Describe "RuleSuppressionWithoutScope" {
 
 Describe "RuleSuppressionWithScope" {
     Context "FunctionScope" {
-        It "Does not raise violations" {
+        It "Does not raise violations" -skip:$script:skipForV3V4 {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidUsingPositionalParameters" }
             $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidUsingPositionalParameters" }
@@ -62,12 +57,11 @@ Describe "RuleSuppressionWithScope" {
     }
 
     Context "ClassScope" {
-        It "Does not raise violations" {
+        It "Does not raise violations" -skip:$script:skipForV3V4 {
             $suppression = $violations | Where-Object {$_.RuleName -eq "PSAvoidUsingConvertToSecureStringWithPlainText" }
             $suppression.Count | Should -Be 0
             $suppression = $violationsUsingScriptDefinition | Where-Object {$_.RuleName -eq "PSAvoidUsingConvertToSecureStringWithPlainText" }
             $suppression.Count | Should -Be 0
         }
     }
-  }
- }
+}

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -1,7 +1,3 @@
-if (!(Get-Module PSScriptAnalyzer)) {
-    Import-Module PSScriptAnalyzer
-}
-
 $directory = Split-Path $MyInvocation.MyCommand.Path
 $settingsTestDirectory = [System.IO.Path]::Combine($directory, "SettingsTest")
 $project1Root = [System.IO.Path]::Combine($settingsTestDirectory, "Project1")

--- a/Tests/Engine/TextEdit.tests.ps1
+++ b/Tests/Engine/TextEdit.tests.ps1
@@ -1,5 +1,3 @@
-Import-Module PSScriptAnalyzer
-
 Describe "TextEdit Class" {
     $type = [Microsoft.Windows.PowerShell.ScriptAnalyzer.TextEdit]
 

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -1,7 +1,6 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 $ruleConfiguration = @{

--- a/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
+++ b/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$ruleName = "PSAvoidAssignmentToAutomaticVariable"
+﻿$ruleName = "PSAvoidAssignmentToAutomaticVariable"
 
 Describe "AvoidAssignmentToAutomaticVariables" {
     Context "ReadOnly Variables" {

--- a/Tests/Rules/AvoidConvertToSecureStringWithPlainText.tests.ps1
+++ b/Tests/Rules/AvoidConvertToSecureStringWithPlainText.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-Set-Alias ctss ConvertTo-SecureString
+﻿Set-Alias ctss ConvertTo-SecureString
 $violationMessage = "File 'AvoidConvertToSecureStringWithPlainText.ps1' uses ConvertTo-SecureString with plaintext. This will expose secure information. Encrypted standard strings should be used instead."
 $violationName = "PSAvoidUsingConvertToSecureStringWithPlainText"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/Tests/Rules/AvoidDefaultTrueValueSwitchParameter.tests.ps1
+++ b/Tests/Rules/AvoidDefaultTrueValueSwitchParameter.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = "File 'AvoidDefaultTrueValueSwitchParameter.ps1' has a switch parameter default to true."
+﻿$violationMessage = "File 'AvoidDefaultTrueValueSwitchParameter.ps1' has a switch parameter default to true."
 $violationName = "PSAvoidDefaultValueSwitchParameter"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidDefaultTrueValueSwitchParameter.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidDefaultValueForMandatoryParameter.tests.ps1
+++ b/Tests/Rules/AvoidDefaultValueForMandatoryParameter.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$ruleName = 'PSAvoidDefaultValueForMandatoryParameter'
+﻿$ruleName = 'PSAvoidDefaultValueForMandatoryParameter'
 
 Describe "AvoidDefaultValueForMandatoryParameter" {
     Context "When there are violations" {

--- a/Tests/Rules/AvoidEmptyCatchBlock.tests.ps1
+++ b/Tests/Rules/AvoidEmptyCatchBlock.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = "Empty catch block is used. Please use Write-Error or throw statements in catch blocks."
+﻿$violationMessage = "Empty catch block is used. Please use Write-Error or throw statements in catch blocks."
 $violationName = "PSAvoidUsingEmptyCatchBlock"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidEmptyCatchBlock.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidGlobalAliases.tests.ps1
+++ b/Tests/Rules/AvoidGlobalAliases.tests.ps1
@@ -1,7 +1,6 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
-Import-Module PSScriptAnalyzer
 
 $AvoidGlobalAliasesError = "Avoid creating aliases with a Global scope."
 $violationName = "PSAvoidGlobalAliases"

--- a/Tests/Rules/AvoidGlobalFunctions.tests.ps1
+++ b/Tests/Rules/AvoidGlobalFunctions.tests.ps1
@@ -1,6 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-
-$functionErroMessage = "Avoid creating functions with a Global scope."
+﻿$functionErroMessage = "Avoid creating functions with a Global scope."
 $violationName = "PSAvoidGlobalFunctions"
 
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/Tests/Rules/AvoidGlobalOrUnitializedVars.tests.ps1
+++ b/Tests/Rules/AvoidGlobalOrUnitializedVars.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$globalMessage = "Found global variable 'Global:1'."
+﻿$globalMessage = "Found global variable 'Global:1'."
 $globalName = "PSAvoidGlobalVars"
 
 # PSAvoidUninitializedVariable rule has been deprecated

--- a/Tests/Rules/AvoidInvokingEmptyMembers.tests.ps1
+++ b/Tests/Rules/AvoidInvokingEmptyMembers.tests.ps1
@@ -1,6 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-
-$violationMessage = "() has non-constant members. Invoking non-constant members may cause bugs in the script."
+﻿$violationMessage = "() has non-constant members. Invoking non-constant members may cause bugs in the script."
 $violationName = "PSAvoidInvokingEmptyMembers"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidInvokingEmptyMembers.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidNullOrEmptyHelpMessageAttribute.tests.ps1
+++ b/Tests/Rules/AvoidNullOrEmptyHelpMessageAttribute.tests.ps1
@@ -1,4 +1,3 @@
-Import-Module PSScriptAnalyzer
 $violationName = "PSAvoidNullOrEmptyHelpMessageAttribute"
 $violationMessage = "HelpMessage parameter attribute should not be null or empty. To fix a violation of this rule, please set its value to a non-empty string."
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/Tests/Rules/AvoidPositionalParameters.tests.ps1
+++ b/Tests/Rules/AvoidPositionalParameters.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = "Cmdlet 'Get-Command' has positional parameter. Please use named parameters instead of positional parameters when calling a command."
+﻿$violationMessage = "Cmdlet 'Get-Command' has positional parameter. Please use named parameters instead of positional parameters when calling a command."
 $violationName = "PSAvoidUsingPositionalParameters"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidPositionalParameters.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidReservedParams.tests.ps1
+++ b/Tests/Rules/AvoidReservedParams.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = [regex]::Escape("Verb-Files' defines the reserved common parameter 'Verbose'.")
+﻿$violationMessage = [regex]::Escape("Verb-Files' defines the reserved common parameter 'Verbose'.")
 $violationName = "PSReservedParams"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\BadCmdlet.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidShouldContinueWithoutForce.tests.ps1
+++ b/Tests/Rules/AvoidShouldContinueWithoutForce.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = "Function 'Verb-Noun2' in file 'AvoidShouldContinueWithoutForce.ps1' uses ShouldContinue but does not have a boolean force parameter. The force parameter will allow users of the script to bypass ShouldContinue prompt"
+﻿$violationMessage = "Function 'Verb-Noun2' in file 'AvoidShouldContinueWithoutForce.ps1' uses ShouldContinue but does not have a boolean force parameter. The force parameter will allow users of the script to bypass ShouldContinue prompt"
 $violationName = "PSAvoidShouldContinueWithoutForce"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidShouldContinueWithoutForce.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidTrailingWhitespace.tests.ps1
+++ b/Tests/Rules/AvoidTrailingWhitespace.tests.ps1
@@ -1,7 +1,6 @@
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 $ruleName = "PSAvoidTrailingWhitespace"

--- a/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
+++ b/Tests/Rules/AvoidUnloadableModuleOrMissingRequiredFieldInManifest.tests.ps1
@@ -1,6 +1,5 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
 
 $missingMessage = "The member 'ModuleVersion' is not present in the module manifest."

--- a/Tests/Rules/AvoidUserNameAndPasswordParams.tests.ps1
+++ b/Tests/Rules/AvoidUserNameAndPasswordParams.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-
+﻿
 $violationMessage = "Function 'TestFunction1' has both Username and Password parameters. Either set the type of the Password parameter to SecureString or replace the Username and Password parameters with a Credential parameter of type PSCredential. If using a Credential parameter in PowerShell 4.0 or earlier, please define a credential transformation attribute after the PSCredential type attribute."
 $violationName = "PSAvoidUsingUserNameAndPasswordParams"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/Tests/Rules/AvoidUsingAlias.tests.ps1
+++ b/Tests/Rules/AvoidUsingAlias.tests.ps1
@@ -6,7 +6,6 @@ $violationFilepath = Join-Path $directory 'AvoidUsingAlias.ps1'
 $violations = Invoke-ScriptAnalyzer $violationFilepath | Where-Object {$_.RuleName -eq $violationName}
 $noViolations = Invoke-ScriptAnalyzer $directory\AvoidUsingAliasNoViolations.ps1 | Where-Object {$_.RuleName -eq $violationName}
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 Describe "AvoidUsingAlias" {

--- a/Tests/Rules/AvoidUsingComputerNameHardcoded.tests.ps1
+++ b/Tests/Rules/AvoidUsingComputerNameHardcoded.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = [regex]::Escape("The ComputerName parameter of cmdlet 'Invoke-Command' is hardcoded. This will expose sensitive information about the system if the script is shared.")
+﻿$violationMessage = [regex]::Escape("The ComputerName parameter of cmdlet 'Invoke-Command' is hardcoded. This will expose sensitive information about the system if the script is shared.")
 $violationName = "PSAvoidUsingComputerNameHardcoded"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidUsingComputerNameHardcoded.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidUsingDeprecatedManifestFields.tests.ps1
+++ b/Tests/Rules/AvoidUsingDeprecatedManifestFields.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationName = "PSAvoidUsingDeprecatedManifestFields"
+﻿$violationName = "PSAvoidUsingDeprecatedManifestFields"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer "$directory\TestBadModule\TestDeprecatedManifestFields.psd1" | Where-Object {$_.RuleName -eq $violationName}
 $noViolations = Invoke-ScriptAnalyzer "$directory\TestGoodModule\TestGoodModule.psd1" | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidUsingInvokeExpression.tests.ps1
+++ b/Tests/Rules/AvoidUsingInvokeExpression.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = "Invoke-Expression is used. Please remove Invoke-Expression from script and find other options instead."
+﻿$violationMessage = "Invoke-Expression is used. Please remove Invoke-Expression from script and find other options instead."
 $violationName = "PSAvoidUsingInvokeExpression"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidUsingInvokeExpression.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/AvoidUsingPlainTextForPassword.tests.ps1
+++ b/Tests/Rules/AvoidUsingPlainTextForPassword.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = [regex]::Escape("Parameter '`$password' should use SecureString, otherwise this will expose sensitive information. See ConvertTo-SecureString for more information.")
+﻿$violationMessage = [regex]::Escape("Parameter '`$password' should use SecureString, otherwise this will expose sensitive information. See ConvertTo-SecureString for more information.")
 $violationName = "PSAvoidUsingPlainTextForPassword"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violationFilepath = Join-Path $directory 'AvoidUsingPlainTextForPassword.ps1'

--- a/Tests/Rules/AvoidUsingReservedCharNames.tests.ps1
+++ b/Tests/Rules/AvoidUsingReservedCharNames.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$reservedCharMessage = "The cmdlet 'Use-#Reserved' uses a reserved char in its name."
+﻿$reservedCharMessage = "The cmdlet 'Use-#Reserved' uses a reserved char in its name."
 $reservedCharName = "PSReservedCmdletChar"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidUsingReservedCharNames.ps1 | Where-Object {$_.RuleName -eq $reservedCharName}

--- a/Tests/Rules/AvoidUsingWMICmdlet.tests.ps1
+++ b/Tests/Rules/AvoidUsingWMICmdlet.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$WMIRuleName = "PSAvoidUsingWMICmdlet"
+﻿$WMIRuleName = "PSAvoidUsingWMICmdlet"
 $violationMessage = "File 'AvoidUsingWMICmdlet.ps1' uses WMI cmdlet. For PowerShell 3.0 and above, use CIM cmdlet which perform the same tasks as the WMI cmdlets. The CIM cmdlets comply with WS-Management (WSMan) standards and with the Common Information Model (CIM) standard, which enables the cmdlets to use the same techniques to manage Windows computers and those running other operating systems."
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidUsingWMICmdlet.ps1 -IncludeRule $WMIRuleName

--- a/Tests/Rules/AvoidUsingWriteHost.tests.ps1
+++ b/Tests/Rules/AvoidUsingWriteHost.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-Set-Alias ctss ConvertTo-SecureString
+﻿Set-Alias ctss ConvertTo-SecureString
 $writeHostMessage = [Regex]::Escape("File 'AvoidUsingWriteHost.ps1' uses Write-Host. Avoid using Write-Host because it might not work in all hosts, does not work when there is no host, and (prior to PS 5.0) cannot be suppressed, captured, or redirected. Instead, use Write-Output, Write-Verbose, or Write-Information.")
 $writeHostName = "PSAvoidUsingWriteHost"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/Tests/Rules/DscExamplesPresent.tests.ps1
+++ b/Tests/Rules/DscExamplesPresent.tests.ps1
@@ -1,5 +1,3 @@
-Import-Module -Verbose PSScriptAnalyzer
-
 $currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ruleName = "PSDSCDscExamplesPresent"
 

--- a/Tests/Rules/DscTestsPresent.tests.ps1
+++ b/Tests/Rules/DscTestsPresent.tests.ps1
@@ -1,5 +1,3 @@
-Import-Module -Verbose PSScriptAnalyzer
-
 $currentPath = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ruleName = "PSDSCDscTestsPresent"
 

--- a/Tests/Rules/MisleadingBacktick.tests.ps1
+++ b/Tests/Rules/MisleadingBacktick.tests.ps1
@@ -1,4 +1,3 @@
-Import-Module PSScriptAnalyzer
 $writeHostName = "PSMisleadingBacktick"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violationFilepath = Join-Path $directory 'MisleadingBacktick.ps1'

--- a/Tests/Rules/PSCredentialType.tests.ps1
+++ b/Tests/Rules/PSCredentialType.tests.ps1
@@ -1,7 +1,6 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
-Import-Module PSScriptAnalyzer
 
 $violationMessage = "The Credential parameter in 'Credential' must be of type PSCredential. For PowerShell 4.0 and earlier, please define a credential transformation attribute, e.g. [System.Management.Automation.Credential()], after the PSCredential type attribute."
 $violationName = "PSUsePSCredentialType"

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -1,7 +1,6 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 $ruleConfiguration = @{

--- a/Tests/Rules/PlaceOpenBrace.tests.ps1
+++ b/Tests/Rules/PlaceOpenBrace.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$ruleConfiguration = @{
+﻿$ruleConfiguration = @{
     Enable = $true
     OnSameLine = $true
     NewLineAfter = $true

--- a/Tests/Rules/PossibleIncorrectComparisonWithNull.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectComparisonWithNull.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer 
-$violationMessage = [regex]::Escape('$null should be on the left side of equality comparisons.')
+﻿$violationMessage = [regex]::Escape('$null should be on the left side of equality comparisons.')
 $violationName = "PSPossibleIncorrectComparisonWithNull"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\PossibleIncorrectComparisonWithNull.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
+++ b/Tests/Rules/PossibleIncorrectUsageOfAssignmentOperator.tests.ps1
@@ -1,4 +1,3 @@
-Import-Module PSScriptAnalyzer
 $ruleName = "PSPossibleIncorrectUsageOfAssignmentOperator"
 
 Describe "PossibleIncorrectUsageOfAssignmentOperator" {

--- a/Tests/Rules/ProvideCommentHelp.tests.ps1
+++ b/Tests/Rules/ProvideCommentHelp.tests.ps1
@@ -1,7 +1,6 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 $violationMessage = "The cmdlet 'Comment' does not have a help comment."

--- a/Tests/Rules/ReturnCorrectTypesForDSCFunctions.tests.ps1
+++ b/Tests/Rules/ReturnCorrectTypesForDSCFunctions.tests.ps1
@@ -1,6 +1,4 @@
-﻿Import-Module -Verbose PSScriptAnalyzer
-
-$violationMessageDSCResource = "Test-TargetResource function in DSC Resource should return object of type System.Boolean instead of System.Collections.Hashtable"
+﻿$violationMessageDSCResource = "Test-TargetResource function in DSC Resource should return object of type System.Boolean instead of System.Collections.Hashtable"
 $violationMessageDSCClass = "Get function in DSC Class FileResource should return object of type FileResource instead of type System.Collections.Hashtable"
 $violationName = "PSDSCReturnCorrectTypesForDSCFunctions"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/Tests/Rules/UseBOMForUnicodeEncodedFile.tests.ps1
+++ b/Tests/Rules/UseBOMForUnicodeEncodedFile.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessageOne = "Missing BOM encoding for non-ASCII encoded file 'BOMAbsent_UTF16EncodedScript.ps1'"
+﻿$violationMessageOne = "Missing BOM encoding for non-ASCII encoded file 'BOMAbsent_UTF16EncodedScript.ps1'"
 $violationMessageTwo = "Missing BOM encoding for non-ASCII encoded file 'BOMAbsent_UnknownEncodedScript.ps1'"
 $violationName = "PSUseBOMForUnicodeEncodedFile"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/Tests/Rules/UseCmdletCorrectly.tests.ps1
+++ b/Tests/Rules/UseCmdletCorrectly.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module -Verbose PSScriptAnalyzer
-$violationMessage = "Cmdlet 'Write-Warning' may be used incorrectly. Please check that all mandatory parameters are supplied."
+﻿$violationMessage = "Cmdlet 'Write-Warning' may be used incorrectly. Please check that all mandatory parameters are supplied."
 $violationName = "PSUseCmdletCorrectly"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\UseCmdletCorrectly.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/UseCompatibleCmdlets.tests.ps1
+++ b/Tests/Rules/UseCompatibleCmdlets.tests.ps1
@@ -3,7 +3,6 @@ $directory = Split-Path $MyInvocation.MyCommand.Path -Parent
 $testRootDirectory = Split-Path -Parent $directory
 $ruleTestDirectory = Join-Path $directory 'UseCompatibleCmdlets'
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
 
 Describe "UseCompatibleCmdlets" {

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -1,7 +1,6 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 $indentationUnit = ' '

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -1,7 +1,6 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 $ruleName = "PSUseConsistentWhitespace"

--- a/Tests/Rules/UseDSCResourceFunctions.tests.ps1
+++ b/Tests/Rules/UseDSCResourceFunctions.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module -Verbose PSScriptAnalyzer
-
+﻿
 $violationMessage = "Missing 'Get-TargetResource' function. DSC Resource must implement Get, Set and Test-TargetResource functions."
 $classViolationMessage = "Missing 'Set' function. DSC Class must implement Get, Set and Test functions."
 $violationName = "PSDSCStandardDSCFunctionsInResource"

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -1,7 +1,6 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
 
 $violationMessage = "The variable 'declaredVar2' is assigned but never used."

--- a/Tests/Rules/UseIdenticalParametersDSC.tests.ps1
+++ b/Tests/Rules/UseIdenticalParametersDSC.tests.ps1
@@ -1,6 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-
-$violationMessage = "The Test and Set-TargetResource functions of DSC Resource must have the same parameters."
+﻿$violationMessage = "The Test and Set-TargetResource functions of DSC Resource must have the same parameters."
 $violationName = "PSDSCUseIdenticalParametersForDSC"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\DSCResourceModule\DSCResources\MSFT_WaitForAll\MSFT_WaitForAll.psm1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/UseLiteralInitializerForHashtable.tests.ps1
+++ b/Tests/Rules/UseLiteralInitializerForHashtable.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$ruleName = "PSUseLiteralInitializerForHashtable"
+﻿$ruleName = "PSUseLiteralInitializerForHashtable"
 
 Describe "UseLiteralInitlializerForHashtable" {
     Context "When new-object hashtable is used to create a hashtable" {

--- a/Tests/Rules/UseOutputTypeCorrectly.tests.ps1
+++ b/Tests/Rules/UseOutputTypeCorrectly.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = "The cmdlet 'Verb-Files' returns an object of type 'System.Collections.Hashtable' but this type is not declared in the OutputType attribute."
+﻿$violationMessage = "The cmdlet 'Verb-Files' returns an object of type 'System.Collections.Hashtable' but this type is not declared in the OutputType attribute."
 $violationName = "PSUseOutputTypeCorrectly"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\BadCmdlet.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/UseShouldProcessCorrectly.tests.ps1
+++ b/Tests/Rules/UseShouldProcessCorrectly.tests.ps1
@@ -4,7 +4,6 @@ $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')
-Import-Module PSScriptAnalyzer
 
 $violations = Invoke-ScriptAnalyzer $directory\BadCmdlet.ps1 | Where-Object {$_.RuleName -eq $violationName}
 $noViolations = Invoke-ScriptAnalyzer $directory\GoodCmdlet.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
+++ b/Tests/Rules/UseShouldProcessForStateChangingFunctions.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = "Function 'Set-MyObject' has verb that could change system state. Therefore, the function has to support 'ShouldProcess'"
+﻿$violationMessage = "Function 'Set-MyObject' has verb that could change system state. Therefore, the function has to support 'ShouldProcess'"
 $violationName = "PSUseShouldProcessForStateChangingFunctions"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\UseShouldProcessForStateChangingFunctions.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
+++ b/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
@@ -1,4 +1,3 @@
-Import-Module PSScriptAnalyzer
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')

--- a/Tests/Rules/UseSupportsShouldProcess.tests.ps1
+++ b/Tests/Rules/UseSupportsShouldProcess.tests.ps1
@@ -1,7 +1,6 @@
 ﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 
-Import-Module PSScriptAnalyzer
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
 $settings = @{

--- a/Tests/Rules/UseToExportFieldsInManifest.tests.ps1
+++ b/Tests/Rules/UseToExportFieldsInManifest.tests.ps1
@@ -1,4 +1,3 @@
-Import-Module PSScriptAnalyzer
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $testRootDirectory = Split-Path -Parent $directory
 Import-Module (Join-Path $testRootDirectory 'PSScriptAnalyzerTestHelper.psm1')

--- a/Tests/Rules/UseUTF8EncodingForHelpFile.tests.ps1
+++ b/Tests/Rules/UseUTF8EncodingForHelpFile.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = "File about_utf16.help.txt has to use UTF8 instead of System.Text.UTF32Encoding encoding because it is a powershell help file."
+﻿$violationMessage = "File about_utf16.help.txt has to use UTF8 instead of System.Text.UTF32Encoding encoding because it is a powershell help file."
 $violationName = "PSUseUTF8EncodingForHelpFile"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\about_utf16.help.txt | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Rules/UseVerboseMessageInDSCResource.Tests.ps1
+++ b/Tests/Rules/UseVerboseMessageInDSCResource.Tests.ps1
@@ -1,6 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-
-$violationMessage = "There is no call to Write-Verbose in DSC function 'Test-TargetResource'. If you are using Write-Verbose in a helper function, suppress this rule application."
+﻿$violationMessage = "There is no call to Write-Verbose in DSC function 'Test-TargetResource'. If you are using Write-Verbose in a helper function, suppress this rule application."
 $violationName = "PSDSCUseVerboseMessageInDSCResource"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\DSCResourceModule\DSCResources\MSFT_WaitForAll\MSFT_WaitForAll.psm1 | Where-Object {$_.RuleName -eq $violationName}


### PR DESCRIPTION
## PR Summary
The expectation is that these tests are run as part of the test harness, the re-importing of the module is unneeded. Also, module autoloading should take care of this in any event.

<!-- summarize your PR between here and the checklist -->

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [ ] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
