### PR TITLE
Prevent .NET members with names differing only by case from crashing the compatibility profiler

### DIFF
--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Data/Types/AssemblyData.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Data/Types/AssemblyData.cs
@@ -24,7 +24,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data.Types
         /// and then type name.
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public JsonCaseInsensitiveStringDictionary<JsonCaseInsensitiveStringDictionary<TypeData>> Types { get; set; }
+        public JsonDictionary<string, JsonDictionary<string, TypeData>> Types { get; set; }
 
         /// <summary>
         /// Create a deep clone of the assembly data object.
@@ -34,7 +34,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data.Types
             return new AssemblyData()
             {
                 AssemblyName = (AssemblyNameData)AssemblyName.Clone(),
-                Types = (JsonCaseInsensitiveStringDictionary<JsonCaseInsensitiveStringDictionary<TypeData>>)Types?.Clone()
+                Types = (JsonDictionary<string, JsonDictionary<string, TypeData>>)Types?.Clone()
             };
         }
     }

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Data/Types/AvailableTypeData.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Data/Types/AvailableTypeData.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data.Types
         /// keyed by simple assembly name.
         /// </summary>
         [DataMember]
-        public JsonCaseInsensitiveStringDictionary<AssemblyData> Assemblies { get; set; }
+        public JsonDictionary<string, AssemblyData> Assemblies { get; set; }
 
         /// <summary>
         /// Create a deep clone of the available type data object.

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Data/Types/AvailableTypeData.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Data/Types/AvailableTypeData.cs
@@ -36,7 +36,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data.Types
             return new AvailableTypeData()
             {
                 TypeAccelerators = (JsonCaseInsensitiveStringDictionary<TypeAcceleratorData>)TypeAccelerators.Clone(),
-                Assemblies = (JsonCaseInsensitiveStringDictionary<AssemblyData>)Assemblies.Clone()
+                Assemblies = (JsonDictionary<string, AssemblyData>)Assemblies.Clone()
             };
         }
     }

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Data/Types/MemberData.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Data/Types/MemberData.cs
@@ -26,13 +26,13 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data.Types
         /// Fields on the type, keyed by field name.
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public JsonCaseInsensitiveStringDictionary<FieldData> Fields { get; set; }
+        public JsonDictionary<string, FieldData> Fields { get; set; }
 
         /// <summary>
         /// Properties on this type, keyed by property name.
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public JsonCaseInsensitiveStringDictionary<PropertyData> Properties { get; set; }
+        public JsonDictionary<string, PropertyData> Properties { get; set; }
 
         /// <summary>
         /// Indexers on the type.
@@ -44,19 +44,19 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data.Types
         /// Methods on the type, keyed by method name.
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public JsonCaseInsensitiveStringDictionary<MethodData> Methods { get; set; }
+        public JsonDictionary<string, MethodData> Methods { get; set; }
 
         /// <summary>
         /// Events on the type, keyed by event name.
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public JsonCaseInsensitiveStringDictionary<EventData> Events { get; set; }
+        public JsonDictionary<string, EventData> Events { get; set; }
 
         /// <summary>
         /// Types nested within the type, keyed by type name.
         /// </summary>
         [DataMember(EmitDefaultValue = false)]
-        public JsonCaseInsensitiveStringDictionary<TypeData> NestedTypes { get; set; }
+        public JsonDictionary<string, TypeData> NestedTypes { get; set; }
 
         /// <summary>
         /// Create a deep clone of the member data object.
@@ -66,12 +66,12 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data.Types
             return new MemberData()
             {
                 Constructors = Constructors?.Select(c => (string[])c.Clone()).ToArray(),
-                Events = (JsonCaseInsensitiveStringDictionary<EventData>)Events?.Clone(),
-                Fields = (JsonCaseInsensitiveStringDictionary<FieldData>)Fields?.Clone(),
+                Events = (JsonDictionary<string, EventData>)Events?.Clone(),
+                Fields = (JsonDictionary<string, FieldData>)Fields?.Clone(),
                 Indexers = Indexers?.Select(i => (IndexerData)i.Clone()).ToArray(),
-                Methods = (JsonCaseInsensitiveStringDictionary<MethodData>)Methods?.Clone(),
-                NestedTypes = (JsonCaseInsensitiveStringDictionary<TypeData>)NestedTypes?.Clone(),
-                Properties = (JsonCaseInsensitiveStringDictionary<PropertyData>)Properties?.Clone(),
+                Methods = (JsonDictionary<string, MethodData>)Methods?.Clone(),
+                NestedTypes = (JsonDictionary<string, TypeData>)NestedTypes?.Clone(),
+                Properties = (JsonDictionary<string, PropertyData>)Properties?.Clone(),
             };
         }
     }

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Query/Types/AssemblyData.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Query/Types/AssemblyData.cs
@@ -38,10 +38,10 @@ namespace Microsoft.PowerShell.CrossCompatibility.Query
         /// </summary>
         public IReadOnlyDictionary<string, IReadOnlyDictionary<string, TypeData>> Types => _types?.Value;
 
-        private static IReadOnlyDictionary<string, IReadOnlyDictionary<string, TypeData>> CreateTypeDictionary(IReadOnlyDictionary<string, JsonCaseInsensitiveStringDictionary<Data.Types.TypeData>> typeData)
+        private static IReadOnlyDictionary<string, IReadOnlyDictionary<string, TypeData>> CreateTypeDictionary(IReadOnlyDictionary<string, JsonDictionary<string, Data.Types.TypeData>> typeData)
         {
             var namespaceDict = new Dictionary<string, IReadOnlyDictionary<string, TypeData>>(typeData.Count, StringComparer.OrdinalIgnoreCase);
-            foreach (KeyValuePair<string, JsonCaseInsensitiveStringDictionary<Data.Types.TypeData>> nspace in typeData)
+            foreach (KeyValuePair<string, JsonDictionary<string, Data.Types.TypeData>> nspace in typeData)
             {
                 var typeDict = new Dictionary<string, TypeData>(nspace.Value.Count, StringComparer.OrdinalIgnoreCase);
                 foreach (KeyValuePair<string, Data.Types.TypeData> type in nspace.Value)

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/ProfileCombination.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/ProfileCombination.cs
@@ -122,7 +122,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
 
         private static object Union(AvailableTypeData thisTypes, AvailableTypeData thatTypes)
         {
-            thisTypes.Assemblies = StringDictionaryUnion(thisTypes.Assemblies, thatTypes.Assemblies, Union);
+            thisTypes.Assemblies = DictionaryUnion(thisTypes.Assemblies, thatTypes.Assemblies, Union);
             thisTypes.TypeAccelerators = StringDictionaryUnion(thisTypes.TypeAccelerators, thatTypes.TypeAccelerators);
 
             return thisTypes;
@@ -136,10 +136,10 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
             {
                 if (thisAssembly.Types == null)
                 {
-                    thisAssembly.Types = new JsonCaseInsensitiveStringDictionary<JsonCaseInsensitiveStringDictionary<TypeData>>();
+                    thisAssembly.Types = new JsonDictionary<string, JsonDictionary<string, TypeData>>();
                 }
 
-                foreach (KeyValuePair<string, JsonCaseInsensitiveStringDictionary<TypeData>> nspace in thatAssembly.Types)
+                foreach (KeyValuePair<string, JsonDictionary<string, TypeData>> nspace in thatAssembly.Types)
                 {
                     if (!thisAssembly.Types.ContainsKey(nspace.Key))
                     {
@@ -147,7 +147,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
                         continue;
                     }
 
-                    thisAssembly.Types[nspace.Key] = StringDictionaryUnion(thisAssembly.Types[nspace.Key], nspace.Value, Union);
+                    thisAssembly.Types[nspace.Key] = DictionaryUnion(thisAssembly.Types[nspace.Key], nspace.Value, Union);
                 }
             }
 

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/ProfileCombination.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/ProfileCombination.cs
@@ -192,11 +192,11 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
 
             thisMembers.Constructors = ParameterUnion(thisMembers.Constructors, thatMembers.Constructors);
 
-            thisMembers.Events = StringDictionaryUnion(thisMembers.Events, thatMembers.Events);
-            thisMembers.Fields = StringDictionaryUnion(thisMembers.Fields, thatMembers.Fields);
-            thisMembers.Methods = StringDictionaryUnion(thisMembers.Methods, thatMembers.Methods, Union);
-            thisMembers.NestedTypes = StringDictionaryUnion(thisMembers.NestedTypes, thatMembers.NestedTypes, Union);
-            thisMembers.Properties = StringDictionaryUnion(thisMembers.Properties, thatMembers.Properties, Union);
+            thisMembers.Events = DictionaryUnion(thisMembers.Events, thatMembers.Events);
+            thisMembers.Fields = DictionaryUnion(thisMembers.Fields, thatMembers.Fields);
+            thisMembers.Methods = DictionaryUnion(thisMembers.Methods, thatMembers.Methods, Union);
+            thisMembers.NestedTypes = DictionaryUnion(thisMembers.NestedTypes, thatMembers.NestedTypes, Union);
+            thisMembers.Properties = DictionaryUnion(thisMembers.Properties, thatMembers.Properties, Union);
 
             return thisMembers;
         }

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/TypeDataConversion.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/TypeDataConversion.cs
@@ -271,12 +271,12 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
             return new MemberData()
             {
                 Constructors = constructors.Any() ? constructors.Select(c => AssembleConstructor(c)).ToArray() : null,
-                Events = events.Any() ? new JsonCaseInsensitiveStringDictionary<EventData>(events.ToDictionary(e => e.Name, e => AssembleEvent(e))) : null,
-                Fields = fields.Any() ? new JsonCaseInsensitiveStringDictionary<FieldData>(fields.ToDictionary(f => f.Name, f => AssembleField(f))) : null,
+                Events = events.Any() ? new JsonDictionary<string, EventData>(events.ToDictionary(e => e.Name, e => AssembleEvent(e))) : null,
+                Fields = fields.Any() ? new JsonDictionary<string, FieldData>(fields.ToDictionary(f => f.Name, f => AssembleField(f))) : null,
                 Indexers = indexers.Any() ? indexers.Select(i => AssembleIndexer(i)).ToArray() : null,
-                Methods = methods.Any() ? new JsonCaseInsensitiveStringDictionary<MethodData>(methods.ToDictionary(m => m.Key, m => AssembleMethod(m.Value))) : null,
-                NestedTypes = nestedTypes.Any() ? new JsonCaseInsensitiveStringDictionary<TypeData>(nestedTypes.ToDictionary(t => t.Name, t => AssembleType(t))) : null,
-                Properties = properties.Any() ? new JsonCaseInsensitiveStringDictionary<PropertyData>(properties.ToDictionary(p => p.Name, p => AssembleProperty(p))) : null
+                Methods = methods.Any() ? new JsonDictionary<string, MethodData>(methods.ToDictionary(m => m.Key, m => AssembleMethod(m.Value))) : null,
+                NestedTypes = nestedTypes.Any() ? new JsonDictionary<string, TypeData>(nestedTypes.ToDictionary(t => t.Name, t => AssembleType(t))) : null,
+                Properties = properties.Any() ? new JsonDictionary<string, PropertyData>(properties.ToDictionary(p => p.Name, p => AssembleProperty(p))) : null
             };
         }
 

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/TypeDataConversion.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/TypeDataConversion.cs
@@ -50,7 +50,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
                 typeAcceleratorDict.Add(typeAccelerator.Key, ta);
             }
 
-            var asms = new JsonCaseInsensitiveStringDictionary<AssemblyData>();
+            var asms = new JsonDictionary<string, AssemblyData>();
             foreach (Assembly asm in assemblies)
             {
                 // Don't want to include this module or assembly in the output
@@ -96,10 +96,10 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
             };
 
             Type[] types = asm.GetTypes();
-            JsonCaseInsensitiveStringDictionary<JsonCaseInsensitiveStringDictionary<TypeData>> namespacedTypes = null;
+            JsonDictionary<string, JsonDictionary<string, TypeData>> namespacedTypes = null;
             if (types.Any())
             {
-                namespacedTypes = new JsonCaseInsensitiveStringDictionary<JsonCaseInsensitiveStringDictionary<TypeData>>();
+                namespacedTypes = new JsonDictionary<string, JsonDictionary<string, TypeData>>();
                 foreach (Type type in asm.GetTypes())
                 {
                     if (!type.IsPublic)
@@ -110,14 +110,14 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
                     // Some types don't have a namespace, but we still want to file them
                     string typeNamespace = type.Namespace ?? "";
 
-                    if (!namespacedTypes.ContainsKey(typeNamespace))
+                    if (!namespacedTypes.TryGetValue(typeNamespace, out JsonDictionary<string, TypeData> typeDictionary))
                     {
-                        namespacedTypes.Add(typeNamespace, new JsonCaseInsensitiveStringDictionary<TypeData>());
+                        typeDictionary = new JsonDictionary<string, TypeData>();
                     }
 
                     TypeData typeData = AssembleType(type);
 
-                    namespacedTypes[typeNamespace][type.Name] = typeData;
+                    typeDictionary[type.Name] = typeData;
                 }
             }
 
@@ -271,12 +271,12 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
             return new MemberData()
             {
                 Constructors = constructors.Any() ? constructors.Select(c => AssembleConstructor(c)).ToArray() : null,
-                Events = events.Any() ? new JsonCaseInsensitiveStringDictionary<EventData>(events.ToDictionary(e => e.Name, e => AssembleEvent(e), StringComparer.OrdinalIgnoreCase)) : null,
-                Fields = fields.Any() ? new JsonCaseInsensitiveStringDictionary<FieldData>(fields.ToDictionary(f => f.Name, f => AssembleField(f), StringComparer.OrdinalIgnoreCase)) : null,
+                Events = events.Any() ? new JsonCaseInsensitiveStringDictionary<EventData>(events.ToDictionary(e => e.Name, e => AssembleEvent(e))) : null,
+                Fields = fields.Any() ? new JsonCaseInsensitiveStringDictionary<FieldData>(fields.ToDictionary(f => f.Name, f => AssembleField(f))) : null,
                 Indexers = indexers.Any() ? indexers.Select(i => AssembleIndexer(i)).ToArray() : null,
-                Methods = methods.Any() ? new JsonCaseInsensitiveStringDictionary<MethodData>(methods.ToDictionary(m => m.Key, m => AssembleMethod(m.Value), StringComparer.OrdinalIgnoreCase)) : null,
-                NestedTypes = nestedTypes.Any() ? new JsonCaseInsensitiveStringDictionary<TypeData>(nestedTypes.ToDictionary(t => t.Name, t => AssembleType(t), StringComparer.OrdinalIgnoreCase)) : null,
-                Properties = properties.Any() ? new JsonCaseInsensitiveStringDictionary<PropertyData>(properties.ToDictionary(p => p.Name, p => AssembleProperty(p), StringComparer.OrdinalIgnoreCase)) : null
+                Methods = methods.Any() ? new JsonCaseInsensitiveStringDictionary<MethodData>(methods.ToDictionary(m => m.Key, m => AssembleMethod(m.Value))) : null,
+                NestedTypes = nestedTypes.Any() ? new JsonCaseInsensitiveStringDictionary<TypeData>(nestedTypes.ToDictionary(t => t.Name, t => AssembleType(t))) : null,
+                Properties = properties.Any() ? new JsonCaseInsensitiveStringDictionary<PropertyData>(properties.ToDictionary(p => p.Name, p => AssembleProperty(p))) : null
             };
         }
 

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/TypeDataConversion.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/TypeDataConversion.cs
@@ -62,7 +62,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
                 try
                 {
                     KeyValuePair<string, AssemblyData> asmData = AssembleAssembly(asm);
-                    asms.Add(asmData.Key, asmData.Value);
+                    asms[asmData.Key] = asmData.Value;
                 }
                 catch (ReflectionTypeLoadException e)
                 {

--- a/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/TypeDataConversion.cs
+++ b/PSCompatibilityAnalyzer/Microsoft.PowerShell.CrossCompatibility/Utility/TypeDataConversion.cs
@@ -61,6 +61,15 @@ namespace Microsoft.PowerShell.CrossCompatibility.Utility
 
                 try
                 {
+                    // First check whether an assembly with this name already exists
+                    // Only replace it if the current one is newer
+                    AssemblyName asmName = asm.GetName();
+                    if (asms.TryGetValue(asmName.Name, out AssemblyData currentAssemblyData)
+                        && asmName.Version < currentAssemblyData.AssemblyName.Version)
+                    {
+                        continue;
+                    }
+
                     KeyValuePair<string, AssemblyData> asmData = AssembleAssembly(asm);
                     asms[asmData.Key] = asmData.Value;
                 }

--- a/PSCompatibilityAnalyzer/Tests/QueryApi.Tests.ps1
+++ b/PSCompatibilityAnalyzer/Tests/QueryApi.Tests.ps1
@@ -21,7 +21,16 @@ namespace PSScriptAnalyzerTests
 
         $typeQueryObject = New-Object 'Microsoft.PowerShell.CrossCompatibility.Query.TypeData' ('QueryApiTestObject', $typeData)
 
+        $typeData.Instance.Properties.Count | Should -Be 2
+
+        $typeData.Instance.Properties.ContainsKey('JobId') | Should -BeTrue
+        $typeData.Instance.Properties.ContainsKey('JOBID') | Should -BeTrue
+        $typeData.Instance.Properties.ContainsKey('jobid') | Should -Not -BeTrue
+
         $typeQueryObject.Instance.Properties.Count | Should -Be 1
-        $typeQueryObject.Instance.Properties.Keys | Should -Contain 'jobid'
+
+        $typeQueryObject.Instance.Properties.ContainsKey('JobId') | Should -BeTrue
+        $typeQueryObject.Instance.Properties.ContainsKey('JobID') | Should -BeTrue
+        $typeQueryObject.Instance.Properties.ContainsKey('jobid') | Should -BeTrue
     }
 }

--- a/PSCompatibilityAnalyzer/Tests/QueryApi.Tests.ps1
+++ b/PSCompatibilityAnalyzer/Tests/QueryApi.Tests.ps1
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe ".NET type with members with names differing only by name" {
+    BeforeAll {
+        Add-Type -TypeDefinition @'
+namespace PSScriptAnalyzerTests
+{
+    public class QueryApiTestObject
+    {
+        public string JobId { get; set; }
+
+        public object JOBID { get; set; }
+    }
+}
+'@
+    }
+
+    It "Does not crash the query API" {
+        $typeData = [Microsoft.PowerShell.CrossCompatibility.Utility.TypeDataConversion]::AssembleType([PSScriptAnalyzerTests.QueryApiTestObject])
+
+        $typeQueryObject = New-Object 'Microsoft.PowerShell.CrossCompatibility.Query.TypeData' ('QueryApiTestObject', $typeData)
+
+        $typeData.Instance.Properties.Count | Should -Be 1
+        $typeData.Instance.Properties.Keys | Should -Contain 'jobid'
+    }
+}

--- a/PSCompatibilityAnalyzer/Tests/QueryApi.Tests.ps1
+++ b/PSCompatibilityAnalyzer/Tests/QueryApi.Tests.ps1
@@ -21,7 +21,7 @@ namespace PSScriptAnalyzerTests
 
         $typeQueryObject = New-Object 'Microsoft.PowerShell.CrossCompatibility.Query.TypeData' ('QueryApiTestObject', $typeData)
 
-        $typeData.Instance.Properties.Count | Should -Be 1
-        $typeData.Instance.Properties.Keys | Should -Contain 'jobid'
+        $typeQueryObject.Instance.Properties.Count | Should -Be 1
+        $typeQueryObject.Instance.Properties.Keys | Should -Contain 'jobid'
     }
 }


### PR DESCRIPTION
## PR Summary

.NET allows type/member names that are case-insensitively equal on the same object (of course), but PowerShell can't differentiate these.

This changes the collector so that it builds a case-sensitive dictionary of types/members for JSON serialisation, rather than crashing when we hit this edge case (for the record, I hit [Microsoft.Azure.Management.HDInsight.Job.Models.Profile](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.management.hdinsight.job.models.profile?view=azure-dotnet) having both `JobID` and `JobId` as properties...).

The query API still handles this without any problems: it just exposes the last property (it overwrites the previous one in the slot if there are duplicates). This is essentially consistent with PowerShell, which exposes the properties by reflection and also clobbers them in an undefined order.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.