### PR TITLE
Raise minimum required PS version of PS 6 to 6.1.0 due to 6.0 running out of support now and update Newtonsoft.Json to 11.0.2

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Management.Automation" Version="6.0.2" />
+    <PackageReference Include="System.Management.Automation" Version="6.1.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452' AND '$(Configuration)' == 'PSV3Release' AND '$(Configuration)' != 'PSV4Release'">

--- a/Engine/PSScriptAnalyzer.psm1
+++ b/Engine/PSScriptAnalyzer.psm1
@@ -13,8 +13,8 @@ $binaryModuleRoot = $PSModuleRoot
 
 if (($PSVersionTable.Keys -contains "PSEdition") -and ($PSVersionTable.PSEdition -ne 'Desktop')) {
     $binaryModuleRoot = Join-Path -Path $PSModuleRoot -ChildPath 'coreclr'
-    if ($PSVersionTable.PSVersion -lt [version]'6.0.2') {
-        throw "Minimum supported version of PSScriptAnalyzer for PowerShell Core is 6.0.2 but current version is '$($PSVersionTable.PSVersion)'. Please update PowerShell Core."
+    if ($PSVersionTable.PSVersion -lt [Version]'6.1.0') {
+        throw "Minimum supported version of PSScriptAnalyzer for PowerShell Core is 6.1.0 but current version is '$($PSVersionTable.PSVersion)'. Please update PowerShell Core."
     }
 }
 elseif ($PSVersionTable.PSVersion.Major -eq 5) {

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Microsoft.PowerShell.CrossCompatibility.csproj
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Microsoft.PowerShell.CrossCompatibility.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
 </Project>

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Engine\Engine.csproj" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
## PR Summary

- Fixes #1159 by raising the minimum required PowerShell version of PS6 to be 6.1 (6.0 is running out of support at some point in March 2019).
- Fixes #1058 by raising the version of `Newtonsoft.Json` to `11.0.2`, which is the version used by PS 6.1.0, see [here](https://github.com/PowerShell/PowerShell/blob/v6.1.0/src/System.Management.Automation/System.Management.Automation.csproj#L12) (the version cannot be higher due to the missing assembly redirect feature in .Net Core and PowerShell Core at the moment)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes) Well, sort of is, but by design :-)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.