### PR TITLE
Add OutputType attributes to cmdlets to enhance tab completion

### DIFF
--- a/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
+++ b/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
     /// GetScriptAnalyzerRuleCommand: Cmdlet to list all the analyzer rule names and descriptions.
     /// </summary>
     [Cmdlet(VerbsCommon.Get, "ScriptAnalyzerRule", HelpUri = "https://go.microsoft.com/fwlink/?LinkId=525913")]
+    [OutputType(typeof(RuleInfo))]
     public class GetScriptAnalyzerRuleCommand : PSCmdlet, IOutputWriter
     {
         #region Parameters

--- a/Engine/Commands/InvokeFormatterCommand.cs
+++ b/Engine/Commands/InvokeFormatterCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System;
 using System.Globalization;
 using System.Management.Automation;

--- a/Engine/Commands/InvokeFormatterCommand.cs
+++ b/Engine/Commands/InvokeFormatterCommand.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System;
 using System.Globalization;
 using System.Management.Automation;
@@ -14,7 +13,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
     /// A cmdlet to format a PowerShell script text.
     /// </summary>
     [Cmdlet(VerbsLifecycle.Invoke, "Formatter")]
-    [OutputType(typeof(RuleInfo))]
+    [OutputType(typeof(string))]
     public class InvokeFormatterCommand : PSCmdlet, IOutputWriter
     {
         private const string defaultSettingsPreset = "CodeFormatting";

--- a/Engine/Commands/InvokeFormatterCommand.cs
+++ b/Engine/Commands/InvokeFormatterCommand.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
     /// A cmdlet to format a PowerShell script text.
     /// </summary>
     [Cmdlet(VerbsLifecycle.Invoke, "Formatter")]
+    [OutputType(typeof(RuleInfo))]
     public class InvokeFormatterCommand : PSCmdlet, IOutputWriter
     {
         private const string defaultSettingsPreset = "CodeFormatting";

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         DefaultParameterSetName = "File",
         SupportsShouldProcess = true,
         HelpUri = "https://go.microsoft.com/fwlink/?LinkId=525914")]
+    [OutputType(typeof(DiagnosticRecord))]
     public class InvokeScriptAnalyzerCommand : PSCmdlet, IOutputWriter
     {
         #region Private variables

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         SupportsShouldProcess = true,
         HelpUri = "https://go.microsoft.com/fwlink/?LinkId=525914")]
     [OutputType(typeof(DiagnosticRecord))]
+    [OutputType(typeof(SuppressedRecord))]
     public class InvokeScriptAnalyzerCommand : PSCmdlet, IOutputWriter
     {
         #region Private variables

--- a/docs/markdown/Invoke-Formatter.md
+++ b/docs/markdown/Invoke-Formatter.md
@@ -111,3 +111,8 @@ Default value:
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+## OUTPUTS
+
+### System.String
+The formatted string result.


### PR DESCRIPTION
## PR Summary

Closes #1019 as requested/suggested by @seeminglyscience

Add `OutputType` attributes to the cmdlets to help e.g. tab completion.
Example of what this enables:
```powershell
Get-ScriptAnalyzerRule | Select-Object
TAB
Get-ScriptAnalyzerRule | Select-Object CommonName
```

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] User facing documentation needed
- [x] Change is not breaking
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
