### PR TITLE
UseCorrectCasing: Fix wildcard lookups for command lookup and do not append .exe for applications on Windows

### DIFF
--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -69,6 +69,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// <returns>Returns null if command does not exists</returns>
         private static CommandInfo GetCommandInfoInternal(string cmdName, CommandTypes? commandType)
         {
+            if (cmdName == "?")
+            {
+                // 'Get-Command ?' would return % due to PowerShell interpreting is a single-character-wildcard search and not just the ? alias.
+                // For more details see https://github.com/PowerShell/PowerShell/issues/9308
+                // Using the escape character makes PowerShell interpret ? as a literal string.
+                cmdName = "`?";
+            }
+
             using (var ps = System.Management.Automation.PowerShell.Create())
             {
                 ps.AddCommand("Get-Command")

--- a/Rules/UseCorrectCasing.cs
+++ b/Rules/UseCorrectCasing.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 var fullyqualifiedName = $"{commandInfo.ModuleName}\\{shortName}";
                 var isFullyQualified = commandName.Equals(fullyqualifiedName, StringComparison.OrdinalIgnoreCase);
                 var correctlyCasedCommandName = isFullyQualified ? fullyqualifiedName : shortName;
-                if (commandInfo.CommandType == CommandTypes.Application && isWindows && !Path.HasExtension(commandName))
+                if (isWindows && commandInfo.CommandType == CommandTypes.Application && !Path.HasExtension(commandName))
                 {
                     // For binaries that could exist on both Windows and Linux like e.g. git we do not want to expand
                     // git to git.exe to keep the script cross-platform compliant

--- a/Rules/UseCorrectCasing.cs
+++ b/Rules/UseCorrectCasing.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Management.Automation.Language;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+using System.Management.Automation;
 #if !CORECLR
 using System.ComponentModel.Composition;
 #endif
@@ -52,6 +53,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 var fullyqualifiedName = $"{commandInfo.ModuleName}\\{shortName}";
                 var isFullyQualified = commandName.Equals(fullyqualifiedName, StringComparison.OrdinalIgnoreCase);
                 var correctlyCasedCommandName = isFullyQualified ? fullyqualifiedName : shortName;
+                // For binaries that could exist on both Windows and Linux like e.g. git we do not want to expand
+                // git to git.exe to keep the script cross-platform compliant
+                if (commandInfo.CommandType == CommandTypes.Application && correctlyCasedCommandName.EndsWith(".exe"))
+                {
+                    correctlyCasedCommandName = correctlyCasedCommandName.Substring(0, correctlyCasedCommandName.Length - 4);
+                }
 
                 if (!commandName.Equals(correctlyCasedCommandName, StringComparison.Ordinal))
                 {

--- a/Rules/UseCorrectCasing.cs
+++ b/Rules/UseCorrectCasing.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             IEnumerable<Ast> commandAsts = ast.FindAll(testAst => testAst is CommandAst, true);
 
+            bool isWindows = true;
+#if CORECLR
+            isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#endif
+
             // Iterates all CommandAsts and check the command name.
             foreach (CommandAst commandAst in commandAsts)
             {
@@ -55,11 +60,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 var fullyqualifiedName = $"{commandInfo.ModuleName}\\{shortName}";
                 var isFullyQualified = commandName.Equals(fullyqualifiedName, StringComparison.OrdinalIgnoreCase);
                 var correctlyCasedCommandName = isFullyQualified ? fullyqualifiedName : shortName;
-                var isWindows = true;
-#if CORECLR
-                isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-#endif
-                if (commandInfo.CommandType == CommandTypes.Application && isWindows)
+                if (commandInfo.CommandType == CommandTypes.Application && isWindows && !Path.HasExtension(commandName))
                 {
                     // For binaries that could exist on both Windows and Linux like e.g. git we do not want to expand
                     // git to git.exe to keep the script cross-platform compliant

--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -20,6 +20,10 @@ Describe "UseCorrectCasing" {
         Invoke-Formatter 'Cmd' | Should -Be 'cmd'
     }
 
+    It "Preserves extension of applications on Windows" -Skip:($IsLinux -or $IsMacOS) {
+        Invoke-Formatter 'Cmd.exe' | Should -Be 'cmd.exe'
+    }
+
     It "corrects case of script function" {
         function Invoke-DummyFunction
         {

--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -11,6 +11,15 @@ Describe "UseCorrectCasing" {
         Invoke-Formatter '"$(get-childitem)"' | Should -Be '"$(get-childitem)"'
     }
 
+    It "Corrects alias correctly" {
+        Invoke-Formatter 'Gci' | Should -Be 'gci'
+        Invoke-Formatter '?' | Should -Be '?'
+    }
+
+    It "Corrects applications on Windows to not end in .exe" -Skip:($IsLinux -or $IsMacOS) {
+        Invoke-Formatter 'Cmd' | Should -Be 'cmd'
+    }
+
     It "corrects case of script function" {
         function Invoke-DummyFunction
         {

--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -18,10 +18,17 @@ Describe "UseCorrectCasing" {
 
     It "Corrects applications on Windows to not end in .exe" -Skip:($IsLinux -or $IsMacOS) {
         Invoke-Formatter 'Cmd' | Should -Be 'cmd'
+        Invoke-Formatter 'Cmd' | Should -Be 'cmd'
+        Invoke-Formatter 'MORE' | Should -Be 'more'
+        Invoke-Formatter 'WinRM' | Should -Be 'winrm'
+        Invoke-Formatter 'CertMgr' | Should -Be 'certmgr'
     }
 
     It "Preserves extension of applications on Windows" -Skip:($IsLinux -or $IsMacOS) {
         Invoke-Formatter 'Cmd.exe' | Should -Be 'cmd.exe'
+        Invoke-Formatter 'MORE.com' | Should -Be 'more.com'
+        Invoke-Formatter 'WinRM.cmd' | Should -Be 'winrm.cmd'
+        Invoke-Formatter 'CertMgr.MSC' | Should -Be 'certmgr.msc'
     }
 
     It "corrects case of script function" {


### PR DESCRIPTION
## PR Summary

UseCorrectCasing: Fix command lookups using wildcards, e.g. ? would've wrongly returned ForEach-Object and do not append .exe to binaries on Windows

- Fixes #1209
- Fixes some symptoms of https://github.com/PowerShell/vscode-powershell/issues/1842 (but the generic alias expansion)
- Fixes https://github.com/PowerShell/vscode-powershell/issues/1849

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.