### PR TITLE
Add suppression of warning for MS policy

### DIFF
--- a/Tests/Rules/AvoidConvertToSecureStringWithPlainText.ps1
+++ b/Tests/Rules/AvoidConvertToSecureStringWithPlainText.ps1
@@ -1,3 +1,4 @@
+#[SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Test/NotASecret.")]
 $supersecure = convertto-securestring "sdfdsfd" -asplaintext -force
 
 New-Object System.Management.Automation.PSCredential -ArgumentList "username", (ConvertTo-SecureString "really secure" -AsPlainText -Force)


### PR DESCRIPTION
Because we are using a direct invocation of ConvertTo-SecureString it triggers a warning by MS tools that secrets are not allowed to be checked in to our repository. This suppresses this warning.

## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.