### PR TITLE
Use RTM version 1.0.0 of Microsoft.Management.Infrastructure instead of preview version 1.0.0-alpha08

### DIFF
--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0-alpha*" />
+    <PackageReference Include="Microsoft.Management.Infrastructure" Version="1.0.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.0" />
     <Compile Remove="UseSingularNouns.cs" />
   </ItemGroup>


### PR DESCRIPTION
## PR Summary

Use RTM version `1.0.0` of [Microsoft.Management.Infrastructure](https://www.nuget.org/packages/Microsoft.Management.Infrastructure/1.0.0) that got published 2 weeks ago instead of preview `1.0.0-alpha08`

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
