### PR TITLE
Changing back to non-zipped compatibility profiles

### DIFF
--- a/Rules/CompatibilityRules/CompatibilityRule.cs
+++ b/Rules/CompatibilityRules/CompatibilityRule.cs
@@ -24,14 +24,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         // The name of the directory where compatibility profiles are looked for by default.
         private const string PROFILE_DIR_NAME = "compatibility_profiles";
 
-        // The name of the file to hydrate the compatibility profile assets from.
-        private const string PROFILE_ZIP_NAME = "compatibility_profiles.zip";
-
         // The full path of the directory where compatiblity profiles are looked for by default.
         private static readonly string s_defaultProfileDirPath;
-
-        // The full path of the file where the zipped compatibility profiles are.
-        private static readonly string s_profileZipPath;
 
         // Memoized path to the module root of PSScriptAnalyzer.
         private static readonly Lazy<string> s_moduleRootDirPath;
@@ -45,10 +39,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             s_moduleRootDirPath = new Lazy<string>(() => GetModuleRootDirPath());
             s_defaultProfileDirPath = Path.Combine(s_moduleRootDirPath.Value, PROFILE_DIR_NAME);
-            s_profileZipPath = Path.Combine(s_moduleRootDirPath.Value, PROFILE_ZIP_NAME);
-
-            // On first run, we need to make sure the profile assets have been hydrated from the zip
-            ExpandZipToDirectory(s_profileZipPath, s_defaultProfileDirPath);
         }
 
         private readonly CompatibilityProfileLoader _profileLoader;
@@ -238,18 +228,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             return Path.GetFullPath(nonNormalizedRoot);
         }
 
-        private static void ExpandZipToDirectory(string zipPath, string destinationDirectoryPath)
-        {
-            // Assume that if the directory already exists, there is nothing to do.
-            // Profile unzipping can be forced by deleting the directory.
-            if (Directory.Exists(destinationDirectoryPath))
-            {
-                return;
-            }
-
-            // Note: This method will throw if the directory already exists
-            ZipFile.ExtractToDirectory(zipPath, destinationDirectoryPath, Encoding.UTF8);
-        }
     }
 
     /// <summary>

--- a/build.psm1
+++ b/build.psm1
@@ -118,24 +118,9 @@ function Copy-CompatibilityProfiles
     }
 
     $profileDir = [System.IO.Path]::Combine($PSScriptRoot, 'PSCompatibilityAnalyzer', 'profiles')
-    $destinationDir = [System.IO.Path]::Combine($PSScriptRoot, 'out', 'PSScriptAnalyzer')
-    $destination = Join-Path $destinationDir 'compatibility_profiles.zip'
+    $destinationDir = [System.IO.Path]::Combine($PSScriptRoot, 'out', 'PSScriptAnalyzer', "compatability_profiles")
 
-    if (Test-Path -LiteralPath $destinationDir -PathType Container)
-    {
-        Remove-Item -Force -Recurse $destination -ErrorAction Ignore
-    }
-    else
-    {
-        $null = New-Item -Path $destinationDir -ItemType Directory
-    }
-
-    [System.IO.Compression.ZipFile]::CreateFromDirectory(
-        $profileDir,
-        $destination,
-        [System.IO.Compression.CompressionLevel]::Optimal,
-        <# includeBaseDirectory #> $false,
-        [System.Text.Encoding]::UTF8)
+    Copy-Item -Recurse $profileDir $destinationDir
 }
 
 # build script analyzer (and optionally build everything with -All)

--- a/build.psm1
+++ b/build.psm1
@@ -118,7 +118,7 @@ function Copy-CompatibilityProfiles
     }
 
     $profileDir = [System.IO.Path]::Combine($PSScriptRoot, 'PSCompatibilityAnalyzer', 'profiles')
-    $destinationDir = [System.IO.Path]::Combine($PSScriptRoot, 'out', 'PSScriptAnalyzer', "compatability_profiles")
+    $destinationDir = [System.IO.Path]::Combine($PSScriptRoot, 'out', 'PSScriptAnalyzer', "compatibility_profiles")
 
     Copy-Item -Recurse $profileDir $destinationDir
 }


### PR DESCRIPTION
## PR Summary

We were trying to save space/download time by providing the profiles in a .zip file, but
the size savings aren't there, as the gallery stores modules as .nupkg files.
The .nupkg with the zip file was bigger than just distributing the .json files.
Also, there was a serious issue that if you installed into the public location as administrator and then ran as a regular user, a catastrophic failure in analyzer occurred.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.