### PR TITLE
AvoidDefaultValueForMandatoryParameter triggers when the field has specification: Mandatory=value and value!=0

### DIFF
--- a/Rules/AvoidDefaultValueForMandatoryParameter.cs
+++ b/Rules/AvoidDefaultValueForMandatoryParameter.cs
@@ -52,10 +52,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                         if (String.Equals(namedArgument.ArgumentName, "mandatory", StringComparison.OrdinalIgnoreCase))
                                         {
                                             // 3 cases: [Parameter(Mandatory)], [Parameter(Mandatory=$true)] and [Parameter(Mandatory=value)] where value is not equal to 0.
-                                            int mandatoryValue = 0;
                                             if (namedArgument.ExpressionOmitted
                                                 || (String.Equals(namedArgument.Argument.Extent.Text, "$true", StringComparison.OrdinalIgnoreCase))
-                                                || (int.TryParse(namedArgument.Argument.Extent.Text, out mandatoryValue) && mandatoryValue != 0))
+                                                || (int.TryParse(namedArgument.Argument.Extent.Text, out int mandatoryValue) && mandatoryValue != 0))
                                             {
                                                 mandatory = true;
                                                 break;

--- a/Rules/AvoidDefaultValueForMandatoryParameter.cs
+++ b/Rules/AvoidDefaultValueForMandatoryParameter.cs
@@ -51,8 +51,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                     {
                                         if (String.Equals(namedArgument.ArgumentName, "mandatory", StringComparison.OrdinalIgnoreCase))
                                         {
-                                            // 2 cases: [Parameter(Mandatory)] and [Parameter(Mandatory=$true)]
-                                            if (namedArgument.ExpressionOmitted || (!namedArgument.ExpressionOmitted && String.Equals(namedArgument.Argument.Extent.Text, "$true", StringComparison.OrdinalIgnoreCase)))
+                                            // 3 cases: [Parameter(Mandatory)], [Parameter(Mandatory=$true)] and [Parameter(Mandatory=value)] where value is not equal to 0.
+                                            int mandatoryValue = 0;
+                                            if (namedArgument.ExpressionOmitted
+                                                || (String.Equals(namedArgument.Argument.Extent.Text, "$true", StringComparison.OrdinalIgnoreCase))
+                                                || (int.TryParse(namedArgument.Argument.Extent.Text, out mandatoryValue) && mandatoryValue != 0))
                                             {
                                                 mandatory = true;
                                                 break;

--- a/Tests/Rules/AvoidDefaultValueForMandatoryParameter.tests.ps1
+++ b/Tests/Rules/AvoidDefaultValueForMandatoryParameter.tests.ps1
@@ -29,7 +29,7 @@ Describe "AvoidDefaultValueForMandatoryParameter" {
         }
 
         It "returns no violations when the parameter is specified as mandatory=0 and has a default value" {
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'Function foo{ Param([Parameter(Mandatory=$false)]$Param1=''val1'', [Parameter(Mandatory)]$Param2=''val2'', $Param3=''val3'') }' |
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'Function foo{ Param([Parameter(Mandatory=0)]$Param1=''val1'') }' |
                 Where-Object { $_.RuleName -eq $ruleName }
             $violations.Count | Should -Be 0
         }

--- a/Tests/Rules/AvoidDefaultValueForMandatoryParameter.tests.ps1
+++ b/Tests/Rules/AvoidDefaultValueForMandatoryParameter.tests.ps1
@@ -13,10 +13,22 @@ Describe "AvoidDefaultValueForMandatoryParameter" {
                 Where-Object { $_.RuleName -eq $ruleName }
             $violations.Count | Should -Be 1
         }
+
+        It "returns violations when the parameter is specified as mandatory=1 and has a default value" {
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'Function foo{ Param([Parameter(Mandatory=1)]$Param1=''defaultValue'') }' |
+                Where-Object { $_.RuleName -eq $ruleName }
+            $violations.Count | Should -Be 1
+        }
     }
 
     Context "When there are no violations" {
         It "has 1 provide default value for mandatory parameter violation" {
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'Function foo{ Param([Parameter(Mandatory=$false)]$Param1=''val1'', [Parameter(Mandatory)]$Param2=''val2'', $Param3=''val3'') }' |
+                Where-Object { $_.RuleName -eq $ruleName }
+            $violations.Count | Should -Be 0
+        }
+
+        It "returns no violations when the parameter is specified as mandatory=0 and has a default value" {
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'Function foo{ Param([Parameter(Mandatory=$false)]$Param1=''val1'', [Parameter(Mandatory)]$Param2=''val2'', $Param3=''val3'') }' |
                 Where-Object { $_.RuleName -eq $ruleName }
             $violations.Count | Should -Be 0


### PR DESCRIPTION
## PR Summary

AvoidDefaultValueForMandatoryParameter triggers when the field has specification: Mandatory=value and value is not equal to 0.

Fixes: #877 

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
