### PR TITLE
Remove pwsh 6.0.2 installation code during AppVeyor build boostrap that is not needed any more

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,16 +20,6 @@ cache:
 install:
   - ps:   if ($env:PowerShellEdition -eq 'WindowsPowerShell') { Import-Module .\tools\appveyor.psm1; Invoke-AppveyorInstall }
   - pwsh: if ($env:PowerShellEdition -eq 'PowerShellCore')    { Import-Module .\tools\appveyor.psm1; Invoke-AppveyorInstall }
-  - ps:   |
-            # Windows image still has version 6.0.0 of pwsh but 6.0.2 is required due to System.Management.Automation package https://github.com/appveyor/ci/issues/2230
-            if ($env:PowerShellEdition -eq 'PowerShellCore' -and $PSVersionTable.PSVersion -lt [version]'6.0.2' -and $IsWindows) {
-                $msiPath = "$env:TEMP\PowerShell-6.0.2-win-x64.msi"
-                (New-Object Net.WebClient).DownloadFile('https://github.com/PowerShell/PowerShell/releases/download/v6.0.2/PowerShell-6.0.2-win-x64.msi', $msiPath)
-                Write-Verbose 'Installing pwsh 6.0.2' -Verbose
-                Start-Process 'msiexec.exe' -Wait -ArgumentList "/i $msiPath /quiet"
-                Remove-Item $msiPath
-                $env:Path = "$env:ProgramFiles\PowerShell\6.0.2;$env:Path"
-            }
 
 build_script:
   - ps:   |


### PR DESCRIPTION
## PR Summary

Removes the update of pwsh from 6.0.0 to 6.0.2 on AppVeyor Windows image since the image is updated. See the list of [installed software](https://www.appveyor.com/docs/windows-images-software/#powershell) and the [16 September 2018 update](https://www.appveyor.com/updates/2018/09/16/).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.