### PR TITLE
Fix culture issue error that occurs when using turkish culture and Invoke-Formatter

### DIFF
--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -395,7 +395,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             var settings = GetDictionaryFromHashtable(settingsHashtable);
             foreach (var settingKey in settings.Keys)
             {
-                var key = settingKey.ToLower();
+                var key = settingKey.ToLowerInvariant(); // Invariant is important to also work with turkish culture, see https://github.com/PowerShell/PSScriptAnalyzer/issues/1095
                 object val = settings[key];
                 switch (key)
                 {

--- a/Tests/Engine/InvokeFormatter.tests.ps1
+++ b/Tests/Engine/InvokeFormatter.tests.ps1
@@ -85,6 +85,17 @@ function foo {
 
             Invoke-Formatter -ScriptDefinition $def | Should -Be $expected
         }
+
+        It "Does not throw when using turkish culture - https://github.com/PowerShell/PSScriptAnalyzer/issues/1095" {
+            $initialCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+            try {
+                [System.Threading.Thread]::CurrentThread.CurrentCulture = [cultureinfo]::CreateSpecificCulture('tr-TR')
+                Invoke-Formatter ' foo' | Should -Be 'foo'
+            }
+            finally {
+                [System.Threading.Thread]::CurrentThread.CurrentCulture = $initialCulture
+            }
+        }
     }
 
 }


### PR DESCRIPTION
## PR Summary

Fixes #1095 as reported by @alatas (I could reproduce locally, see tests). Thanks for the detailed report.
This is an alternative to #1096 that seems to cause problems in CI, this approach is using `ToLowerInvariant` instead.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.