### PR TITLE
Improve performance with better CommandInfo cache locking making Invoke-ScriptAnalyzer nearly twice as fast

### DIFF
--- a/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
+++ b/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
@@ -84,8 +84,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 
             // Initialize helper
             Helper.Instance = new Helper(
-                SessionState.InvokeCommand,
-                this);
+                SessionState.InvokeCommand);
             Helper.Instance.Initialize();
 
             string[] rulePaths = Helper.ProcessCustomRulePaths(customRulePath,

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -266,8 +266,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             }
 #endif
             Helper.Instance = new Helper(
-                SessionState.InvokeCommand,
-                this);
+                SessionState.InvokeCommand);
             Helper.Instance.Initialize();
 
             var psVersionTable = this.SessionState.PSVariable.GetValue("PSVersionTable") as Hashtable;

--- a/Engine/Formatter.cs
+++ b/Engine/Formatter.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             ValidateNotNull(settings, "settings");
             ValidateNotNull(cmdlet, "cmdlet");
 
-            Helper.Instance = new Helper(cmdlet.SessionState.InvokeCommand, cmdlet);
+            Helper.Instance = new Helper(cmdlet.SessionState.InvokeCommand);
             Helper.Instance.Initialize();
 
             var ruleOrder = new string[]

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         #region Private members
 
         private readonly CommandInvocationIntrinsics invokeCommand;
-        private readonly ReaderWriterLockSlim commandInfoCacheLock = new ReaderWriterLockSlim();
         private readonly static Version minSupportedPSVersion = new Version(3, 0);
         private Dictionary<string, Dictionary<string, object>> ruleArguments;
         private PSVersionTable psVersionTable;

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -25,11 +25,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
         private CommandInvocationIntrinsics invokeCommand;
         private readonly IOutputWriter outputWriter;
+        private readonly ReaderWriterLockSlim commandInfoCacheLock = new ReaderWriterLockSlim();
         private readonly static Version minSupportedPSVersion = new Version(3, 0);
         private Dictionary<string, Dictionary<string, object>> ruleArguments;
         private PSVersionTable psVersionTable;
         private Dictionary<CommandLookupKey, CommandInfo> commandInfoCache;
-        private ReaderWriterLockSlim commandInfoCacheLock = new ReaderWriterLockSlim();
 
         #endregion
 

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -699,7 +699,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
         private Task<CommandInfo> GetCommandInfoInternal(string cmdName, CommandTypes? commandType)
         {
-            //Task.Factory.StartNew(() =>
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
                 var psCommand = ps.AddCommand("Get-Command")
@@ -711,8 +710,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     psCommand.AddParameter("CommandType", commandType);
                 }
 
-                var commandInfo = psCommand.Invoke<CommandInfo>()
-                         .FirstOrDefault();
+                var commandInfo = psCommand.Invoke<CommandInfo>().FirstOrDefault();
 
                 return Task.FromResult(commandInfo);
             }

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -673,6 +673,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 commandInfoLookupTask.Start();
                 commandInfoLookupTask.Wait();
                 commandInfoCache.TryAdd(commandLookupKey, commandInfoLookupTask.Result);
+                commandInfoLookupItemsInProcess.TryRemove(commandLookupKey, out _);
                 return commandInfoLookupTask.Result;
             }
             else

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -159,8 +159,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             //initialize helper
             Helper.Instance = new Helper(
-                runspace.SessionStateProxy.InvokeCommand,
-                outputWriter);
+                runspace.SessionStateProxy.InvokeCommand);
             Helper.Instance.Initialize();
 
 


### PR DESCRIPTION
## PR Summary

This nearly halves the execution time (measured using PS 5.1 and 6.2). For example when recursively analyzing the `test` folder of the PowerShell repo, the time goes down from 170 seconds to 100 seconds. When analysing the `build.psm1` module of the PowerShell repo (clean, fresh, shell), then the time went down from 11 seconds to 7 seconds.

Background: The bottleneck of PSSA's performance are the `CommandInfo`  lookups (where basically `Get-Command` gets called), not just because they are expensive but even when results are cached, there was was 1 heavy lock (all PSSA rules are executing in parallel threads and access the Singleton `Helper` class) around the 3 following operations:
1. Check if CommandInfo is in Cache
2. If CommandInfo was not cached, execute `Get-Command` to get details. This is the most expensive part
3. Add retrieved CommandInfo to Cache

This PR improves it by:
- Using a `ConcurrentDictionary` for the Cache instead to avoid the heavy lock. This means effectively that step 1 is only under a read lock and step 3 under a write lock.
- Because threads can now proceed to step 2 without being blocked, it can happen that a thread issues the same `Get-Command` request, therefore resulting in unnecessary CPU churn and potentially slowing down execution. To counteract this, step 2 now submits its requests as a `Task` to another ConcurrentDictionary so that one can check if there is already a request for a particular command, get that task and wait for its result.
- The `outputwriter` field on the `Helper` class is not used and therefore removed. Some other members could be made `readonly`

In the future we might enhance it further to
- Go Async, but this requires more work since we need to go up to the top to be able to receive value from it.
- Pre-initialize the cache with all commands via a background task. This would speed it up by a factor of 10 but is currently not possible to do due to https://github.com/PowerShell/PowerShell/issues/8910 because some rules need those additional properties, applying this only to a subset of rules wouldn't lead to a speedup since the slowest rule is the bottleneck of PSSA's execution (because foreach file it waits until each thread for each rule has finished)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.