### PR TITLE
Change PSGallery rules to remove 2 rules

### DIFF
--- a/Engine/Settings/PSGallery.psd1
+++ b/Engine/Settings/PSGallery.psd1
@@ -18,9 +18,7 @@
                    'PSAvoidUsingInvokeExpression',
                    'PSAvoidUsingPlainTextForPassword',
                    'PSAvoidUsingComputerNameHardcoded',
-                   'PSAvoidUsingConvertToSecureStringWithPlainText',
                    'PSUsePSCredentialType',
-                   'PSAvoidUsingUserNameAndPasswordParams',
                    'PSDSC*'
                    )
 }


### PR DESCRIPTION
## PR Summary

The PowerShell Gallery currently uses the set of rules in this preset configuration to inform module authors of problems in their modules. The 2 rules in question (AvoidUsingConvertToSecureStringWithPlainText' and 'AvoidUsingUserNameAndPasswordParams' are problematic in that:
- they form a large fraction of all the violations we report
- empirically, module authors do not actually fix these. We have some modules where the same violation has been reported for 100's of revision without any change
- authors frequently have reasons why they cannot abide by the recommendation

This changelist acknowledges reality: since the violation reports are not of value to module authors, we'll drop these rules.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [ ] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
