### PR TITLE
Make UseCompatibleCmdlets not throw if default reference desktop-5.1.14393.206-windows is specified in the list of platforms and use core-6.0.2-windows as an alternative default reference

### DIFF
--- a/Rules/UseCompatibleCmdlets.cs
+++ b/Rules/UseCompatibleCmdlets.cs
@@ -326,7 +326,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return;
             }
 
-            var extentedCompatibilityList = compatibilityList.Concat(Enumerable.Repeat(reference, 1));
+            var extentedCompatibilityList = compatibilityList.Union(Enumerable.Repeat(reference, 1));
             foreach (var compat in extentedCompatibilityList)
             {
                 string psedition, psversion, os;

--- a/Rules/UseCompatibleCmdlets.cs
+++ b/Rules/UseCompatibleCmdlets.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         private bool hasInitializationError;
         private string reference;
         private readonly string defaultReference = "desktop-5.1.14393.206-windows";
+        private readonly string alternativeDefaultReference = "core-6.0.2-windows";
         private RuleParameters ruleParameters;
 
         public UseCompatibleCmdlets()
@@ -274,6 +275,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             ruleParameters.compatibility = compatibilityList.ToArray();
             reference = defaultReference;
+            if (compatibilityList.Count == 1 && compatibilityList[0] == defaultReference)
+            {
+                reference = alternativeDefaultReference;
+            }
 #if DEBUG
             // Setup reference file
             object referenceObject;

--- a/Tests/Rules/UseCompatibleCmdlets.tests.ps1
+++ b/Tests/Rules/UseCompatibleCmdlets.tests.ps1
@@ -54,4 +54,9 @@ Describe "UseCompatibleCmdlets" {
         @("Start-VM", "New-SmbShare", "Get-Disk") | `
             Test-Command -Settings $settings -ExpectedViolations 1
     }
+
+    Context "Default reference can also be used as target platform" {
+        $settings = @{rules=@{PSUseCompatibleCmdlets=@{compatibility=@("desktop-5.1.14393.206-windows")}}}
+        @("Remove-Service") | Test-Command -Settings $settings -ExpectedViolations 1
+    }
 }

--- a/Tests/Rules/UseCompatibleCmdlets.tests.ps1
+++ b/Tests/Rules/UseCompatibleCmdlets.tests.ps1
@@ -26,9 +26,11 @@ Describe "UseCompatibleCmdlets" {
         process
         {
             It ("found {0} violations for '{1}'" -f $expectedViolations, $command) {
-                Invoke-ScriptAnalyzer -ScriptDefinition $command -IncludeRule $ruleName -Settings $settings | `
-                    Get-Count | `
-                    Should -Be $expectedViolations
+                $warnings = Invoke-ScriptAnalyzer -ScriptDefinition $command -IncludeRule $ruleName -Settings $settings
+                $warnings.Count | Should -Be  $expectedViolations
+                $warnings | ForEach-Object {
+                    $_.RuleName | Should -Be 'PSUseCompatibleCmdlets'
+                }
             }
         }
     }


### PR DESCRIPTION
## PR Summary

The UseCompatibleCmdlets rule works by flagging up cmdlets that are only either present in the default reference (desktop-5.1.14393.206-windows) or in one of the specified references. According to the code comments this is to ensure that aliases or custom functions are not flagged up as incompatible.
However, from a user's point of view, one might add the default reference also to the list of compatible references in the settings file for implicit documentation of what platforms/versions are supported and also because a user does not care how the work is done under the covers.
This PR ensures that no error is being thrown in this case and also adds `core-6.0.2-windows` as an alternative reference if the user used only `desktop-5.1.14393.206-windows` in the rule settings.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [x]  Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
