### PR TITLE
Fix parsing of empty hashtable when string is provided as settings object

### DIFF
--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -560,11 +560,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     }
                 }
 
-                if (rhsList.Count == 0)
-                {
-                    ThrowInvalidDataException(kvp.Item2);
-                }
-
                 output[key] = rhsList.ToArray();
             }
 
@@ -629,7 +624,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 }
             }
 
-            return null;
+            return result;
         }
 
         private void ThrowInvalidDataException(Ast ast)

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -51,9 +51,10 @@ Describe "Settings Class" {
                 ${settings}.${Name}.Count | Should -Be 0
         }
 
-        It "Should be able to parse empty settings hashtable" {
-            Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Settings @{ ExcludeRules = @()}   | Should -Not -BeNullOrEmpty
-            Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Settings '@{ ExcludeRules = @()}' | Should -Not -BeNullOrEmpty
+        It "Should be able to parse empty settings hashtable from settings file" {
+            $testPSSASettingsFilePath = "TestDrive:\PSSASettings.psd1"
+            Set-Content $testPSSASettingsFilePath -Value '@{ExcludeRules = @()}'
+            Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Settings $testPSSASettingsFilePath | Should -Not -BeNullOrEmpty
         }
     }
 

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -38,19 +38,22 @@ Describe "Settings Precedence" {
 
 Describe "Settings Class" {
     Context "When an empty hashtable is provided" {
-        BeforeAll {
-            $settings = New-Object -TypeName $settingsTypeName -ArgumentList @{}
-        }
 
         It "Should return empty <name> property" -TestCases @(
             @{ Name = "IncludeRules" }
             @{ Name = "ExcludeRules" }
             @{ Name = "Severity" }
             @{ Name = "RuleArguments" }
-        ) {
-            Param($Name)
+            ) {
+                Param($Name)
 
-            ${settings}.${Name}.Count | Should -Be 0
+                $settings = New-Object -TypeName $settingsTypeName -ArgumentList @{}
+                ${settings}.${Name}.Count | Should -Be 0
+        }
+
+        It "Should be able to parse empty settings hashtable" {
+            Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Settings @{ ExcludeRules = @()}   | Should -Not -BeNullOrEmpty
+            Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -Settings '@{ ExcludeRules = @()}' | Should -Not -BeNullOrEmpty
         }
     }
 
@@ -104,7 +107,7 @@ Describe "Settings Class" {
         It "Should return $expectedNumberOfIncludeRules IncludeRules" {
             $settings.IncludeRules.Count | Should -Be $expectedNumberOfIncludeRules
         }
-        
+
         $expectedNumberOfExcludeRules = 3
         It "Should return $expectedNumberOfExcludeRules ExcludeRules" {
             $settings.ExcludeRules.Count | Should -Be $expectedNumberOfExcludeRules


### PR DESCRIPTION
## PR Summary

Fixes #1063 whereby parsing the settings hashtable fails when it is being provided as a string due to a helper method returning null instead of an empty list.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] User facing documentation needed
- [x] Change is not breaking
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
