### PR TITLE
Trigger AvoidPositionalParameters rule for function defined and called inside a script.

### DIFF
--- a/Rules/AvoidPositionalParameters.cs
+++ b/Rules/AvoidPositionalParameters.cs
@@ -27,6 +27,18 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
+            // Find all function definitions in the script and add them to the set.
+            IEnumerable<Ast> functionDefinitionAsts = ast.FindAll(testAst => testAst is FunctionDefinitionAst, true);
+            HashSet<String> declaredFunctionNames = new HashSet<String>();
+
+            foreach (Ast foundAst in functionDefinitionAsts) {
+                FunctionDefinitionAst functionDefinitionAst = (FunctionDefinitionAst)foundAst;
+                if (string.IsNullOrEmpty(functionDefinitionAst.Name)) {
+                    continue;
+                }
+                declaredFunctionNames.Add(functionDefinitionAst.Name);
+            }
+
             // Finds all CommandAsts.
             IEnumerable<Ast> foundAsts = ast.FindAll(testAst => testAst is CommandAst, true);
 
@@ -39,9 +51,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // MSDN: CommandAst.GetCommandName Method
                 if (cmdAst.GetCommandName() == null) continue;
                 
-                if (Helper.Instance.GetCommandInfoLegacy(cmdAst.GetCommandName()) != null
-                    && Helper.Instance.PositionalParameterUsed(cmdAst, true))
+                if ((Helper.Instance.IsCmdlet(cmdAst) || declaredFunctionNames.Contains(cmdAst.GetCommandName())) &&
+                    (Helper.Instance.PositionalParameterUsed(cmdAst)))
                 {
+                    Console.WriteLine("Cmdlet or function call");
                     PipelineAst parent = cmdAst.Parent as PipelineAst;
 
                     if (parent != null && parent.PipelineElements.Count > 1)

--- a/Rules/UseCmdletCorrectly.cs
+++ b/Rules/UseCmdletCorrectly.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return true;
             }
 
-            if (mandParams.Count() == 0 || Helper.Instance.PositionalParameterUsed(cmdAst))
+            if (mandParams.Count() == 0 || (Helper.Instance.IsCmdlet(cmdAst) && Helper.Instance.PositionalParameterUsed(cmdAst)))
             {
                 returnValue = true;
             }


### PR DESCRIPTION
## PR Summary

Trigger AvoidPositionalParameters rule for function defined and called inside a script.

Adresses the issue: #893 

The rule doesn't trigger for the function defined and called in the script, because the script is not run and the function definition is not added to the powershell session runspace. Hence, the called function is not recognized as Cmdlet. 
For the temporary solution I pull the function definitions from the script, store them and search these function calls for positional parameters.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [ ] PR has a meaningful title
    - [ ] Use the present tense and imperative mood when describing your changes
- [ ] Summarized changes
- [ ] User facing documentation needed
- [ ] Change is not breaking
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
