### PR TITLE
Fix AlignAssignment rule to calculate alignment position correctly and avoid crash

### DIFF
--- a/Rules/AlignAssignmentStatement.cs
+++ b/Rules/AlignAssignmentStatement.cs
@@ -191,15 +191,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     continue;
                 }
 
-                var widestKeyExtent = extentTuples
-                    .Select(t => t.Item1)
-                    .Aggregate((t1, tAggregate) =>
-                    {
-                        return TokenOperations.GetExtentWidth(tAggregate) > TokenOperations.GetExtentWidth(t1)
-                            ? tAggregate
-                            : t1;
-                    });
-                var expectedStartColumnNumber = widestKeyExtent.EndColumnNumber + 1;
+                var expectedStartColumnNumber = extentTuples.Max(x => x.Item1.EndColumnNumber) + 1;
                 foreach (var extentTuple in extentTuples)
                 {
                     if (extentTuple.Item2.StartColumnNumber != expectedStartColumnNumber)

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -54,6 +54,16 @@ $hashtable = @{
             $violations.Count | Should -Be 1
             Test-CorrectionExtentFromContent $def $violations 1 '              ' '       '
         }
+        
+        It "Should not crash if property name reaches further to the right than the longest property name (regression test for issue 1067)" {
+            $def = @'
+$hashtable = @{ property1 = "value"
+    anotherProperty = "another value"
+}
+'@
+
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings -ErrorAction Stop | Get-Count | Should -Be 0
+        }
 
         It "Should ignore if a hashtable is empty" {
             $def = @'

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -54,11 +54,11 @@ $hashtable = @{
             $violations.Count | Should -Be 1
             Test-CorrectionExtentFromContent $def $violations 1 '              ' '       '
         }
-        
+
         It "Should not crash if property name reaches further to the right than the longest property name (regression test for issue 1067)" {
             $def = @'
 $hashtable = @{ property1 = "value"
-    anotherProperty = "another value"
+    anotherProperty       = "another value"
 }
 '@
 


### PR DESCRIPTION
## PR Summary

Fixes #1067 by not calculating the alignment position based on the maximum length of the keys but rather the rightmost position of all keys.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [NA] User facing documentation needed
- [x] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
