### PR TITLE
Increase lock granularity for CommandInfo cache

### DIFF
--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     .AddParameter("Name", cmdName)
                     .AddParameter("ErrorAction", "SilentlyContinue");
 
-                if(commandType != null)
+                if (commandType != null)
                 {
                     ps.AddParameter("CommandType", commandType);
                 }

--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             // If alias name is given, we store the entry under that, but search with the command name
             var key = new CommandLookupKey(aliasName ?? commandName, commandTypes);
 
-            // Atomically either use PowerShell to query a command info object, or fetch it from the catch
+            // Atomically either use PowerShell to query a command info object, or fetch it from the cache
             return _commandInfoCache.GetOrAdd(key, new Lazy<CommandInfo>(() => GetCommandInfoInternal(commandName, commandTypes))).Value;
         }
 

--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -1,0 +1,119 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Management.Automation;
+using System.Linq;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
+{
+    /// <summary>
+    /// Provides threadsafe caching around CommandInfo lookups with `Get-Command -Name ...`.
+    /// </summary>
+    internal class CommandInfoCache
+    {
+        private readonly ConcurrentDictionary<CommandLookupKey, Lazy<CommandInfo>> _commandInfoCache;
+
+        private readonly Helper _helperInstance;
+
+        /// <summary>
+        /// Create a fresh command info cache instance.
+        /// </summary>
+        public CommandInfoCache(Helper pssaHelperInstance)
+        {
+            _commandInfoCache = new ConcurrentDictionary<CommandLookupKey, Lazy<CommandInfo>>();
+            _helperInstance = pssaHelperInstance;
+        }
+
+        /// <summary>
+        /// Retrieve a command info object about a command.
+        /// </summary>
+        /// <param name="commandName">Name of the command to get a commandinfo object for.</param>
+        /// <param name="aliasName">The alias of the command to be used in the cache key. If not given, uses the command name.</param>
+        /// <param name="commandTypes">What types of command are needed. If omitted, all types are retrieved.</param>
+        /// <returns></returns>
+        public CommandInfo GetCommandInfo(string commandName, string aliasName = null, CommandTypes? commandTypes = null)
+        {
+            if (string.IsNullOrWhiteSpace(commandName))
+            {
+                return null;
+            }
+
+            // If alias name is given, we store the entry under that, but search with the command name
+            var key = new CommandLookupKey(aliasName ?? commandName, commandTypes);
+
+            // Atomically either use PowerShell to query a command info object, or fetch it from the catch
+            return _commandInfoCache.GetOrAdd(key, new Lazy<CommandInfo>(() => GetCommandInfoInternal(commandName, commandTypes))).Value;
+        }
+
+        /// <summary>
+        /// Retrieve a command info object about a command.
+        /// </summary>
+        /// <param name="commandName">Name of the command to get a commandinfo object for.</param>
+        /// <param name="commandTypes">What types of command are needed. If omitted, all types are retrieved.</param>
+        /// <returns></returns>
+        [Obsolete("Alias lookup is expensive and should not be relied upon for command lookup")]
+        public CommandInfo GetCommandInfoLegacy(string commandOrAliasName, CommandTypes? commandTypes = null)
+        {
+            string commandName = _helperInstance.GetCmdletNameFromAlias(commandOrAliasName);
+
+            return string.IsNullOrEmpty(commandName)
+                ? GetCommandInfo(commandOrAliasName, commandTypes: commandTypes)
+                : GetCommandInfo(commandName, aliasName: commandOrAliasName, commandTypes: commandTypes);
+        }
+
+        /// <summary>
+        /// Get a CommandInfo object of the given command name
+        /// </summary>
+        /// <returns>Returns null if command does not exists</returns>
+        private static CommandInfo GetCommandInfoInternal(string cmdName, CommandTypes? commandType)
+        {
+            using (var ps = System.Management.Automation.PowerShell.Create())
+            {
+                ps.AddCommand("Get-Command")
+                    .AddParameter("Name", cmdName)
+                    .AddParameter("ErrorAction", "SilentlyContinue");
+
+                if(commandType != null)
+                {
+                    ps.AddParameter("CommandType", commandType);
+                }
+
+                return ps.Invoke<CommandInfo>()
+                    .FirstOrDefault();
+            }
+        }
+
+        private struct CommandLookupKey : IEquatable<CommandLookupKey>
+        {
+            private readonly string Name;
+
+            private readonly CommandTypes CommandTypes;
+
+            internal CommandLookupKey(string name, CommandTypes? commandTypes)
+            {
+                Name = name;
+                CommandTypes = commandTypes ?? CommandTypes.All;
+            }
+
+            public bool Equals(CommandLookupKey other)
+            {
+                return CommandTypes == other.CommandTypes
+                    && Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase);
+            }
+
+            public override int GetHashCode()
+            {
+                // Algorithm from https://stackoverflow.com/questions/1646807/quick-and-simple-hash-code-combinations
+                unchecked
+                {
+                    int hash = 17;
+                    hash = hash * 31 + Name.ToUpperInvariant().GetHashCode();
+                    hash = hash * 31 + CommandTypes.GetHashCode();
+                    return hash;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## PR Summary

Introduces a concurrent dictionary allowing different caller threads to get `CommandInfo` objects for different commands without blocking each other.

Alternative implementation of https://github.com/PowerShell/PSScriptAnalyzer/pull/1162.
Closes #1162 

More details:
- Spins the commandinfo cache into its own object, so that the complexity of thread management is managed in one place
- Uses a single concurrency primitive (`ConcurrentDictionary<K, V>.GetOrAdd()`), so very little opportunity to introduce problems later
- Does not use tasks
- Has the same performance characteristics as the task-based implementation

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.