### PR TITLE
Make it easier to install the dotnet CLI tools

### DIFF
--- a/BuildModule.tests.ps1
+++ b/BuildModule.tests.ps1
@@ -75,11 +75,12 @@ Describe "Build Module Tests" {
     }
 
     Context "Receive-DotnetInstallScript" {
+
         Mock -ModuleName Build Receive-File { new-item -type file TestDrive:/dotnet-install.sh }
-        It "Downloads the proper file" {
+        It "Downloads the proper non-Windows file" {
             try {
                 push-location TestDrive:
-                Receive-DotnetInstallScript -forceNonWindows
+                Receive-DotnetInstallScript -platform NonWindows
                 "TestDrive:/dotnet-install.sh" | Should -Exist
             }
             finally {
@@ -87,5 +88,66 @@ Describe "Build Module Tests" {
             }
         }
 
+        Mock -ModuleName Build Receive-File { new-item -type file TestDrive:/dotnet-install.ps1 }
+        It "Downloads the proper file Windows file" {
+            try {
+                push-location TestDrive:
+                Receive-DotnetInstallScript -platform "Windows"
+                "TestDrive:/dotnet-install.ps1" | Should -Exist
+            }
+            finally {
+                Pop-Location
+            }
+        }
+
+    }
+
+    Context "Test result functions" {
+        BeforeAll {
+            $xmlFile = @'
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<test-results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="nunit_schema_2.5.xsd" name="Pester" total="2" errors="0" failures="1" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2019-02-19" time="11:36:56">
+  <environment platform="Darwin" clr-version="Unknown" os-version="18.2.0" cwd="/Users/jimtru/src/github/forks/JamesWTruher/PSScriptAnalyzer" user="jimtru" user-domain="" machine-name="Jims-Mac-mini.guest.corp.microsoft.com" nunit-version="2.5.8.0" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="TestFixture" name="Pester" executed="True" result="Failure" success="False" time="0.0982" asserts="0" description="Pester">
+    <results>
+      <test-suite type="TestFixture" name="/tmp/bad.tests.ps1" executed="True" result="Failure" success="False" time="0.0982" asserts="0" description="/tmp/bad.tests.ps1">
+        <results>
+          <test-suite type="TestFixture" name="test function" executed="True" result="Failure" success="False" time="0.084" asserts="0" description="test function">
+            <results>
+              <test-case description="a passing test" name="test function.a passing test" time="0.0072" asserts="0" success="True" result="Success" executed="True" />
+              <test-case description="a failing test" name="test function.a failing test" time="0.0268" asserts="0" success="False" result="Failure" executed="True">
+                <failure>
+                  <message>Expected 2, but got 1.</message>
+                  <stack-trace>at &lt;ScriptBlock&gt;, /tmp/bad.tests.ps1: line 3
+3:     It "a failing test" { 1 | Should -Be 2 }</stack-trace>
+                </failure>
+              </test-case>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>
+'@
+
+            $xmlFile | out-file TESTDRIVE:/results.xml
+            $results = Get-TestResults -logfile TESTDRIVE:/results.xml
+            $failures = Get-TestFailures -logfile TESTDRIVE:/results.xml
+        }
+
+        It "Get-TestResults finds 2 results" {
+            $results.Count | Should -Be 2
+        }
+        It "Get-TestResults finds 1 pass" {
+            @($results | ?{ $_.result -eq "Success" }).Count |Should -Be 1
+        }
+        It "Get-TestResults finds 1 failure" {
+            @($results | ?{ $_.result -eq "Failure" }).Count |Should -Be 1
+        }
+        It "Get-TestFailures finds 1 failure" {
+            $failures.Count | Should -Be 1
+        }
     }
 }

--- a/BuildModule.tests.ps1
+++ b/BuildModule.tests.ps1
@@ -1,0 +1,91 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# these are tests for the build module
+
+import-module -force "./build.psm1"
+Describe "Build Module Tests" {
+    Context "Global.json" {
+        BeforeAll {
+            $globalJson = Get-Content (Join-Path $PSScriptRoot global.json) | ConvertFrom-Json
+            $expectedVersion = $globalJson.sdk.version
+            $result = Get-GlobalJsonSdkVersion
+        }
+        $propertyTestcases = @{ Name = "Major"; Type = "System.Int32" },
+            @{ Name = "Minor"; Type = "System.Int32" },
+            @{ Name = "Patch"; Type = "System.Int32" },
+            @{ Name = "PrereleaseLabel"; Type = "System.String" }
+        It "Get-GlobalJsonSdkVersion returns a portable version object with property '<Name>' with type '<Type>'" -TestCases $propertyTestcases {
+            param ( $Name, $Type )
+            $result.psobject.properties[$Name] | Should -BeOfType [System.Management.Automation.PSNoteProperty]
+            $result.psobject.properties[$Name].TypeNameOfValue | Should -Be $Type
+        }
+        It "Can retrieve the version from global.json" {
+            $result = Get-GlobalJsonSdkVersion
+            $resultString = "{0}.{1}.{2}" -f $result.Major,$result.Minor,$result.Patch
+            if ( $result.prereleasestring ) { $resultString += "-" + $result.prereleasestring }
+            $resultString | Should -Be $expectedVersion
+        }
+    }
+    Context "Test-SuiteableDotnet" {
+        It "Test-SuitableDotnet should return true when the expected version matches the installed version" {
+            Test-SuitableDotnet -availableVersions 2.1.2 -requiredVersion 2.1.2 | Should -Be $true
+        }
+        It "Test-SuitableDotnet should return true when the expected version matches the available versions" {
+            Test-SuitableDotnet -availableVersions "2.1.1","2.1.2","2.1.3" -requiredVersion 2.1.2 | Should -Be $true
+        }
+        It "Test-SuitableDotnet should return false when the expected version does not match an available" {
+            Test-SuitableDotnet -availableVersions "2.2.100","2.2.300" -requiredVersion 2.2.200 | Should -Be $false
+        }
+        It "Test-SuitableDotnet should return false when the expected version does not match an available" {
+            Test-SuitableDotnet -availableVersions "2.2.100","2.2.300" -requiredVersion 2.2.105 | Should -Be $false
+        }
+        It "Test-SuitableDotnet should return true when the expected version matches an available" {
+            Test-SuitableDotnet -availableVersions "2.2.150","2.2.300" -requiredVersion 2.2.105 | Should -Be $true
+        }
+        It "Test-SuitableDotnet should return false when the expected version does not match an available" {
+            Test-SuitableDotnet -availableVersions "2.2.400","2.2.401","2.2.405" -requiredVersion "2.2.410" | Should -Be $false
+        }
+    }
+
+    Context "Test-DotnetInstallation" {
+        BeforeAll {
+            $availableVersions = ConvertTo-PortableVersion -strVersion "2.2.400","2.2.401","2.2.405"
+            $foundVersion = ConvertTo-PortableVersion -strVersion 2.2.402
+            $missingVersion = ConvertTo-PortableVersion -strVersion 2.2.410
+        }
+
+        It "Test-DotnetInstallation finds a good version" {
+            Mock Get-InstalledCLIVersion { return $availableVersions }
+            Mock Get-GlobalJSonSdkVersion { return $foundVersion }
+            $result = Test-DotnetInstallation -requestedVersion (Get-GlobalJsonSdkVersion) -installedVersions (Get-InstalledCLIVersion)
+            Assert-MockCalled "Get-InstalledCLIVersion" -Times 1
+            Assert-MockCalled "Get-GlobalJsonSdkVersion" -Times 1
+            $result | Should -Be $true
+        }
+
+        It "Test-DotnetInstallation cannot find a good version should return false" {
+            Mock Get-InstalledCLIVersion { return $availableVersions }
+            Mock Get-GlobalJSonSdkVersion { return $missingVersion }
+            $result = Test-DotnetInstallation -requestedVersion (Get-GlobalJsonSdkVersion) -installedVersions (Get-InstalledCLIVersion)
+            Assert-MockCalled "Get-InstalledCLIVersion" -Times 1
+            Assert-MockCalled "Get-GlobalJsonSdkVersion" -Times 1
+            $result | Should -Be $false
+        }
+    }
+
+    Context "Receive-DotnetInstallScript" {
+        Mock -ModuleName Build Receive-File { new-item -type file TestDrive:/dotnet-install.sh }
+        It "Downloads the proper file" {
+            try {
+                push-location TestDrive:
+                Receive-DotnetInstallScript -forceNonWindows
+                "TestDrive:/dotnet-install.sh" | Should -Exist
+            }
+            finally {
+                Pop-Location
+            }
+        }
+
+    }
+}

--- a/build.ps1
+++ b/build.ps1
@@ -31,7 +31,10 @@ param(
     [switch] $Test,
 
     [Parameter(ParameterSetName='Test')]
-    [switch] $InProcess
+    [switch] $InProcess,
+
+    [Parameter(ParameterSetName='Bootstrap')]
+    [switch] $Bootstrap
 )
 
 END {
@@ -57,6 +60,10 @@ END {
                 Configuration = $Configuration
             }
             Start-ScriptAnalyzerBuild @buildArgs
+        }
+        "Bootstrap" {
+            Install-DotNet
+            return
         }
         "Test" {
             Test-ScriptAnalyzer -InProcess:$InProcess

--- a/build.psm1
+++ b/build.psm1
@@ -480,7 +480,7 @@ function Receive-DotnetInstallScript
 
 function Get-DotnetExe
 {
-    $discoveredDotNet = Get-Command -CommandType Application dotnet
+    $discoveredDotNet = Get-Command -CommandType Application dotnet -ErrorAction SilentlyContinue
     if ( $discoveredDotNet ) {
         $discoveredDotNet | Select-Object -First 1 | Foreach-Object { $_.Source }
         return
@@ -499,6 +499,7 @@ function Get-DotnetExe
             return $dotnetHuntPath
         }
     }
-    throw "Could not find dotnet executable"
+    Write-Warning "Could not find dotnet executable"
+    return [String]::Empty
 }
 $script:dotnetExe = Get-DotnetExe

--- a/build.psm1
+++ b/build.psm1
@@ -306,7 +306,12 @@ function Install-Dotnet
 function Test-DotnetInstallation
 {
     param ( $version )
-    $installedVersions = dotnet --list-sdks | Foreach-Object { $_.Split()[0] }
+    try {
+        $installedVersions = dotnet --list-sdks | Foreach-Object { $_.Split()[0] }
+    }
+    catch {
+        $installedVersions = @()
+    }
     if ( $installedVersions -contains $version ) {
         return $true
     }

--- a/build.psm1
+++ b/build.psm1
@@ -386,6 +386,7 @@ function Test-SuitableDotnet {
         $availableVersions = $( Get-InstalledCliVersion),
         $requiredVersion = $( Get-GlobalJsonSdkVersion )
         )
+
     if ( $requiredVersion -is [String] -or $requiredVersion -is [Version] ) {
         $requiredVersion = ConvertTo-PortableVersion "$requiredVersion"
     }
@@ -406,7 +407,7 @@ function Test-SuitableDotnet {
         }
         $requiredPatch = $requiredVersion.Patch
         $possiblePatch = $version.Patch
-        if ( $requiredPatch -gt $possiblePath ) {
+        if ( $requiredPatch -gt $possiblePatch ) {
             continue
         }
         if ( ($requiredPatch - $possiblePatch) -ge 100 ) {

--- a/build.psm1
+++ b/build.psm1
@@ -506,11 +506,24 @@ function Receive-File {
 
 function Receive-DotnetInstallScript
 {
-    param ( [switch]$forceNonWindows )
-    $installScriptName = "dotnet-install.ps1"
+    # param '$platform' is a hook to enable forcing download of a specific
+    # install script, generally it should not be used except in testing.
+    param ( $platform = "" )
 
-    if ( ((Test-Path Variable:IsWindows) -and -not $IsWindows) -or $forceNonWindows ) {
+    # if $platform has been set, it has priority
+    # if it's not set to Windows or NonWindows, it will be ignored
+    if ( $platform -eq "Windows" ) {
+        $installScriptName = "dotnet-install.ps1"
+    }
+    elseif ( $platform -eq "NonWindows" ) {
         $installScriptName = "dotnet-install.sh"
+    }
+    elseif ( ((Test-Path Variable:IsWindows) -and -not $IsWindows) ) {
+        # if the variable IsWindows exists and it is set to false
+        $installScriptName = "dotnet-install.sh"
+    }
+    else { # the default case - we're running on a Windows system
+        $installScriptName = "dotnet-install.ps1"
     }
     $uri = "https://dot.net/v1/${installScriptName}"
 

--- a/build.psm1
+++ b/build.psm1
@@ -298,7 +298,6 @@ function Install-Dotnet
         )
 
     if ( Test-DotnetInstallation -requestedversion $version ) {
-        Write-Verbose -Verbose "dotnet version '$version' already installed"
         if ( $Force ) {
             Write-Verbose -Verbose "Installing again"
         }
@@ -518,7 +517,6 @@ function Get-DotnetExe
             Sort-Object { $pv = ConvertTo-PortableVersion (& $_ --version 2>$null); "$pv" } |
             Select-Object -Last 1
         if ( $latestDotnet ) {
-            Write-Verbose -Verbose "Found dotnet here: $latestDotnet"
             $script:DotnetExe = $latestDotnet
             return $latestDotnet
         }

--- a/build.psm1
+++ b/build.psm1
@@ -412,6 +412,9 @@ function Test-SuitableDotnet {
     if ( $requiredVersion -is [String] -or $requiredVersion -is [Version] ) {
         $requiredVersion = ConvertTo-PortableVersion "$requiredVersion"
     }
+
+    $availableVersionList = $availableVersions | ForEach-Object { if ( $_ -is [string] -or $_ -is [version] ) { ConvertTo-PortableVersion $_ } else { $_ } }
+    $availableVersions = $availableVersionList
     # if we have what was requested, we can use it
     if ( $RequiredVersion.IsContainedIn($availableVersions)) {
         return $true
@@ -429,13 +432,13 @@ function Test-SuitableDotnet {
         }
         $requiredPatch = $requiredVersion.Patch
         $possiblePatch = $version.Patch
+
         if ( $requiredPatch -gt $possiblePatch ) {
             continue
         }
-        if ( ($requiredPatch - $possiblePatch) -ge 100 ) {
-            continue
+        if ( [math]::Abs(($requiredPatch - $possiblePatch)) -lt 100 ) {
+            return $true
         }
-        return $true
     }
     return $false
 }
@@ -468,19 +471,16 @@ function Get-InstalledCLIVersion {
 
 function Test-DotnetInstallation
 {
-    param ( $requestedVersion = $( Get-GlobalJsonSdkVersion ) )
-    $installedVersions = Get-InstalledCLIVersion
+    param (
+        $requestedVersion = $( Get-GlobalJsonSdkVersion ),
+        $installedVersions = $( Get-InstalledCLIVersion )
+        )
     return (Test-SuitableDotnet -availableVersions $installedVersions -requiredVersion $requestedVersion )
 }
 
-function Receive-DotnetInstallScript
-{
-    $installScriptName = "dotnet-install.ps1"
+function Receive-File {
+    param ( [Parameter(Mandatory,Position=0)]$uri )
 
-    if ( (Test-Path Variable:IsWindows) -and -not $IsWindows ) {
-        $installScriptName = "dotnet-install.sh"
-    }
-    $uri = "https://dot.net/v1/${installScriptName}"
     # enable Tls12 for the request
     # -SslProtocol parameter for Invoke-WebRequest wasn't in PSv3
     $securityProtocol = [System.Net.ServicePointManager]::SecurityProtocol
@@ -501,7 +501,20 @@ function Receive-DotnetInstallScript
     if ( -not $installScript ) {
         throw "Download failure of ${uri}"
     }
+    return $installScript
+}
 
+function Receive-DotnetInstallScript
+{
+    param ( [switch]$forceNonWindows )
+    $installScriptName = "dotnet-install.ps1"
+
+    if ( ((Test-Path Variable:IsWindows) -and -not $IsWindows) -or $forceNonWindows ) {
+        $installScriptName = "dotnet-install.sh"
+    }
+    $uri = "https://dot.net/v1/${installScriptName}"
+
+    $installScript = Receive-File -Uri $uri
     return $installScript.FullName
 }
 

--- a/build.psm1
+++ b/build.psm1
@@ -423,7 +423,6 @@ function Get-InstalledCLIVersion {
     try {
         # earlier versions of dotnet do not support --list-sdks, so we'll check the output
         # and use dotnet --version as a fallback
-
         $sdkList = & $script:dotnetExe --list-sdks 2>&1
         $sdkList = "Unknown option"
         if ( $sdkList -match "Unknown option" ) {
@@ -434,7 +433,8 @@ function Get-InstalledCLIVersion {
         }
     }
     catch {
-        $installedVersions = @()
+        Write-Verbose -Verbose "$_"
+        $installedVersions = & $script:dotnetExe --version
     }
     return (ConvertTo-PortableVersion $installedVersions)
 }

--- a/build.psm1
+++ b/build.psm1
@@ -306,7 +306,7 @@ function Install-Dotnet
         $installScriptPath = Receive-DotnetInstallScript
         $installScriptName = [System.IO.Path]::GetFileName($installScriptPath)
         If ( $PSCmdlet.ShouldProcess("$installScriptName for $version")) {
-            & "${installScriptPath}" -c release -v $version
+            & "${installScriptPath}" -c release -version $version
         }
     }
     catch {

--- a/build.psm1
+++ b/build.psm1
@@ -294,7 +294,7 @@ function Install-Dotnet
     [CmdletBinding(SupportsShouldProcess=$true)]
     param (
         [Parameter()][Switch]$Force,
-        [Parameter()]$version = $( Get-GlobalJsonSdkVersion )
+        [Parameter()]$version = $( Get-GlobalJsonSdkVersion -Raw )
         )
 
     if ( Test-DotnetInstallation -requestedversion $version ) {
@@ -332,9 +332,15 @@ function Install-Dotnet
 }
 
 function Get-GlobalJsonSdkVersion {
+    param ( [switch]$Raw )
     $json = Get-Content -raw (Join-Path $PSScriptRoot global.json) | ConvertFrom-Json
     $version = $json.sdk.Version
-    ConvertTo-PortableVersion $version
+    if ( $Raw ) {
+        return $version
+    }
+    else {
+        ConvertTo-PortableVersion $version
+    }
 }
 
 # we don't have semantic version in earlier versions of PowerShell, so we need to

--- a/build.psm1
+++ b/build.psm1
@@ -499,11 +499,13 @@ function Receive-DotnetInstallScript
 
 function Get-DotnetExe
 {
-    $discoveredDotNet = Get-Command -CommandType Application dotnet -ErrorAction SilentlyContinue
-    if ( $discoveredDotNet ) {
-        Write-Verbose -Verbose "Found dotnet here: $dotnetFoundPath"
-        $script:DotnetExe = $discoveredDotNet
-        return $discoveredDotNet
+    $discoveredDotnet = Get-Command -CommandType Application dotnet -ErrorAction SilentlyContinu
+    if ( $discoveredDotnet ) {
+        # it's possible that there are multiples. Take the highest version we find
+        $latestDotnet = $discoveredDotNet | Sort-object { [version](& $_ --version) } | Select-Object -Last 1
+        Write-Verbose -Verbose "Found dotnet here: $latestDotnet"
+        $script:DotnetExe = $latestDotnet
+        return $latestDotnet
     }
     # it's not in the path, try harder to find it
     # check the usual places

--- a/build.psm1
+++ b/build.psm1
@@ -372,7 +372,7 @@ function ConvertTo-PortableVersion {
         # type in script, we need a way to find the highest version of dotnet, it's not a great solution
         # but it will work in most cases.
         Add-Member -inputobject $customObject -Type ScriptMethod -Name ToString -Force -Value {
-            $str = "{0:0000}.{1:0000}.{2:0000}.{3:0000}" -f $this.Major,$this.Minor,$this.Patch
+            $str = "{0:0000}.{1:0000}.{2:0000}" -f $this.Major,$this.Minor,$this.Patch
             if ( $this.PrereleaseLabel ) {
                 $str += "-{0}" -f $this.PrereleaseLabel
             }
@@ -509,7 +509,7 @@ function Get-DotnetExe
         # version in global.json will produce an error, so we can only take the dotnet which executes
         $latestDotnet = $discoveredDotNet |
             Where-Object { try { & $_ --version 2>$null } catch { } } |
-            Sort-Object { $pv = ConvertTo-PortableVersion (& $_ --version 2>$null ); "$pv" } |
+            Sort-Object { $pv = ConvertTo-PortableVersion (& $_ --version 2>$null); "$pv" } |
             Select-Object -Last 1
         if ( $latestDotnet ) {
             Write-Verbose -Verbose "Found dotnet here: $latestDotnet"

--- a/build.psm1
+++ b/build.psm1
@@ -419,7 +419,17 @@ function Test-SuitableDotnet {
 # these are mockable functions for testing
 function Get-InstalledCLIVersion {
     try {
-        $installedVersions = dotnet --list-sdks | Foreach-Object { $_.Split()[0] }
+        # earlier versions of dotnet do not support --list-sdks, so we'll check the output
+        # and use dotnet --version as a fallback
+
+        $sdkList = dotnet --list-sdks 2>&1
+        $sdkList = "Unknown option"
+        if ( $sdkList -match "Unknown option" ) {
+            $installedVersions = dotnet --version
+        }
+        else {
+            $installedVersions = $sdkList | Foreach-Object { $_.Split()[0] }
+        }
     }
     catch {
         $installedVersions = @()

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -31,8 +31,9 @@ function Invoke-AppVeyorInstall {
         Install-Module -Name platyPS -Force -Scope CurrentUser -RequiredVersion $platyPSVersion
     }
 
-    Write-Verbose -Verbose "Installing required .Net CORE SDK $requiredDotNetCoreSDKVersion"
     # the build script sorts out the problems of WMF4 and earlier versions of dotnet CLI
+    Write-Verbose -Verbose "Installing required .Net CORE SDK"
+    Write-Verbose "& $buildScriptDir/build.ps1 -bootstrap"
     $buildScriptDir = (Resolve-Path "$PSScriptRoot/..").Path
     & "$buildScriptDir/build.ps1" -bootstrap
 }

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -5,7 +5,7 @@ $ErrorActionPreference = 'Stop'
 
 # Implements the AppVeyor 'install' step and installs the required versions of Pester, platyPS and the .Net Core SDK if needed.
 function Invoke-AppVeyorInstall {
-    $requiredPesterVersion = '4.4.1'
+    $requiredPesterVersion = '4.4.4'
     $pester = Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq $requiredPesterVersion }
     if ($null -eq $pester) {
         if ($null -eq (Get-Module -ListAvailable PowershellGet)) {
@@ -70,6 +70,7 @@ function Invoke-AppveyorFinish {
     Add-Type -AssemblyName 'System.IO.Compression.FileSystem'
     [System.IO.Compression.ZipFile]::CreateFromDirectory((Join-Path $pwd 'out'), $zipFile)
     @(
+        (Get-ChildItem TestResults.xml)
         # You can add other artifacts here
         (Get-ChildItem $zipFile)
     ) | ForEach-Object { Push-AppveyorArtifact $_.FullName }

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -46,6 +46,8 @@ function Invoke-AppveyorTest {
         $CheckoutPath
     )
 
+    # enforce the language to utf-8 to avoid issues
+    $env:LANG = "en_US.UTF-8"
     Write-Verbose -Verbose ("Running tests on PowerShell version " + $PSVersionTable.PSVersion)
     Write-Verbose -Verbose "Language set to '${env:LANG}'"
 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -31,36 +31,10 @@ function Invoke-AppVeyorInstall {
         Install-Module -Name platyPS -Force -Scope CurrentUser -RequiredVersion $platyPSVersion
     }
 
-    # the legacy WMF4 image only has the old preview SDKs of dotnet
-    $globalDotJson = Get-Content (Join-Path $PSScriptRoot '..\global.json') -Raw | ConvertFrom-Json
-    $requiredDotNetCoreSDKVersion = $globalDotJson.sdk.version
-    if ($PSVersionTable.PSVersion.Major -gt 4) {
-        $requiredDotNetCoreSDKVersionPresent = (dotnet --list-sdks) -match $requiredDotNetCoreSDKVersion
-    }
-    else {
-        # WMF 4 image has old SDK that does not have --list-sdks parameter
-        $requiredDotNetCoreSDKVersionPresent = (dotnet --version).StartsWith($requiredDotNetCoreSDKVersion)
-    }
-    if (-not $requiredDotNetCoreSDKVersionPresent) {
-        Write-Verbose -Verbose "Installing required .Net CORE SDK $requiredDotNetCoreSDKVersion"
-        $originalSecurityProtocol = [Net.ServicePointManager]::SecurityProtocol
-        try {
-            [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
-            if ($IsLinux -or $isMacOS) {
-                Invoke-WebRequest 'https://dot.net/v1/dotnet-install.sh' -OutFile dotnet-install.sh
-                bash dotnet-install.sh --version $requiredDotNetCoreSDKVersion
-                [System.Environment]::SetEnvironmentVariable('PATH', "/home/appveyor/.dotnet$([System.IO.Path]::PathSeparator)$PATH")
-            }
-            else {
-                Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile dotnet-install.ps1
-                .\dotnet-install.ps1 -Version $requiredDotNetCoreSDKVersion
-            }
-        }
-        finally {
-            [Net.ServicePointManager]::SecurityProtocol = $originalSecurityProtocol
-            Remove-Item .\dotnet-install.*
-        }
-    }
+    Write-Verbose -Verbose "Installing required .Net CORE SDK $requiredDotNetCoreSDKVersion"
+    # the build script sorts out the problems of WMF4 and earlier versions of dotnet CLI
+    $buildScriptDir = (Resolve-Path "$PSScriptRoot/..").Path
+    & "$buildScriptDir/build.ps1" -bootstrap
 }
 
 # Implements AppVeyor 'test_script' step


### PR DESCRIPTION
## PR Summary

Sometimes the build of script analyzer fails because version specified in `global.json` is not installed. This PR makes it easier to install the proper version of the CLI tools with the `-bootstrap` parameter to `build.ps1`

```powershell
PS> ./build.ps1 -bootstrap
```
will determine which version of the CLI is needed, validate whether the proper version is already present, and if not, will install it.

This does *not* validate whether the net452 targeting framework is installed, that must be done manually.


## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.