### PR TITLE
Upload only out folder as artifact, which is the actual PSSA artifact

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -91,7 +91,7 @@ function Invoke-AppveyorFinish {
     $stagingDirectory = (Resolve-Path ..).Path
     $zipFile = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
     Add-Type -AssemblyName 'System.IO.Compression.FileSystem'
-    [System.IO.Compression.ZipFile]::CreateFromDirectory($pwd, $zipFile)
+    [System.IO.Compression.ZipFile]::CreateFromDirectory((Join-Path $pwd 'out'), $zipFile)
     @(
         # You can add other artifacts here
         (Get-ChildItem $zipFile)


### PR DESCRIPTION
## PR Summary

As per title, at the moment, we upload the full repo, which is not necessary, just the out folder is enough
Related #622
Should we document this and give details which build to choose (since all builds build only for their specific PowerShell version) and tell having to unblock the zip?
To fully close the issue we would need to change one of the build jobs to build for all PowerShell versions.
WDYT?

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [ ] Change is not breaking
- [ ] `NA` Make sure you've added a new test if existing tests do not effectively test the code changed
- [ ] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
