### PR TITLE
Fix UseCompatibleSyntax class error message

### DIFF
--- a/Rules/CompatibilityRules/UseCompatibleSyntax.cs
+++ b/Rules/CompatibilityRules/UseCompatibleSyntax.cs
@@ -347,6 +347,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 string message = string.Format(
                     CultureInfo.CurrentCulture,
+                    Strings.UseCompatibleSyntaxError,
                     "type definition",
                     "class MyClass { ... } | enum MyEnum { ... }",
                     "3,4");


### PR DESCRIPTION
## PR Summary

A bug in the UseCompatibleSyntax rule means error messages come out looking very bad. This fixes that.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.