### PR TITLE
Fix compatibility profile query API so that aliases referring to other modules appear

### DIFF
--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/ModuleData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/ModuleData.cs
@@ -81,7 +81,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Query
                 return null;
             }
 
-            var aliasTable = new Dictionary<string, IReadOnlyList<CommandData>>();
+            var aliasTable = new Dictionary<string, IReadOnlyList<CommandData>>(StringComparer.OrdinalIgnoreCase);
             foreach (KeyValuePair<string, string> alias in aliases)
             {
                 if (_parent.Aliases.TryGetValue(alias.Key, out IReadOnlyList<CommandData> aliasedCommands))

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/ModuleData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/ModuleData.cs
@@ -13,9 +13,13 @@ namespace Microsoft.PowerShell.CrossCompatibility.Query
     /// </summary>
     public class ModuleData
     {
+        private readonly RuntimeData _parent;
+
         private readonly Data.ModuleData _moduleData;
 
-        private readonly Lazy<Tuple<IReadOnlyDictionary<string, FunctionData>, IReadOnlyDictionary<string, CmdletData>, IReadOnlyDictionary<string, CommandData>>> _commands;
+        private readonly Lazy<Tuple<IReadOnlyDictionary<string, FunctionData>, IReadOnlyDictionary<string, CmdletData>>> _lazyCommands;
+
+        private readonly Lazy<IReadOnlyDictionary<string, IReadOnlyList<CommandData>>> _lazyAliases;
 
         /// <summary>
         /// Create a query object around a module data object.
@@ -23,14 +27,16 @@ namespace Microsoft.PowerShell.CrossCompatibility.Query
         /// <param name="name">The name of the module.</param>
         /// <param name="version">The version of the module.</param>
         /// <param name="moduleData">The module data object.</param>
-        public ModuleData(string name, Version version, Data.ModuleData moduleData)
+        public ModuleData(string name, Version version, RuntimeData parent, Data.ModuleData moduleData)
         {
             _moduleData = moduleData;
+            _parent = parent;
 
             Name = name;
             Version = version;
 
-            _commands = new Lazy<Tuple<IReadOnlyDictionary<string, FunctionData>, IReadOnlyDictionary<string, CmdletData>, IReadOnlyDictionary<string, CommandData>>>(() => CreateCommandTables(moduleData.Functions, moduleData.Cmdlets, moduleData.Aliases));
+            _lazyCommands = new Lazy<Tuple<IReadOnlyDictionary<string, FunctionData>, IReadOnlyDictionary<string, CmdletData>>>(() => CreateCommandTables(moduleData.Functions, moduleData.Cmdlets));
+            _lazyAliases = new Lazy<IReadOnlyDictionary<string, IReadOnlyList<CommandData>>>(() => CreateAliasTable(_moduleData.Aliases));
         }
 
         /// <summary>
@@ -51,12 +57,12 @@ namespace Microsoft.PowerShell.CrossCompatibility.Query
         /// <summary>
         /// Functions exported by the module.
         /// </summary>
-        public IReadOnlyDictionary<string, FunctionData> Functions => _commands.Value.Item1;
+        public IReadOnlyDictionary<string, FunctionData> Functions => _lazyCommands.Value.Item1;
 
         /// <summary>
         /// Cmdlets exported by the module.
         /// </summary>
-        public IReadOnlyDictionary<string, CmdletData> Cmdlets => _commands.Value.Item2;
+        public IReadOnlyDictionary<string, CmdletData> Cmdlets => _lazyCommands.Value.Item2;
 
         /// <summary>
         /// Variables exported by the module.
@@ -66,16 +72,33 @@ namespace Microsoft.PowerShell.CrossCompatibility.Query
         /// <summary>
         /// Aliases exported by the module.
         /// </summary>
-        public IReadOnlyDictionary<string, CommandData> Aliases => _commands.Value.Item3;
+        public IReadOnlyDictionary<string, IReadOnlyList<CommandData>> Aliases => _lazyAliases.Value;
 
-        private static Tuple<IReadOnlyDictionary<string, FunctionData>, IReadOnlyDictionary<string, CmdletData>, IReadOnlyDictionary<string, CommandData>> CreateCommandTables(
+        private IReadOnlyDictionary<string, IReadOnlyList<CommandData>> CreateAliasTable(IReadOnlyDictionary<string, string> aliases)
+        {
+            if (aliases == null || aliases.Count == 0)
+            {
+                return null;
+            }
+
+            var aliasTable = new Dictionary<string, IReadOnlyList<CommandData>>();
+            foreach (KeyValuePair<string, string> alias in aliases)
+            {
+                if (_parent.Aliases.TryGetValue(alias.Key, out IReadOnlyList<CommandData> aliasedCommands))
+                {
+                    aliasTable[alias.Key] = aliasedCommands;
+                }
+            }
+
+            return aliasTable;
+        }
+
+        private static Tuple<IReadOnlyDictionary<string, FunctionData>, IReadOnlyDictionary<string, CmdletData>> CreateCommandTables(
             IReadOnlyDictionary<string, Data.FunctionData> functions,
-            IReadOnlyDictionary<string, Data.CmdletData> cmdlets,
-            IReadOnlyDictionary<string, string> aliases)
+            IReadOnlyDictionary<string, Data.CmdletData> cmdlets)
         {
             Dictionary<string, FunctionData> funcDict = null;
             Dictionary<string, CmdletData> cmdletDict = null;
-            Dictionary<string, CommandData> aliasDict = null;
 
             if (functions != null)
             {
@@ -95,29 +118,9 @@ namespace Microsoft.PowerShell.CrossCompatibility.Query
                 }
             }
 
-            if (aliases != null)
-            {
-                aliasDict = new Dictionary<string, CommandData>(aliases.Count, StringComparer.OrdinalIgnoreCase);
-                foreach (KeyValuePair<string, string> alias in aliases)
-                {
-                    if (funcDict != null && funcDict.TryGetValue(alias.Value, out FunctionData function))
-                    {
-                        aliasDict[alias.Key] = function;
-                        continue;
-                    }
-
-                    if (cmdletDict != null && cmdletDict.TryGetValue(alias.Value, out CmdletData cmdlet))
-                    {
-                        aliasDict[alias.Key] = cmdlet;
-                        continue;
-                    }
-                }
-            }
-
-            return new Tuple<IReadOnlyDictionary<string, FunctionData>, IReadOnlyDictionary<string, CmdletData>, IReadOnlyDictionary<string, CommandData>>(
+            return new Tuple<IReadOnlyDictionary<string, FunctionData>, IReadOnlyDictionary<string, CmdletData>>(
                 funcDict,
-                cmdletDict,
-                aliasDict);
+                cmdletDict);
         }
     }
 }

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/RuntimeData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/RuntimeData.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Query
             _modules = new Lazy<IReadOnlyDictionary<string, IReadOnlyDictionary<Version, ModuleData>>>(() => CreateModuleTable(runtimeData.Modules));
             _nonAliasCommands = new Lazy<IReadOnlyDictionary<string, IReadOnlyList<CommandData>>>(() => CreateNonAliasCommandLookupTable(Modules));
             _aliases = new Lazy<IReadOnlyDictionary<string, IReadOnlyList<CommandData>>>(() => CreateAliasLookupTable(runtimeData.Modules, NonAliasCommands));
-            _commands = new Lazy<IReadOnlyDictionary<string, IReadOnlyList<CommandData>>>(() => new DualLookupTable<string, IReadOnlyList<CommandData>>(Aliases, NonAliasCommands));
+            _commands = new Lazy<IReadOnlyDictionary<string, IReadOnlyList<CommandData>>>(() => new DualLookupTable<string, IReadOnlyList<CommandData>>(NonAliasCommands, Aliases));
             _nativeCommands = new Lazy<NativeCommandLookupTable>(() => NativeCommandLookupTable.Create(runtimeData.NativeCommands));
         }
 

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/RuntimeData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/RuntimeData.cs
@@ -133,6 +133,11 @@ namespace Microsoft.PowerShell.CrossCompatibility.Query
             {
                 foreach (KeyValuePair<Version, Data.ModuleData> moduleVersion in module.Value)
                 {
+                    if (moduleVersion.Value.Aliases == null)
+                    {
+                        continue;
+                    }
+
                     foreach (KeyValuePair<string, string> alias in moduleVersion.Value.Aliases)
                     {
                         if (commands.TryGetValue(alias.Value, out IReadOnlyList<CommandData> aliasedCommands))

--- a/Tests/Rules/UseCompatibleCommands.Tests.ps1
+++ b/Tests/Rules/UseCompatibleCommands.Tests.ps1
@@ -36,6 +36,8 @@ $script:CompatibilityTestCases = @(
     @{ Target = $script:Srv2012_3_profile; Script = 'Get-FileHash $pshome\powershell.exe | Format-List'; Commands = @("Get-FileHash"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
     @{ Target = $script:Srv2012_3_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
     @{ Target = $script:Srv2012_3_profile; Script = 'Save-Help -Module $m -DestinationPath "C:\SavedHelp"'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+    @{ Target = $script:Srv2012_3_profile; Script = 'gci .'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+    @{ Target = $script:Srv2012_3_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
 
     @{ Target = $script:Srv2012r2_4_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
     @{ Target = $script:Srv2012r2_4_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
@@ -51,11 +53,16 @@ $script:CompatibilityTestCases = @(
     @{ Target = $script:Srv2012r2_4_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
     @{ Target = $script:Srv2012r2_4_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
     @{ Target = $script:Srv2012r2_4_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+    @{ Target = $script:Srv2012r2_4_profile; Script = 'gci .'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
+    @{ Target = $script:Srv2012r2_4_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
 
     @{ Target = $script:Srv2019_5_profile; Script = "Remove-Alias gcm"; Commands = @("Remove-Alias"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
     @{ Target = $script:Srv2019_5_profile; Script = "Get-Uptime"; Commands = @("Get-Uptime"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
     @{ Target = $script:Srv2019_5_profile; Script = "Remove-Service 'MyService'"; Commands = @("Remove-Service"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
     @{ Target = $script:Srv2019_5_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+    @{ Target = $script:Srv2019_5_profile; Script = 'gci .'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+    @{ Target = $script:Srv2019_5_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+    @{ Target = $script:Srv2019_5_profile; Script = 'fhx $filePath'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
 
     @{ Target = $script:Srv2019_6_1_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "6.1"; OS = "Windows"; ProblemCount = 1 }
     @{ Target = $script:Srv2019_6_1_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.1"; OS = "Windows"; ProblemCount = 1 }
@@ -88,13 +95,17 @@ $script:CompatibilityTestCases = @(
     @{ Target = $script:Srv2019_6_1_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.1"; OS = "Windows"; ProblemCount = 1 }
     @{ Target = $script:Srv2019_6_1_profile; Script = 'curl $uri'; Commands = @("curl"); Version = "6.1"; OS = "Windows"; ProblemCount = 1 }
     @{ Target = $script:Srv2019_6_1_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+    @{ Target = $script:Srv2019_6_1_profile; Script = 'gci .'; Commands = @(); Version = "6.1"; OS = "Windows"; ProblemCount = 0 }
+    @{ Target = $script:Srv2016_6_1_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.1"; OS = "Windows"; ProblemCount = 0 }
 
     @{ Target = $script:Ubuntu1804_6_1_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "6.1"; OS = "Linux"; ProblemCount = 1 }
     @{ Target = $script:Ubuntu1804_6_1_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "6.1"; OS = "Linux"; ProblemCount = 1 }
     @{ Target = $script:Ubuntu1804_6_1_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "6.1"; OS = "Linux"; ProblemCount = 1 }
     @{ Target = $script:Ubuntu1804_6_1_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "6.1"; OS = "Linux"; ProblemCount = 1 }
     @{ Target = $script:Ubuntu1804_6_1_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "6.1"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_6_1_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+    @{ Target = $script:Ubuntu1804_6_1_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "6.1"; OS = "Linux"; ProblemCount = 0 }
+    @{ Target = $script:Ubuntu1804_6_1_profile; Script = 'gci .'; Commands = @(); Version = "6.1"; OS = "Linux"; ProblemCount = 0 }
+    @{ Target = $script:Ubuntu1804_6_1_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.1"; OS = "Linux"; ProblemCount = 0 }
 )
 
 $script:ParameterCompatibilityTestCases = @(


### PR DESCRIPTION
## PR Summary

Previously because of bad assumptions I made, an alias in a module that aliases a command outside that module would just be omitted from that module's query API.

I originally "fixed" this by building a table of aliases at profiling time and putting the aliases back into the modules of the commands they referenced. Not only was that wrong, but it also made profiling much slower.

Functionally, rules will see no differences and there are no breaking changes in the API, BUT this fixes the alias thing and should speed up profiling significantly (the latter being something I need).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.