### PR TITLE
Use TLS 1.2 for bootstrapping dotnet in CI

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -30,6 +30,7 @@ function Invoke-AppVeyorInstall {
     $globalDotJson = Get-Content (Join-Path $PSScriptRoot '..\global.json') -Raw | ConvertFrom-Json
     $dotNetCoreSDKVersion = $globalDotJson.sdk.version
     if (-not ((dotnet --version).StartsWith($dotNetCoreSDKVersion))) {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 # https://github.com/dotnet/announcements/issues/77
         Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile dotnet-install.ps1
         .\dotnet-install.ps1 -Version $dotNetCoreSDKVersion
         Remove-Item .\dotnet-install.ps1


### PR DESCRIPTION
## PR Summary

See this breaking change here, whereby https://dot.net switched to using TLS 1.2-only
https://github.com/dotnet/announcements/issues/77

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [ ] `NA` Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
