### PR TITLE
WIP If no path is found or when using the -ScriptDefinition parameter set, default to the current location for the directory search of the implicit settings file

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             {
                 var settingsObj = PSSASettings.Create(
                     settings,
-                    processedPaths == null || processedPaths.Count == 0 ? null : processedPaths[0],
+                    processedPaths == null || processedPaths.Count == 0 ? CurrentProviderLocation("FileSystem").ProviderPath : processedPaths[0],
                     this,
                     GetResolvedProviderPathFromPSPath);
                 if (settingsObj != null)

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -21,9 +21,12 @@ Describe "Settings Precedence" {
         }
 
         It "runs rules from the implicit setting file using the -ScriptDefinition parameter set" {
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Recurse
+            Push-Location $project1Root
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'gci; Write-Host' -Recurse
+            Pop-Location
             $violations.Count | Should -Be 1
-            $violations[0].RuleName | Should -Be "PSAvoidUsingCmdletAliases"
+            $violations[0].RuleName | Should -Be "PSAvoidUsingCmdletAliases" `
+                -Because 'the implicit settings file should have run only the PSAvoidUsingCmdletAliases rule but not PSAvoidUsingWriteHost'
         }
 
         It "cannot find file if not named PSScriptAnalyzerSettings.psd1" {

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -14,8 +14,14 @@ Describe "Settings Precedence" {
     }
 
     Context "settings file is implicit" {
-        It "runs rules from the implicit setting file" {
+        It "runs rules from the implicit setting file using the -Path parameter set" {
             $violations = Invoke-ScriptAnalyzer -Path $project1Root -Recurse
+            $violations.Count | Should -Be 1
+            $violations[0].RuleName | Should -Be "PSAvoidUsingCmdletAliases"
+        }
+
+        It "runs rules from the implicit setting file using the -ScriptDefinition parameter set" {
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Recurse
             $violations.Count | Should -Be 1
             $violations[0].RuleName | Should -Be "PSAvoidUsingCmdletAliases"
         }


### PR DESCRIPTION
## PR Summary

Fixes #978. This allows usage of the implicit settings file when using the `-ScriptBlock` parameter (or avoid a misleading error message about setting parsing when no file is found to be analysed). When no file path was found using the `-Path` option or using the `-ScriptDefinition` parameter set, the search for implicit setting files used to rely on a path being present. This PR fixes it to fallback to the current working directory as a search directory for implicit setting files.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
