### PR TITLE
Restore caching in Helper.GetCommandInfo

### DIFF
--- a/Engine/CommandLookupKey.cs
+++ b/Engine/CommandLookupKey.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Management.Automation;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
+{
+    internal struct CommandLookupKey : IEquatable<CommandLookupKey>
+    {
+        private readonly string Name;
+
+        private readonly CommandTypes CommandTypes;
+
+        internal CommandLookupKey(string name, CommandTypes? commandTypes)
+        {
+            Name = name;
+            CommandTypes = commandTypes ?? CommandTypes.All;
+        }
+
+        public bool Equals(CommandLookupKey other)
+        {
+            return CommandTypes == other.CommandTypes
+                && Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            // Algorithm from https://stackoverflow.com/questions/1646807/quick-and-simple-hash-code-combinations
+            unchecked
+            {
+                int hash = 17;
+                hash = hash * 31 + Name.ToUpperInvariant().GetHashCode();
+                hash = hash * 31 + CommandTypes.GetHashCode();
+                return hash;
+            }
+        }
+    }
+}

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         private readonly static Version minSupportedPSVersion = new Version(3, 0);
         private Dictionary<string, Dictionary<string, object>> ruleArguments;
         private PSVersionTable psVersionTable;
-        private Dictionary<string, CommandInfo> commandInfoCache;
+        private Dictionary<CommandLookupKey, CommandInfo> commandInfoCache;
 
         #endregion
 
@@ -142,7 +142,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             ruleArguments = new Dictionary<string, Dictionary<string, object>>(StringComparer.OrdinalIgnoreCase);
             if (commandInfoCache == null)
             {
-                commandInfoCache = new Dictionary<string, CommandInfo>(StringComparer.OrdinalIgnoreCase);
+                commandInfoCache = new Dictionary<CommandLookupKey, CommandInfo>();
             }
 
             IEnumerable<CommandInfo> aliases = this.invokeCommand.GetCommands("*", CommandTypes.Alias, true);
@@ -700,15 +700,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 cmdletName = name;
             }
 
+            var key = new CommandLookupKey(name, commandType);
             lock (getCommandLock)
             {
-                if (commandInfoCache.ContainsKey(cmdletName))
+                if (commandInfoCache.ContainsKey(key))
                 {
-                    return commandInfoCache[cmdletName];
+                    return commandInfoCache[key];
                 }
 
                 var commandInfo = GetCommandInfoInternal(cmdletName, commandType);
-                commandInfoCache.Add(cmdletName, commandInfo);
+                commandInfoCache.Add(key, commandInfo);
                 return commandInfo;
             }
         }
@@ -726,15 +727,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 return null;
             }
 
+            var key = new CommandLookupKey(name, commandType);
             lock (getCommandLock)
             {
-                if (commandInfoCache.ContainsKey(name))
+                if (commandInfoCache.ContainsKey(key))
                 {
-                    return commandInfoCache[name];
+                    return commandInfoCache[key];
                 }
 
                 var commandInfo = GetCommandInfoInternal(name, commandType);
-
+                commandInfoCache.Add(key, commandInfo);
                 return commandInfo;
             }
         }
@@ -1910,6 +1912,37 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         }
 
 #endregion Methods
+
+        private struct CommandLookupKey : IEquatable<CommandLookupKey>
+        {
+            private readonly string Name;
+
+            private readonly CommandTypes CommandTypes;
+
+            internal CommandLookupKey(string name, CommandTypes? commandTypes)
+            {
+                Name = name;
+                CommandTypes = commandTypes ?? CommandTypes.All;
+            }
+
+            public bool Equals(CommandLookupKey other)
+            {
+                return CommandTypes == other.CommandTypes
+                    && Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public override int GetHashCode()
+            {
+                // Algorithm from https://stackoverflow.com/questions/1646807/quick-and-simple-hash-code-combinations
+                unchecked
+                {
+                    int hash = 17;
+                    hash = hash * 31 + Name.ToUpperInvariant().GetHashCode();
+                    hash = hash * 31 + CommandTypes.GetHashCode();
+                    return hash;
+                }
+            }
+        }
     }
 
 

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -1912,37 +1912,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         }
 
 #endregion Methods
-
-        private struct CommandLookupKey : IEquatable<CommandLookupKey>
-        {
-            private readonly string Name;
-
-            private readonly CommandTypes CommandTypes;
-
-            internal CommandLookupKey(string name, CommandTypes? commandTypes)
-            {
-                Name = name;
-                CommandTypes = commandTypes ?? CommandTypes.All;
-            }
-
-            public bool Equals(CommandLookupKey other)
-            {
-                return CommandTypes == other.CommandTypes
-                    && Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase);
-            }
-
-            public override int GetHashCode()
-            {
-                // Algorithm from https://stackoverflow.com/questions/1646807/quick-and-simple-hash-code-combinations
-                unchecked
-                {
-                    int hash = 17;
-                    hash = hash * 31 + Name.ToUpperInvariant().GetHashCode();
-                    hash = hash * 31 + CommandTypes.GetHashCode();
-                    return hash;
-                }
-            }
-        }
     }
 
 


### PR DESCRIPTION
## PR Summary

This change restores caching of `CommandInfo` objects in rules were it was previously disabled.  My understanding is that it was disabled due to the fact that retrieving from the cache ignored the specified `CommandTypes` parameter, so the key for the cache is now a struct that takes both the command name, and the specified command types into account.

Performance is significantly improved in situations where either the script being analyzed is quite large, or has many unresolvable commands.  For example, [this build script](https://raw.githubusercontent.com/SeeminglyScience/ImpliedReflection/master/ImpliedReflection.build.ps1) previously took about 10 seconds to complete with just `PSAvoidUsingCmdletAliases` enabled.  Now it is ~2 seconds for the first invocation and ~30-60ms for every subsequent invocation.

## PR Checklist

Note: Tick the boxes below that apply to this pull request by putting an `x` between the square brackets. Please mark anything not applicable to this PR `NA`.

- [x] PR has a meaningful title
    - [x] Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] NA - User facing documentation needed
- [x] Change is not breaking
- [ ] NA - Make sure you've added a new test if existing tests do not effectively test the code changed
- [x] This PR is ready to merge and is not work in progress
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready
