### PR TITLE
An exception is thrown when CurrentCulture is Turkish (tr-TR) 

### DIFF
--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -395,7 +395,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             var settings = GetDictionaryFromHashtable(settingsHashtable);
             foreach (var settingKey in settings.Keys)
             {
-                var key = settingKey.ToLower();
+                var key = settingKey.ToLowerInvariant();
                 object val = settings[key];
                 switch (key)
                 {

--- a/Tests/Engine/SettingsTest/Issue1095/Issue1095.tests.ps1
+++ b/Tests/Engine/SettingsTest/Issue1095/Issue1095.tests.ps1
@@ -1,0 +1,20 @@
+Describe "Issue 1095: An exception is thrown when CurrentCulture is Turkish (tr-TR)" {
+    It "Should not throw an exception when CurrentCulture is tr-TR" {
+        # https://github.com/PowerShell/PSScriptAnalyzer/issues/1095
+
+		$initialCulture = Get-Culture
+        $initialUICulture = Get-UICulture
+
+        {
+            $trTRculture = [System.Globalization.CultureInfo]::GetCultureInfo('tr-TR')
+            [System.Threading.Thread]::CurrentThread.CurrentUICulture = $trTRculture
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = $trTRculture
+            Invoke-Formatter "`$test" -ErrorAction Stop
+
+        } | Should -Throw -Not
+
+        [System.Threading.Thread]::CurrentThread.CurrentCulture = $initialCulture
+        [System.Threading.Thread]::CurrentThread.CurrentUICulture = $initialUICulture
+       
+    }
+}


### PR DESCRIPTION
## PR Summary
This is a fix for #1095, I only changed the ToLower function to force en-US culture.
I also added a new test to assure it's working

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.