### PR TITLE
Allow for suppression of custom rules

### DIFF
--- a/Engine/Generic/ExternalRule.cs
+++ b/Engine/Generic/ExternalRule.cs
@@ -17,11 +17,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         string modPath = string.Empty;
         string paramType = string.Empty;
 
-        /// <summary>
-        /// Adds module name (source name) to handle ducplicate function names in different modules.
-        /// </summary>
-        /// <returns></returns>
         public string GetName()
+        {
+            return this.name;
+        }
+
+        public string GetFullName()
         {
             return string.Format(CultureInfo.CurrentCulture, "{0}\\{1}", this.GetSourceName(), this.name);
         }

--- a/Engine/Generic/ExternalRule.cs
+++ b/Engine/Generic/ExternalRule.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Globalization;
+
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
 {
     internal class ExternalRule : IExternalRule
@@ -15,9 +17,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         string modPath = string.Empty;
         string paramType = string.Empty;
 
+        /// <summary>
+        /// Adds module name (source name) to handle ducplicate function names in different modules.
+        /// </summary>
+        /// <returns></returns>
         public string GetName()
         {
-            return this.name;
+            return string.Format(CultureInfo.CurrentCulture, "{0}\\{1}", this.GetSourceName(), this.name);
         }
 
         public string GetCommonName()

--- a/Engine/Generic/IExternalRule.cs
+++ b/Engine/Generic/IExternalRule.cs
@@ -9,6 +9,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
     internal interface IExternalRule : IRule
     {
         /// <summary>
+        /// Adds module name (source name) to handle ducplicate function names in different modules.
+        /// </summary>
+        /// <returns></returns>
+        string GetFullName();
+
+        /// <summary>
         /// GetParameter: Retrieves AstType parameter
         /// </summary>
         /// <returns>string</returns>

--- a/Engine/Generic/RuleSuppression.cs
+++ b/Engine/Generic/RuleSuppression.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
                     && (ScriptAnalyzer.Instance.TokenRules != null
                         && ScriptAnalyzer.Instance.TokenRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
                     && (ScriptAnalyzer.Instance.ExternalRules != null
-                        && ScriptAnalyzer.Instance.ExternalRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
+                        && ScriptAnalyzer.Instance.ExternalRules.Count(item => String.Equals(item.GetFullName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
                     && (ScriptAnalyzer.Instance.DSCResourceRules != null
                         && ScriptAnalyzer.Instance.DSCResourceRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0))
                 {

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -1419,7 +1419,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 while (startRecord < diagnostics.Count
                     // && diagnostics[startRecord].Extent.StartOffset < ruleSuppression.StartOffset)
                     // && diagnostics[startRecord].Extent.StartLineNumber < ruleSuppression.st)
-                    && offsetArr[startRecord].Item1 < ruleSuppression.StartOffset)
+                    && offsetArr[startRecord] != null && offsetArr[startRecord].Item1 < ruleSuppression.StartOffset)
                 {
                     startRecord += 1;
                 }
@@ -1433,7 +1433,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     var curOffset = offsetArr[recordIndex];
 
                     //if (record.Extent.EndOffset > ruleSuppression.EndOffset)
-                    if (curOffset.Item2 > ruleSuppression.EndOffset)
+                    if (curOffset != null && curOffset.Item2 > ruleSuppression.EndOffset)
                     {
                         break;
                     }
@@ -1489,6 +1489,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             for (int k = 0; k < diagnostics.Count; k++)
             {
                 var ext = diagnostics[k].Extent;
+                if (ext == null)
+                {
+                    continue;
+                }
                 if (ext.StartOffset == 0 && ext.EndOffset == 0)
                 {
                     // check if line and column number correspond to 0 offsets

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1206,9 +1206,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                         // Adds command to run external analyzer rule, like
                         // Measure-CurlyBracket -ScriptBlockAst $ScriptBlockAst
-                        // Adds module name (source name) to handle ducplicate function names in different modules.
-                        string ruleName = string.Format("{0}\\{1}", rule.GetSourceName(), rule.GetName());
-                        posh.Commands.AddCommand(ruleName);
+                        posh.Commands.AddCommand(rule.GetName());
                         posh.Commands.AddParameter(rule.GetParameter(), token);
 
                         // Merges results because external analyzer rules may throw exceptions.
@@ -1236,9 +1234,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                             // Adds command to run external analyzer rule, like
                             // Measure-CurlyBracket -ScriptBlockAst $ScriptBlockAst
-                            // Adds module name (source name) to handle ducplicate function names in different modules.
-                            string ruleName = string.Format("{0}\\{1}", rule.GetSourceName(), rule.GetName());
-                            posh.Commands.AddCommand(ruleName);
+                            posh.Commands.AddCommand(rule.GetName());
                             posh.Commands.AddParameter(rule.GetParameter(), childAst);
 
                             // Merges results because external analyzer rules may throw exceptions.
@@ -2278,7 +2274,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 {
                     if (IsRuleAllowed(exRule))
                     {
-                        string ruleName = string.Format(CultureInfo.CurrentCulture, "{0}\\{1}", exRule.GetSourceName(), exRule.GetName());
+                        string ruleName = exRule.GetName();
                         this.outputWriter.WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, ruleName));
 
                         // Ensure that any unhandled errors from Rules are converted to non-terminating errors

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1206,7 +1206,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                         // Adds command to run external analyzer rule, like
                         // Measure-CurlyBracket -ScriptBlockAst $ScriptBlockAst
-                        posh.Commands.AddCommand(rule.GetName());
+                        posh.Commands.AddCommand(rule.GetFullName());
                         posh.Commands.AddParameter(rule.GetParameter(), token);
 
                         // Merges results because external analyzer rules may throw exceptions.
@@ -1234,7 +1234,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                             // Adds command to run external analyzer rule, like
                             // Measure-CurlyBracket -ScriptBlockAst $ScriptBlockAst
-                            posh.Commands.AddCommand(rule.GetName());
+                            posh.Commands.AddCommand(rule.GetFullName());
                             posh.Commands.AddParameter(rule.GetParameter(), childAst);
 
                             // Merges results because external analyzer rules may throw exceptions.
@@ -2274,7 +2274,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 {
                     if (IsRuleAllowed(exRule))
                     {
-                        string ruleName = exRule.GetName();
+                        string ruleName = exRule.GetFullName();
                         this.outputWriter.WriteVerbose(string.Format(CultureInfo.CurrentCulture, Strings.VerboseRunningMessage, ruleName));
 
                         // Ensure that any unhandled errors from Rules are converted to non-terminating errors

--- a/README.md
+++ b/README.md
@@ -307,8 +307,6 @@ Suppress violation in `start-bar`, `start-baz` and `start-bam` but not in `start
 Param()
 ```
 
-**Note**: Rule suppression is currently supported only for built-in rules.
-
 **Note**: Parser Errors cannot be suppressed via the `SuppressMessageAttribute`
 
 [Back to ToC](#table-of-contents)

--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -160,6 +160,17 @@ Describe "Test importing correct customized rules" {
             $violations[0].SuggestedCorrections.Text   | Should -Be 'text'
             $violations[0].SuggestedCorrections.File   | Should -Be 'filePath'
             $violations[0].SuggestedCorrections.Description   | Should -Be 'description'
+		}
+
+        It "can suppress custom rule" {
+			$script = "[Diagnostics.CodeAnalysis.SuppressMessageAttribute('samplerule\$measure','')]Param()"
+			$testScriptPath = "TestDrive:\SuppressedCustomRule.ps1"
+			Set-Content -Path $testScriptPath -Value $script
+
+            $customizedRulePath = Invoke-ScriptAnalyzer -Path $testScriptPath -CustomizedRulePath $directory\samplerule\samplerule.psm1 |
+				Where-Object { $_.Message -eq $message }
+
+            $customizedRulePath.Count | Should -Be 0
         }
 
         if (!$testingLibraryUsage)

--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -20,13 +20,12 @@ if (-not (Test-PSEditionCoreCLR))
 
 
 $message = "this is help"
-$ruleFunctionName = "Measure-RequiresRunAsAdministrator"
+$measure = "Measure-RequiresRunAsAdministrator"
 
 Describe "Test importing customized rules with null return results" {
-	$ruleName = "SampleRulesWithErrors\$ruleFunctionName"
     Context "Test Get-ScriptAnalyzer with customized rules" {
         It "will not terminate the engine" {
-            $customizedRulePath = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $ruleName}
+            $customizedRulePath = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $measure}
             $customizedRulePath.Count | Should -Be 1
         }
 
@@ -34,7 +33,7 @@ Describe "Test importing customized rules with null return results" {
 
     Context "Test Invoke-ScriptAnalyzer with customized rules" {
         It "will not terminate the engine" {
-            $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $ruleName}
+            $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $measure}
             $customizedRulePath.Count | Should -Be 0
         }
     }
@@ -79,20 +78,19 @@ Describe "Test importing correct customized rules" {
 	}
 
     Context "Test Get-ScriptAnalyzer with customized rules" {
-		$ruleName = "samplerule\$ruleFunctionName"
         It "will show the custom rule" {
-            $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.RuleName -eq $ruleName}
+            $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.RuleName -eq $measure}
             $customizedRulePath.Count | Should -Be 1
         }
 
 		It "will show the custom rule when given a rule folder path" {
-			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule | Where-Object {$_.RuleName -eq $ruleName}
+			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule | Where-Object {$_.RuleName -eq $measure}
 		    $customizedRulePath.Count | Should -Be 1
 		}
 
         It "will show the custom rule when given a rule folder path with trailing backslash" -skip:$($IsLinux -or $IsMacOS) {
 			# needs fixing for linux
-            $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory/samplerule/ | Where-Object {$_.RuleName -eq $ruleName}
+            $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory/samplerule/ | Where-Object {$_.RuleName -eq $measure}
             $customizedRulePath.Count | Should -Be 1
 		}
 
@@ -103,14 +101,12 @@ Describe "Test importing correct customized rules" {
 			{
 				$expectedNumRules = 3
 			}
-			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule* |
-				Where-Object {$_.RuleName -match $ruleFunctionName}
+			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.RuleName -match $measure}
 			$customizedRulePath.Count | Should -Be $expectedNumRules
 		}
 
 		It "will show the custom rules when given recurse switch" {
-			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath "$directory\samplerule", "$directory\samplerule\samplerule2" |
-				Where-Object { $_.RuleName.EndsWith($ruleFunctionName) }
+			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath "$directory\samplerule", "$directory\samplerule\samplerule2" | Where-Object {$_.RuleName -eq $measure}
 			$customizedRulePath.Count | Should -Be 5
 		}
 
@@ -121,14 +117,12 @@ Describe "Test importing correct customized rules" {
 			{
 				$expectedNumRules = 4
 			}
-			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule\samplerule* |
-                Where-Object { $_.RuleName.EndsWith($ruleFunctionName) }
+			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.RuleName -eq $measure}
 			$customizedRulePath.Count | Should -Be $expectedNumRules
 		}
 
 		It "will show the custom rules when given glob with recurse switch" {
-			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule* |
-				Where-Object { $_.RuleName.EndsWith($ruleFunctionName) }
+			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule* | Where-Object {$_.RuleName -eq $measure}
 			$customizedRulePath.Count | Should -Be 3
 		}
     }

--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -20,12 +20,13 @@ if (-not (Test-PSEditionCoreCLR))
 
 
 $message = "this is help"
-$measure = "Measure-RequiresRunAsAdministrator"
+$ruleFunctionName = "Measure-RequiresRunAsAdministrator"
 
 Describe "Test importing customized rules with null return results" {
+	$ruleName = "SampleRulesWithErrors\$ruleFunctionName"
     Context "Test Get-ScriptAnalyzer with customized rules" {
         It "will not terminate the engine" {
-            $customizedRulePath = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $measure}
+            $customizedRulePath = Get-ScriptAnalyzerRule -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $ruleName}
             $customizedRulePath.Count | Should -Be 1
         }
 
@@ -33,7 +34,7 @@ Describe "Test importing customized rules with null return results" {
 
     Context "Test Invoke-ScriptAnalyzer with customized rules" {
         It "will not terminate the engine" {
-            $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $measure}
+            $customizedRulePath = Invoke-ScriptAnalyzer $directory\TestScript.ps1 -CustomizedRulePath $directory\samplerule\SampleRulesWithErrors.psm1 | Where-Object {$_.RuleName -eq $ruleName}
             $customizedRulePath.Count | Should -Be 0
         }
     }
@@ -78,19 +79,20 @@ Describe "Test importing correct customized rules" {
 	}
 
     Context "Test Get-ScriptAnalyzer with customized rules" {
+		$ruleName = "samplerule\$ruleFunctionName"
         It "will show the custom rule" {
-            $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.RuleName -eq $measure}
+            $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule.psm1 | Where-Object {$_.RuleName -eq $ruleName}
             $customizedRulePath.Count | Should -Be 1
         }
 
 		It "will show the custom rule when given a rule folder path" {
-			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule | Where-Object {$_.RuleName -eq $measure}
+			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule | Where-Object {$_.RuleName -eq $ruleName}
 		    $customizedRulePath.Count | Should -Be 1
 		}
 
         It "will show the custom rule when given a rule folder path with trailing backslash" -skip:$($IsLinux -or $IsMacOS) {
 			# needs fixing for linux
-            $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory/samplerule/ | Where-Object {$_.RuleName -eq $measure}
+            $customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory/samplerule/ | Where-Object {$_.RuleName -eq $ruleName}
             $customizedRulePath.Count | Should -Be 1
 		}
 
@@ -101,12 +103,14 @@ Describe "Test importing correct customized rules" {
 			{
 				$expectedNumRules = 3
 			}
-			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.RuleName -match $measure}
+			$customizedRulePath = Get-ScriptAnalyzerRule  -CustomizedRulePath $directory\samplerule\samplerule* |
+				Where-Object {$_.RuleName -match $ruleFunctionName}
 			$customizedRulePath.Count | Should -Be $expectedNumRules
 		}
 
 		It "will show the custom rules when given recurse switch" {
-			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath "$directory\samplerule", "$directory\samplerule\samplerule2" | Where-Object {$_.RuleName -eq $measure}
+			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath "$directory\samplerule", "$directory\samplerule\samplerule2" |
+				Where-Object { $_.RuleName.EndsWith($ruleFunctionName) }
 			$customizedRulePath.Count | Should -Be 5
 		}
 
@@ -117,12 +121,14 @@ Describe "Test importing correct customized rules" {
 			{
 				$expectedNumRules = 4
 			}
-			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule\samplerule* | Where-Object {$_.RuleName -eq $measure}
+			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule\samplerule* |
+                Where-Object { $_.RuleName.EndsWith($ruleFunctionName) }
 			$customizedRulePath.Count | Should -Be $expectedNumRules
 		}
 
 		It "will show the custom rules when given glob with recurse switch" {
-			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule* | Where-Object {$_.RuleName -eq $measure}
+			$customizedRulePath = Get-ScriptAnalyzerRule  -RecurseCustomRulePath -CustomizedRulePath $directory\samplerule* |
+				Where-Object { $_.RuleName.EndsWith($ruleFunctionName) }
 			$customizedRulePath.Count | Should -Be 3
 		}
     }

--- a/Tests/Engine/samplerule/samplerule.psm1
+++ b/Tests/Engine/samplerule/samplerule.psm1
@@ -28,12 +28,15 @@ function Measure-RequiresRunAsAdministrator
         [System.Management.Automation.Language.ScriptBlockAst]
         $testAst
     )
+
+    # The implementation is mocked out for testing purposes only and many properties are deliberately set to null to test if PSSA can cope with it
     $l=(new-object System.Collections.ObjectModel.Collection["Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent"])
     $c = (new-object Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent 1,2,3,4,'text','filePath','description')
     $l.Add($c)
+    $extent = $null
     $dr = New-Object `
             -Typename "Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord" `
-            -ArgumentList "This is help",$testAst.Extent,$PSCmdlet.MyInvocation.InvocationName,Warning,$null,$null,$l
+            -ArgumentList "This is help",$extent,$PSCmdlet.MyInvocation.InvocationName,Warning,$null,$null,$l
         return $dr
 }
 Export-ModuleMember -Function Measure*

--- a/Tests/Engine/samplerule/samplerule.psm1
+++ b/Tests/Engine/samplerule/samplerule.psm1
@@ -27,13 +27,13 @@ function Measure-RequiresRunAsAdministrator
         [ValidateNotNullOrEmpty()]
         [System.Management.Automation.Language.ScriptBlockAst]
         $testAst
-    )        
+    )
     $l=(new-object System.Collections.ObjectModel.Collection["Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent"])
     $c = (new-object Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent 1,2,3,4,'text','filePath','description')
     $l.Add($c)
     $dr = New-Object `
             -Typename "Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord" `
-            -ArgumentList "This is help",$ast.Extent,$PSCmdlet.MyInvocation.InvocationName,Warning,$null,$null,$l     
+            -ArgumentList "This is help",$testAst.Extent,$PSCmdlet.MyInvocation.InvocationName,Warning,$null,$null,$l
         return $dr
 }
 Export-ModuleMember -Function Measure*


### PR DESCRIPTION
## PR Summary

- Fixes #1140 by calling `GetFullName` in the rule suppression lookup code as custom rules have a longer rule name. This might be also interesting for you guys: @LaurentDardenne @thomasrayner
- Fix rule name lookup mismatch for custom rules to allow for suppression and unify code.
- Fix engine code to be able to cope with custom rules that return records where the `Extent` is not set (i.e. null), before PSSA threw NullReferenceExceptions.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.