### PR TITLE
Change module root find function in CompatibilityRule

### DIFF
--- a/Rules/CompatibilityRules/CompatibilityRule.cs
+++ b/Rules/CompatibilityRules/CompatibilityRule.cs
@@ -237,7 +237,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             throw new FileNotFoundException("Unable to find the PSScriptAnalyzer module root");
         }
-
     }
 
     /// <summary>

--- a/Rules/CompatibilityRules/CompatibilityRule.cs
+++ b/Rules/CompatibilityRules/CompatibilityRule.cs
@@ -235,6 +235,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return dirUpOneLevel;
             }
 
+            // Unable to find the root of the module where it should be, so we give up
             throw new FileNotFoundException("Unable to find the PSScriptAnalyzer module root");
         }
     }


### PR DESCRIPTION
## PR Summary

After @bergmeister's comments in @JamesWTruher's PR, I've made some small changes to the function that finds the PSScriptAnalyzer module root, the main one being that it will explicitly throw a `FileNotFoundException` when it gives up.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.