### PR TITLE
Give explicit error on unsupported versions of PSCore and document it in ReadMe as well

### DIFF
--- a/Engine/PSScriptAnalyzer.psm1
+++ b/Engine/PSScriptAnalyzer.psm1
@@ -13,6 +13,9 @@ $binaryModuleRoot = $PSModuleRoot
 
 if (($PSVersionTable.Keys -contains "PSEdition") -and ($PSVersionTable.PSEdition -ne 'Desktop')) {
     $binaryModuleRoot = Join-Path -Path $PSModuleRoot -ChildPath 'coreclr'
+    if ($PSVersionTable.PSVersion -lt [version]'6.0.2') {
+        throw "Minimum supported version of PSScriptAnalyzer for PowerShell Core is 6.0.2 but current version is '$($PSVersionTable.PSVersion)'. Please update PowerShell Core."
+    }
 }
 else {
     if ($PSVersionTable.PSVersion.Major -eq 3) {

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Exit
 #### Supported PowerShell Versions and Platforms
 
 - Windows PowerShell 3.0 or greater
-- PowerShell Core on Windows/Linux/macOS
+- PowerShell Core 6.0.2 or greater on Windows/Linux/macOS
 - Docker (tested only using Docker CE on Windows 10 1803
   - PowerShell 6 Windows Image tags using  from [microsoft/powershell](https://hub.docker.com/r/microsoft/powershell/): `nanoserver`, `6.0.2-nanoserver`, `6.0.2-nanoserver-1709`, `windowsservercore` and `6.0.2-windowsservercore`. Example (1 warning gets produced by `Save-Module` but can be ignored):
 


### PR DESCRIPTION
## PR Summary

Closes #1042 by giving an explicit error on unsupported versions of pscore and document it. It is already documented in the release notes (and the release blog post)
The reason for that is the reference to SMA (which cannot be lower because the 6.0.0 and 6.0.1 NuGet packages had bugs in them that made them not usable for PSSA.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] User facing documentation needed
- [x] Change is not breaking
- [ ] `NA` Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
