### PR TITLE
Fix regression caused by PR #963 during development of PSSA 1.18.0 whereby PSAvoidUsingPositionalParameters was not taking aliases into account any more

### DIFF
--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -605,18 +605,26 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         }
 
         /// <summary>
-        /// Given a commandast, checks if the command is a Cmdlet.
+        /// Given a commandast, checks if the command is a known cmdlet, function or ExternalScript. 
         /// </summary>
         /// <param name="cmdAst"></param>
         /// <returns></returns>
-        public bool IsCmdlet(CommandAst cmdAst) {
+        public bool IsKnownCmdletFunctionOrExternalScript(CommandAst cmdAst)
+        {
             if (cmdAst == null)
             {
                 return false;
             }
 
             var commandInfo = GetCommandInfo(cmdAst.GetCommandName());
-            return (commandInfo != null && commandInfo.CommandType == System.Management.Automation.CommandTypes.Cmdlet);
+            if (commandInfo == null)
+            {
+                return false;
+            }
+
+            return commandInfo.CommandType == CommandTypes.Cmdlet ||
+                   commandInfo.CommandType == CommandTypes.Alias ||
+                   commandInfo.CommandType == CommandTypes.ExternalScript;
         }
 
         /// <summary>

--- a/Rules/AvoidPositionalParameters.cs
+++ b/Rules/AvoidPositionalParameters.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // MSDN: CommandAst.GetCommandName Method
                 if (cmdAst.GetCommandName() == null) continue;
                 
-                if ((Helper.Instance.IsCmdlet(cmdAst) || declaredFunctionNames.Contains(cmdAst.GetCommandName())) &&
+                if ((Helper.Instance.IsKnownCmdletFunctionOrExternalScript(cmdAst) || declaredFunctionNames.Contains(cmdAst.GetCommandName())) &&
                     (Helper.Instance.PositionalParameterUsed(cmdAst, true)))
                 {
                     PipelineAst parent = cmdAst.Parent as PipelineAst;

--- a/Rules/UseCmdletCorrectly.cs
+++ b/Rules/UseCmdletCorrectly.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return true;
             }
 
-            if (mandParams.Count == 0 || (Helper.Instance.IsCmdlet(cmdAst) && Helper.Instance.PositionalParameterUsed(cmdAst)))
+            if (mandParams.Count == 0 || (Helper.Instance.IsKnownCmdletFunctionOrExternalScript(cmdAst) && Helper.Instance.PositionalParameterUsed(cmdAst)))
             {
                 returnValue = true;
             }

--- a/Tests/Rules/AvoidPositionalParameters.tests.ps1
+++ b/Tests/Rules/AvoidPositionalParameters.tests.ps1
@@ -15,6 +15,13 @@ Describe "AvoidPositionalParameters" {
             $violations[0].Message | Should -Match $violationMessage
         }
 
+        It "Triggers on alias" {
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition "gcm 'abc' 4 4.3"
+            $violations.Count | Should -Be 2
+            $violations.RuleName | Should -Contain $violationName
+            $violations.RuleName | Should -Contain 'PSAvoidUsingCmdletAliases'
+        }
+
     }
 
     Context "When there are no violations" {


### PR DESCRIPTION
## PR Summary

Fix regression caused by PR #963 during development of PSSA 1.18.0 whereby PSAvoidUsingPositionalParameters was not taking alias into account any more.
Also allow `CommandTypes.ExternalScript` types as they can have paramters as well. Since only PowerShell Core ships with ExternalScripts but they have less than 3 parameters, it was hard to write a test for that case.

Thanks for spotting this @jaykul

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.