### PR TITLE
Upgrade Nuget packages and make them more consistent

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net451' ">
-    <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha08" />
+    <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net451' AND '$(Configuration)' != 'PSV3Release'">
@@ -64,7 +64,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Management.Automation" Version="6.0.2" />
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.0" />
     <Compile Remove="UseSingularNouns.cs" />
   </ItemGroup>
 


### PR DESCRIPTION
## PR Summary

- `Microsoft.Management.Infrastructure` is not being upgraded but uses now a wildcard for the latest pre-release for net451 in the same way how it is already done for netstandard2.0
- Upgrade `System.Reflection.TypeExtensions` and `Microsoft.CSharp` to `4.5.0`

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [ ] `NA` Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
