### PR TITLE
Fix formatting regression in 1.18.0 whereby single-line pipeline reduces indentation level incorrectly

### DIFF
--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -220,15 +220,18 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // Check if the current token matches the end of a PipelineAst
                 var matchingPipeLineAstEnd = pipelineAsts.FirstOrDefault(pipelineAst =>
                         PositionIsEqual(pipelineAst.Extent.EndScriptPosition, token.Extent.EndScriptPosition)) as PipelineAst;
+
                 if (matchingPipeLineAstEnd == null)
                 {
                     break;
                 }
-                var pipelineSpansOnlyOneLine = matchingPipeLineAstEnd.Extent.StartLineNumber == matchingPipeLineAstEnd.Extent.EndLineNumber;
+
+                bool pipelineSpansOnlyOneLine = matchingPipeLineAstEnd.Extent.StartLineNumber == matchingPipeLineAstEnd.Extent.EndLineNumber;
                 if (pipelineSpansOnlyOneLine)
                 {
                     break;
                 }
+
                 if (pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationForFirstPipeline)
                 {
                     indentationLevel = ClipNegative(indentationLevel - 1);

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -220,16 +220,22 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // Check if the current token matches the end of a PipelineAst
                 var matchingPipeLineAstEnd = pipelineAsts.FirstOrDefault(pipelineAst =>
                         PositionIsEqual(pipelineAst.Extent.EndScriptPosition, token.Extent.EndScriptPosition)) as PipelineAst;
-                if (matchingPipeLineAstEnd != null)
+                if (matchingPipeLineAstEnd == null)
                 {
-                    if (pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationForFirstPipeline)
-                    {
-                        indentationLevel = ClipNegative(indentationLevel - 1);
-                    }
-                    else if (pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationAfterEveryPipeline)
-                    {
-                        indentationLevel = ClipNegative(indentationLevel - (matchingPipeLineAstEnd.PipelineElements.Count - 1));
-                    }
+                    break;
+                }
+                var pipelineSpansOnlyOneLine = matchingPipeLineAstEnd.Extent.StartLineNumber == matchingPipeLineAstEnd.Extent.EndLineNumber;
+                if (pipelineSpansOnlyOneLine)
+                {
+                    break;
+                }
+                if (pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationForFirstPipeline)
+                {
+                    indentationLevel = ClipNegative(indentationLevel - 1);
+                }
+                else if (pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationAfterEveryPipeline)
+                {
+                    indentationLevel = ClipNegative(indentationLevel - (matchingPipeLineAstEnd.PipelineElements.Count - 1));
                 }
             }
 

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -223,13 +223,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 if (matchingPipeLineAstEnd == null)
                 {
-                    break;
+                    continue;
                 }
 
                 bool pipelineSpansOnlyOneLine = matchingPipeLineAstEnd.Extent.StartLineNumber == matchingPipeLineAstEnd.Extent.EndLineNumber;
                 if (pipelineSpansOnlyOneLine)
                 {
-                    break;
+                    continue;
                 }
 
                 if (pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationForFirstPipeline)

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -174,6 +174,23 @@ baz
             Test-CorrectionExtentFromContent @params
         }
 
+        It "Should preserve script when using PipelineIndentation <PipelineIndentation>" -TestCases @(
+                @{ PipelineIndentation = 'IncreaseIndentationForFirstPipeline' }
+                @{ PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline' }
+                @{ PipelineIndentation = 'NoIndentation' }
+                ) {
+            param ($PipelineIndentation)
+            $idempotentScriptDefinition = @'
+function hello {
+    if ($true) {
+        "hello" | Out-Host
+    }
+}
+'@
+            $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+            Invoke-Formatter -ScriptDefinition $idempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
+        }
+
         It "Should indent pipelines correctly using NoIndentation option" {
             $def = @'
 foo |


### PR DESCRIPTION

## PR Summary

Fixes #1187 by excluding single-line pipelines to avoid reduce indentation level incorrectly. This case showed up only when there is already some indentation.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.