### PR TITLE
Emit parsing errors as diagnostic records 

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         /// <summary>
         /// IncludeRule: Array of the severity types to be enabled.
         /// </summary>
-        [ValidateSet("Warning", "Error", "Information", IgnoreCase = true)]
+        [ValidateSet("Warning", "Error", "Information", "ParseError", IgnoreCase = true)]
         [Parameter(Mandatory = false)]
         [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
         public string[] Severity
@@ -432,6 +432,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                 var errorCount = 0;
                 var warningCount = 0;
                 var infoCount = 0;
+                var parseErrorCount = 0;
 
                 foreach (DiagnosticRecord diagnostic in diagnosticRecords)
                 {
@@ -446,6 +447,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                             break;
                         case DiagnosticSeverity.Error:
                             errorCount++;
+                            break;
+                        case DiagnosticSeverity.ParseError:
+                            parseErrorCount++;
                             break;
                         default:
                             throw new ArgumentOutOfRangeException(nameof(diagnostic.Severity), $"Severity '{diagnostic.Severity}' is unknown");

--- a/Engine/Generic/DiagnosticRecord.cs
+++ b/Engine/Generic/DiagnosticRecord.cs
@@ -142,5 +142,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// ERROR: This diagnostic is likely to cause a problem or does not follow PowerShell's required guidelines.
         /// </summary>
         Error    = 2,
+
+        /// <summary>
+        /// ERROR: This diagnostic is caused by an actual parsing error, and is generated only by the engine.
+        /// </summary>
+        ParseError    = 3,
     };
 }

--- a/Engine/Generic/RuleSeverity.cs
+++ b/Engine/Generic/RuleSeverity.cs
@@ -22,5 +22,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// ERROR: This warning is likely to cause a problem or does not follow PowerShell's required guidelines.
         /// </summary>
         Error = 2,
+
+        /// <summary>
+        /// ERROR: This diagnostic is caused by an actual parsing error, and is generated only by the engine.
+        /// </summary>
+        ParseError    = 3,
     };
 }

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1526,8 +1526,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             var relevantParseErrors = RemoveTypeNotFoundParseErrors(errors, out List<DiagnosticRecord> diagnosticRecords);
 
-            // Add parse errors first!
-            if ( relevantParseErrors != null )
+            int emitParseErrors = severity == null ? 1 : severity.Count(item => item == "ParseError");
+            // Add parse errors first if requested!
+            if ( relevantParseErrors != null && emitParseErrors == 1)
             {
                 List<DiagnosticRecord> results = new List<DiagnosticRecord>();
                 foreach ( var parseError in relevantParseErrors )
@@ -1878,8 +1879,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 #endif //!PSV3
             var relevantParseErrors = RemoveTypeNotFoundParseErrors(errors, out diagnosticRecords);
 
-            // First, add all parse errors
-            if ( relevantParseErrors != null )
+            // First, add all parse errors if they've been requested
+            int emitParseErrors = severity == null ? 1 : severity.Count(item => item == "ParseError");
+            if ( relevantParseErrors != null && emitParseErrors == 1 )
             {
                 List<DiagnosticRecord> results = new List<DiagnosticRecord>();
                 foreach ( var parseError in relevantParseErrors )

--- a/README.md
+++ b/README.md
@@ -187,6 +187,43 @@ Get-TestFailures
 
 [Back to ToC](#table-of-contents)
 
+Parser Errors
+=============
+
+In prior versions of ScriptAnalyer, errors found during parsing were reported as errors and diagnostic records were not created.
+ScriptAnalyzer now emits parser errors as diagnostic records in the output stream with other diagnostic records.
+
+```powershell
+PS> Invoke-ScriptAnalyzer -ScriptDefinition '"b" = "b"; function eliminate-file () { }'
+
+RuleName            Severity   ScriptName Line Message
+--------            --------   ---------- ---- -------
+InvalidLeftHandSide ParseError            1    The assignment expression is not
+                                               valid. The input to an
+                                               assignment operator must be an
+                                               object that is able to accept
+                                               assignments, such as a variable
+                                               or a property.
+PSUseApprovedVerbs  Warning               1    The cmdlet 'eliminate-file' uses an
+                                               unapproved verb.
+```
+
+The RuleName is set to the `ErrorId` of the parser error.
+
+If ParseErrors would like to be suppressed, do not include it as a value in the `-Severity` parameter.
+
+```powershell
+PS> Invoke-ScriptAnalyzer -ScriptDefinition '"b" = "b"; function eliminate-file () { }' -Severity Warning
+
+RuleName           Severity ScriptName Line Message
+--------           -------- ---------- ---- -------
+PSUseApprovedVerbs Warning             1    The cmdlet 'eliminate-file' uses an
+                                            unapproved verb.
+```
+
+
+
+
 Suppressing Rules
 =================
 
@@ -271,6 +308,8 @@ Param()
 ```
 
 **Note**: Rule suppression is currently supported only for built-in rules.
+
+**Note**: Parser Errors cannot be suppressed via the `SuppressMessageAttribute`
 
 [Back to ToC](#table-of-contents)
 

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -126,11 +126,13 @@ Describe "Test Path" {
             $withoutPath = Invoke-ScriptAnalyzer -Path $scriptPath
             $withPath.Count | Should -Be $withoutPath.Count
         }
+    }
 
-        It "Runs rules on script with more than 10 parser errors" {
+    Context "When there are more than 10 errors in a file" {
+        It "All errors are found in a file" {
             # this is a script with 12 parse errors
-            1..12 | Foreach-Object { ');' } | Out-File -Encoding ASCII "TestDrive:\badfile.ps1"
-            $moreThanTenErrors = Invoke-ScriptAnalyzer -Path "TestDrive:\badfile.ps1"
+            1..12 | Foreach-Object { ');' } | Out-File -Encoding ASCII "${TestDrive}\badfile.ps1"
+            $moreThanTenErrors = Invoke-ScriptAnalyzer -Path "${TestDrive}\badfile.ps1"
             @($moreThanTenErrors).Count | Should -Be 12
         }
     }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -121,9 +121,10 @@ Describe "Test ScriptDefinition" {
 Describe "Test Path" {
     Context "When given a single file" {
         It "Has the same effect as without Path parameter" {
-            $withPath = Invoke-ScriptAnalyzer $directory\TestScript.ps1
-            $withoutPath = Invoke-ScriptAnalyzer -Path $directory\TestScript.ps1
-            $withPath.Count -eq $withoutPath.Count | Should -BeTrue
+            $scriptPath = Join-Path $directory "TestScript.ps1"
+            $withPath = Invoke-ScriptAnalyzer $scriptPath
+            $withoutPath = Invoke-ScriptAnalyzer -Path $scriptPath
+            $withPath.Count | Should -Be $withoutPath.Count
         }
 
         It "Runs rules on script with more than 10 parser errors" {

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -313,6 +313,32 @@ Describe "Test Exclude And Include" {1
 }
 
 Describe "Test Severity" {
+    Context "Each severity can be chosen in any combination" {
+        BeforeAll {
+            $Severities = "ParseError","Error","Warning","Information"
+            # end space is important
+            $script = '$a=;ConvertTo-SecureString -Force -AsPlainText "bad practice" '
+            $testcases = @{ Severity = "ParseError" }, @{ Severity = "Error" },
+                @{ Severity = "Warning" }, @{ Severity = "Information" },
+                @{ Severity = "ParseError", "Error" }, @{ Severity = "ParseError","Information" },
+                @{ Severity = "Information", "Warning", "Error" }
+        }
+
+        It "Can retrieve specific severity <severity>" -testcase $testcases {
+            param ( $severity )
+            $result = Invoke-ScriptAnalyzer -ScriptDefinition $script -Severity $severity
+            if ( $severity -is [array] ) {
+                @($result).Count | Should -Be @($severity).Count
+                foreach ( $sev in $severity ) {
+                    $result.Severity | Should -Contain $sev
+                }
+            }
+            else {
+                $result.Severity | Should -Be $severity
+            }
+        }
+    }
+
     Context "When used correctly" {
         It "works with one argument" {
             $errors = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -Severity Information

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -109,9 +109,11 @@ Describe "Test available parameters" {
 
 Describe "Test ScriptDefinition" {
     Context "When given a script definition" {
-        It "Does not run rules on script with more than 10 parser errors" {
-            $moreThanTenErrors = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue -ScriptDefinition (Get-Content -Raw "$directory\CSharp.ps1")
-            $moreThanTenErrors.Count | Should -Be 0
+        It "Runs rules on script with more than 10 parser errors" {
+            # this is a script with 12 parse errors
+            $script = ');' * 12
+            $moreThanTenErrors = Invoke-ScriptAnalyzer -ScriptDefinition $script
+            $moreThanTenErrors.Count | Should -Be 12
         }
     }
 }
@@ -124,9 +126,11 @@ Describe "Test Path" {
             $withPath.Count -eq $withoutPath.Count | Should -BeTrue
         }
 
-        It "Does not run rules on script with more than 10 parser errors" {
-            $moreThanTenErrors = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $directory\CSharp.ps1
-            $moreThanTenErrors.Count | Should -Be 0
+        It "Runs rules on script with more than 10 parser errors" {
+            # this is a script with 12 parse errors
+            1..12 | Foreach-Object { ')' } | Out-File "TestDrive:\badfile.ps1"
+            $moreThanTenErrors = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue "TestDrive:\badfile.ps1"
+            $moreThanTenErrors.Count | Should -Be 12
         }
     }
 

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -129,9 +129,9 @@ Describe "Test Path" {
 
         It "Runs rules on script with more than 10 parser errors" {
             # this is a script with 12 parse errors
-            1..12 | Foreach-Object { ')' } | Out-File "TestDrive:\badfile.ps1"
-            $moreThanTenErrors = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue "TestDrive:\badfile.ps1"
-            $moreThanTenErrors.Count | Should -Be 12
+            1..12 | Foreach-Object { ');' } | Out-File -Encoding ASCII "TestDrive:\badfile.ps1"
+            $moreThanTenErrors = Invoke-ScriptAnalyzer -Path "TestDrive:\badfile.ps1"
+            @($moreThanTenErrors).Count | Should -Be 12
         }
     }
 

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -36,7 +36,7 @@ function Invoke-ScriptAnalyzer {
         [Parameter(Mandatory = $false)]
         [string[]] $IncludeRule = $null, 
 
-        [ValidateSet("Warning", "Error", "Information", IgnoreCase = $true)]
+        [ValidateSet("Warning", "Error", "Information", "ParseError", IgnoreCase = $true)]
         [Parameter(Mandatory = $false)]
         [string[]] $Severity = $null,
         

--- a/Tests/Engine/ModuleDependencyHandler.tests.ps1
+++ b/Tests/Engine/ModuleDependencyHandler.tests.ps1
@@ -139,8 +139,12 @@ Describe "Resolve DSC Resource Dependency" {
 
     Context "Invoke-ScriptAnalyzer without switch" {
         It "Has parse errors" -skip:$skipTest {
-            $dr = Invoke-ScriptAnalyzer -Path $violationFilePath -ErrorVariable parseErrors -ErrorAction SilentlyContinue
-            $parseErrors.Count | Should -Be 1
+            $dr = Invoke-ScriptAnalyzer -Path $violationFilePath -ErrorVariable analyzerErrors -ErrorAction SilentlyContinue
+            $analyzerErrors.Count | Should -Be 0
+
+            $dr |
+                Where-Object { $_.Severity -eq "ParseError" } |
+                Get-Count | Should -Be 1
         }
     }
 
@@ -182,10 +186,13 @@ Describe "Resolve DSC Resource Dependency" {
             Copy-Item -Recurse -Path $modulePath -Destination $tempModulePath
         }
 
-        It "Doesn't have parse errors" -skip:$skipTest {
+        It "has a single parse error" -skip:$skipTest {
             # invoke script analyzer
-            $dr = Invoke-ScriptAnalyzer -Path $violationFilePath -ErrorVariable parseErrors -ErrorAction SilentlyContinue
-            $dr.Count | Should -Be 0
+            $dr = Invoke-ScriptAnalyzer -Path $violationFilePath -ErrorVariable analyzerErrors -ErrorAction SilentlyContinue
+            $analyzerErrors.Count | Should -Be 0
+            $dr |
+                Where-Object { $_.Severity -eq "ParseError" } |
+                Get-Count | Should -Be 1
         }
 
         It "Keeps PSModulePath unchanged before and after invocation" -skip:$skipTest {

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -127,6 +127,7 @@ Configuration Sample_ChangeDescriptionAndPermissions
                 # SilentlyContinue
                 Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings -ErrorAction SilentlyContinue |
                     Get-Count |
+                    Where-Object { $_.Severity -ne "ParseError" } |
                     Should -Be 4
             }
         }

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -126,8 +126,8 @@ Configuration Sample_ChangeDescriptionAndPermissions
                 # NonExistentModule is not really avaiable to load. Therefore we set erroraction to
                 # SilentlyContinue
                 Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings -ErrorAction SilentlyContinue |
-                    Get-Count |
                     Where-Object { $_.Severity -ne "ParseError" } |
+                    Get-Count |
                     Should -Be 4
             }
         }

--- a/Tests/Rules/UseUTF8EncodingForHelpFile.tests.ps1
+++ b/Tests/Rules/UseUTF8EncodingForHelpFile.tests.ps1
@@ -1,11 +1,13 @@
-﻿$violationMessage = "File about_utf16.help.txt has to use UTF8 instead of System.Text.UTF32Encoding encoding because it is a powershell help file."
-$violationName = "PSUseUTF8EncodingForHelpFile"
-$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
-$violations = Invoke-ScriptAnalyzer $directory\about_utf16.help.txt | Where-Object {$_.RuleName -eq $violationName}
-$noViolations = Invoke-ScriptAnalyzer $directory\about_utf8.help.txt | Where-Object {$_.RuleName -eq $violationName}
-$notHelpFileViolations = Invoke-ScriptAnalyzer $directory\utf16.txt | Where-Object {$_.RuleName -eq $violationName}
-
+﻿$directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 Describe "UseUTF8EncodingForHelpFile" {
+    BeforeAll {
+        $violationMessage = "File about_utf16.help.txt has to use UTF8 instead of System.Text.UTF32Encoding encoding because it is a powershell help file."
+        $violationName = "PSUseUTF8EncodingForHelpFile"
+        $violations = Invoke-ScriptAnalyzer $directory\about_utf16.help.txt | Where-Object {$_.RuleName -eq $violationName}
+        $noViolations = Invoke-ScriptAnalyzer $directory\about_utf8.help.txt | Where-Object {$_.RuleName -eq $violationName}
+        $notHelpFileViolations = Invoke-ScriptAnalyzer $directory\utf16.txt | Where-Object {$_.RuleName -eq $violationName}
+    }
+
     Context "When there are violations" {
         It "has 1 avoid use utf8 encoding violation" {
             $violations.Count | Should -Be 1

--- a/build.psm1
+++ b/build.psm1
@@ -197,6 +197,7 @@ function Start-ScriptAnalyzerBuild
             if ( $LASTEXITCODE -ne 0 ) { throw "$buildOutput" }
         }
         catch {
+            Write-Warning $_
             Write-Error "Failure to build for PSVersion '$PSVersion' using framework '$framework' and configuration '$config'"
             return
         }


### PR DESCRIPTION
## PR Summary

Fixes #1041
Emit parsing errors as diagnostic records.

I'm attempting to bring analyzer into a more lint like behavior which treats parsing/syntax errors as just another type of diagnostic. 

Currently, errors during parsing are written as error records, but they should probably just be diagnostic records.  This PR creates a new diagnostic record type and emits errors found during parsing into the result stream. This is far more useful to downstream readers (such as VSCode/EditorServices) because there's a single stream for information about the script. Rule violations *and* syntax errors.

I have also removed the current limitation of any time there are more than 10 parse errors, the analyzer simply returns, which seems to me to be pretty undesirable. We will now emit diagnostic records for all parse errors.

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.