### PR TITLE
Change logic for copying profiles into the 'install' directory

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -119,8 +119,11 @@ function Copy-CompatibilityProfiles
 
     $profileDir = [System.IO.Path]::Combine($PSScriptRoot, 'PSCompatibilityAnalyzer', 'profiles')
     $destinationDir = [System.IO.Path]::Combine($PSScriptRoot, 'out', 'PSScriptAnalyzer', "compatibility_profiles")
+    if ( -not (Test-Path $destinationDir) ) {
+        $null = New-Item -Type Directory $destinationDir
+    }
 
-    Copy-Item -Recurse $profileDir $destinationDir
+    Copy-Item -Force $profileDir/* $destinationDir
 }
 
 # build script analyzer (and optionally build everything with -All)


### PR DESCRIPTION

## PR Summary

Multiple runs would result in an incorrect layout of the compatibility profiles
The problem did not exist in our CI/Release system as those are clean environments. This problem only exists if you run build multiple times.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.