### PR TITLE
Do not use alias name as key for command info cache to fix the problem where UseCorrectCasing corrects aliases

### DIFF
--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -40,9 +40,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 return null;
             }
 
-            // If alias name is given, we store the entry under that, but search with the command name
-            var key = new CommandLookupKey(aliasName ?? commandName, commandTypes);
-
+            var key = new CommandLookupKey(commandName, commandTypes);
             // Atomically either use PowerShell to query a command info object, or fetch it from the cache
             return _commandInfoCache.GetOrAdd(key, new Lazy<CommandInfo>(() => GetCommandInfoInternal(commandName, commandTypes))).Value;
         }

--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -30,10 +30,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// Retrieve a command info object about a command.
         /// </summary>
         /// <param name="commandName">Name of the command to get a commandinfo object for.</param>
-        /// <param name="aliasName">The alias of the command to be used in the cache key. If not given, uses the command name.</param>
         /// <param name="commandTypes">What types of command are needed. If omitted, all types are retrieved.</param>
         /// <returns></returns>
-        public CommandInfo GetCommandInfo(string commandName, string aliasName = null, CommandTypes? commandTypes = null)
+        public CommandInfo GetCommandInfo(string commandName, CommandTypes? commandTypes = null)
         {
             if (string.IsNullOrWhiteSpace(commandName))
             {
@@ -58,7 +57,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             return string.IsNullOrEmpty(commandName)
                 ? GetCommandInfo(commandOrAliasName, commandTypes: commandTypes)
-                : GetCommandInfo(commandName, aliasName: commandOrAliasName, commandTypes: commandTypes);
+                : GetCommandInfo(commandName, commandTypes: commandTypes);
         }
 
         /// <summary>

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -402,7 +402,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             IEnumerable<Ast> cmdAsts = ast.FindAll(item => item is CommandAst
                 && exportFunctionsCmdlet.Contains((item as CommandAst).GetCommandName(), StringComparer.OrdinalIgnoreCase), true);
 
-            CommandInfo exportMM = Helper.Instance.GetCommandInfoLegacy("export-modulemember", CommandTypes.Cmdlet);
+            CommandInfo exportMM = Helper.Instance.GetCommandInfo("export-modulemember", CommandTypes.Cmdlet);
 
             // switch parameters
             IEnumerable<ParameterMetadata> switchParams = (exportMM != null) ? exportMM.Parameters.Values.Where<ParameterMetadata>(pm => pm.SwitchParameter) : Enumerable.Empty<ParameterMetadata>();
@@ -659,31 +659,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
 
             return moreThanTwoPositional ? argumentsWithoutProcedingParameters > 2 : argumentsWithoutProcedingParameters > 0;
-        }
-
-
-        /// <summary>
-        /// Get a CommandInfo object of the given command name
-        /// </summary>
-        /// <returns>Returns null if command does not exists</returns>
-        private CommandInfo GetCommandInfoInternal(string cmdName, CommandTypes? commandType)
-        {
-            using (var ps = System.Management.Automation.PowerShell.Create())
-            {
-                var psCommand = ps.AddCommand("Get-Command")
-                    .AddParameter("Name", cmdName)
-                    .AddParameter("ErrorAction", "SilentlyContinue");
-
-                if(commandType!=null)
-                {
-                    psCommand.AddParameter("CommandType", commandType);
-                }
-
-                var commandInfo = psCommand.Invoke<CommandInfo>()
-                         .FirstOrDefault();
-
-                return commandInfo;
-            }
         }
 
         /// <summary>


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/PowerShell/vscode-powershell/issues/1842
Because aliases were used as the key for the cache, once those entities are created, it caused the UseCorrectCasing rule to correct aliases, somehow those cache entries could only be populated when and lead to this behaviour when being used via the vscode extension so I assume it must the some of the commands being issued at startup that cause other rules to populate this entry
Writing a test for this turned out to be hard as only when being used via the PowerShell vscode extension, alias key entries were populated in PSSA's command info cache first.
The intention is to have this PR fix the root cause and another PR to a bit of a cleanup.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.