### PR TITLE
Fix settings file array parsing when no commas are present

### DIFF
--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -522,6 +522,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                         case "false":
                             return false;
 
+                        case "null":
+                            return null;
+
                         default:
                             throw CreateInvalidDataExceptionFromAst(varExprAst);
                     }
@@ -547,13 +550,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     // This will also mean that @(1; 2) is parsed as an array of two elements, but there's not much point defending against this
                     foreach (StatementAst statement in arrExprAst.SubExpression.Statements)
                     {
-                        var pipelineAst = statement as PipelineAst;
-                        if (pipelineAst == null)
+                        if (!(statement is PipelineAst pipelineAst))
                         {
                             throw CreateInvalidDataExceptionFromAst(arrExprAst);
                         }
 
-                        var pipelineExpressionAst = pipelineAst.GetPureExpression();
+                        ExpressionAst pipelineExpressionAst = pipelineAst.GetPureExpression();
                         if (pipelineExpressionAst == null)
                         {
                             throw CreateInvalidDataExceptionFromAst(arrExprAst);
@@ -660,10 +662,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 throw new ArgumentNullException(nameof(ast));
             }
 
-            return ThrowInvalidDataException(ast.Extent);
+            return CreateInvalidDataException(ast.Extent);
         }
 
-        private static InvalidDataException ThrowInvalidDataException(IScriptExtent extent)
+        private static InvalidDataException CreateInvalidDataException(IScriptExtent extent)
         {
             return new InvalidDataException(string.Format(
                                     CultureInfo.CurrentCulture,

--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -541,6 +541,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     }
 
                     var listComponents = new List<object>();
+                    // Arrays can either be array expressions (1, 2, 3) or array literals with statements @(1 `n 2 `n 3)
+                    // Or they can be a combination of these
+                    // We go through each statement (line) in an array and read the whole subarray
+                    // This will also mean that @(1; 2) is parsed as an array of two elements, but there's not much point defending against this
                     foreach (StatementAst statement in arrExprAst.SubExpression.Statements)
                     {
                         var pipelineAst = statement as PipelineAst;

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -218,6 +218,10 @@ Describe "Settings Class" {
                 @{ Expr = '@("A","B","C")'; Count = 3 }
                 @{ Expr = '@()'; Count = 0 }
                 @{ Expr = '@(7)'; Count = 1 }
+                @{ Expr = "'1',`n'2',`n'3'"; Count = 3 }
+                @{ Expr = "@(1`n3`n5`n7)"; Count = 4 }
+                @{ Expr = "'1',`r`n'2',`r`n'3'"; Count = 3 }
+                @{ Expr = "@(1`r`n3`r`n5`r`n7)"; Count = 4 }
             )
 
             $gsvHashtableTests = @(

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -222,6 +222,7 @@ Describe "Settings Class" {
                 @{ Expr = "@(1`n3`n5`n7)"; Count = 4 }
                 @{ Expr = "'1',`r`n'2',`r`n'3'"; Count = 3 }
                 @{ Expr = "@(1`r`n3`r`n5`r`n7)"; Count = 4 }
+                @{ Expr = "@(1,2,3`n7,8,9)"; Count = 6 }
             )
 
             $gsvHashtableTests = @(

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -209,6 +209,7 @@ Describe "Settings Class" {
                 @{ Expr = '0.142' }
                 @{ Expr = '"Hello"' }
                 @{ Expr = '"Well then"' }
+                @{ Expr = '$null' }
             )
 
             $gsvArrayTests = @(
@@ -240,7 +241,6 @@ Describe "Settings Class" {
             $gsvThrowTests = @(
                 @{ Expr = '$var' }
                 @{ Expr = '' }
-                @{ Expr = '$null' }
                 @{ Expr = '3+7' }
                 @{ Expr = '- 2.5'}
                 @{ Expr = '-not $true' }

--- a/Tests/Rules/AllCompatibilityRules.Tests.ps1
+++ b/Tests/Rules/AllCompatibilityRules.Tests.ps1
@@ -1,0 +1,133 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+$script:fileContent = @'
+$assetDir = 'C:\ImportantFiles\'
+$archiveDir = 'C:\Archived\'
+
+$runningOnWindows = -not ($IsLinux -or $IsMacOS)
+$zipCompressionLevel = 'Optimal'
+$includeBaseDirInZips = $true
+
+if (-not (Test-Path $archiveDir))
+{
+    New-Item -Type Directory $archiveDir
+}
+
+Import-Module -FullyQualifiedName @{ ModuleName = 'MyArchiveUtilities'; ModuleVersion = '2.0' }
+
+$sigs = [System.Collections.Generic.List[System.Management.Automation.Signature]]::new()
+$filePattern = [System.Management.Automation.WildcardPattern]::Get('system*')
+foreach ($file in Get-ChildItem $assetDir -Recurse -Depth 1)
+{
+    if (-not $filePattern.IsMatch($file.Name))
+    {
+        continue
+    }
+
+    if ($file.Name -like '*.dll')
+    {
+        $sig = Get-AuthenticodeSignature $file
+        $sigs.Add($sig)
+        continue
+    }
+
+    if (Test-WithFunctionFromMyModule -File $file)
+    {
+        $destZip = Join-Path $archiveDir $file.BaseName
+        [System.IO.Compression.ZipFile]::CreateFromDirectory($file.FullName, "$destZip.zip", $zipCompressionLevel, $includeBaseDirInZips)
+    }
+}
+
+Write-Output $sigs
+'@
+
+$script:settingsContent = @'
+@{
+    Rules = @{
+        PSUseCompatibleCommands = @{
+            Enable = $true
+            TargetProfiles = @(
+                'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework' # Server 2019 - PS 5.1 (the platform it already runs on)
+                'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework' # Server 2012 - PS 3
+                'ubuntu_x64_18.04_6.1.3_x64_4.0.30319.42000_core' # Ubuntu 18.04 - PS 6.1
+            )
+        }
+        PSUseCompatibleTypes = @{
+            Enable = $true
+            # Same as for command targets
+            TargetProfiles = @(
+                'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+                'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
+                'ubuntu_x64_18.04_6.1.3_x64_4.0.30319.42000_core'
+            )
+        }
+        PSUseCompatibleSyntax = @{
+            Enable = $true
+            TargetVersions = @('3.0', '5.1', '6.1')
+        }
+    }
+}
+'@
+
+$script:expectedCommandDiagnostics = @(
+    @{ Command = 'Import-Module'; Parameter = 'FullyQualifiedName'; Line = 13 }
+    @{ Command = 'Get-ChildItem'; Parameter = 'Depth'; Line = 17 }
+    @{ Command = 'Get-AuthenticodeSignature'; Line = 26 }
+)
+
+$script:expectedTypeDiagnostics = @(
+    @{ Type = 'System.Management.Automation.WildcardPattern'; Member = 'Get'; Line = 16 }
+    @{ Type = 'System.IO.Compression.ZipFile'; Line = 34 }
+)
+
+$script:expectedSyntaxDiagnostics = @(
+    @{ Line = 15; CorrectionText = "New-Object 'System.Collections.Generic.List[System.Management.Automation.Signature]'" }
+)
+
+Describe "Running all compatibility rules with a settings file" {
+    BeforeAll {
+        $testFile = New-Item -Path "$TestDrive/test.ps1" -Value $script:fileContent
+        $settingsFile = New-Item -Path "$TestDrive/settings.psd1" -Value $script:settingsContent
+        $diagnostics = Invoke-ScriptAnalyzer -Path $testFile.FullName -Settings $settingsFile.FullName |
+            Group-Object -Property RuleName -AsHashtable
+        $commandDiagnostics = $diagnostics.PSUseCompatibleCommands
+        $typeDiagnostics = $diagnostics.PSUseCompatibleTypes
+        $syntaxDiagnostics = $diagnostics.PSUseCompatibleSyntax
+    }
+
+    It "Finds the problem with command <Command> on line <Line> in the file" -TestCases $script:expectedCommandDiagnostics {
+        param([string]$Command, [string]$Parameter, [int]$Line)
+
+        $actualDiagnostic = $commandDiagnostics | Where-Object { $_.Command -eq $Command -and $_.Line -eq $Line }
+        $actualDiagnostic.Command | Should -BeExactly $Command
+        $actualDiagnostic.Line | Should -Be $Line
+        if ($Parameter)
+        {
+            $actualDiagnostic.Parameter | Should -Be $Parameter
+        }
+    }
+
+    It "Finds the problem with type <Type> on line <Line> in the file" -TestCases $script:expectedTypeDiagnostics {
+        param([string]$Type, [string]$Member, [int]$Line)
+
+        $actualDiagnostic = $typeDiagnostics | Where-Object { $_.Type -eq $Type -and $_.Line -eq $Line }
+        $actualDiagnostic.Type | Should -BeExactly $Type
+        $actualDiagnostic.Line | Should -Be $Line
+        if ($Member)
+        {
+            $actualDiagnostic.Member | Should -Be $Member
+        }
+    }
+
+    It "Finds the problem with syntax on line <Line> in the file" -TestCases $script:expectedSyntaxDiagnostics {
+        param([string]$Suggestion, [int]$Line)
+
+        $actualDiagnostic = $syntaxDiagnostics | Where-Object { $_.Line -eq $Line }
+        $actualDiagnostic.Line | Should -Be $Line
+        if ($Suggestion)
+        {
+            $actualDiagnostic.Suggestion | Should -Be $Suggestion
+        }
+    }
+}

--- a/Tests/Rules/AllCompatibilityRules.Tests.ps1
+++ b/Tests/Rules/AllCompatibilityRules.Tests.ps1
@@ -87,8 +87,8 @@ $script:expectedSyntaxDiagnostics = @(
 
 Describe "Running all compatibility rules with a settings file" {
     BeforeAll {
-        $testFile = New-Item -Path "$TestDrive/test.ps1" -Value $script:fileContent
-        $settingsFile = New-Item -Path "$TestDrive/settings.psd1" -Value $script:settingsContent
+        $testFile = New-Item -Path "$TestDrive/test.ps1" -Value $script:fileContent -ItemType File
+        $settingsFile = New-Item -Path "$TestDrive/settings.psd1" -Value $script:settingsContent -ItemType File
         $diagnostics = Invoke-ScriptAnalyzer -Path $testFile.FullName -Settings $settingsFile.FullName |
             Group-Object -Property RuleName -AsHashtable
         $commandDiagnostics = $diagnostics.PSUseCompatibleCommands


### PR DESCRIPTION
## PR Summary

Fixes #1160.

The settings parsing logic didn't automatically capture arrays where elements are separated by newline.

I've fix that in the parser and added some tests to make sure it stays fixed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.