### PR TITLE
WIP Upgrade to v 2.1.105 .Net SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Exit
 
 ### From Source
 
-* [.NET Core 2.1.101 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.101) or newer
+* [.NET Core 2.1.105 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.105) or newer
 * [PlatyPS 0.9.0 or greater](https://github.com/PowerShell/platyPS/releases)
 * Optionally but recommended for development: [Visual Studio 2017](https://www.visualstudio.com/downloads/)
 

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
         "Rules"
     ],
     "sdk": {
-        "version": "2.1.101"
+        "version": "2.1.105"
     }
 }


### PR DESCRIPTION
## PR Summary

To get the latest fixes. The recently released version 2.1.200 has problems installing on Ubuntu (see PR #992) but is not needed for PSSA as it only contains for a security vuln that does not affect PSSA, therefore 2.1.105 is fine

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] NA User facing documentation needed
- [ ] Change is not breaking
- [ ] NA Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
