### PR TITLE
Make IncreaseIndentationForFirstPipeline the true default option for PipelineIndentationStyle option

### DIFF
--- a/Engine/Settings/CodeFormatting.psd1
+++ b/Engine/Settings/CodeFormatting.psd1
@@ -26,7 +26,7 @@
         PSUseConsistentIndentation = @{
             Enable          = $true
             Kind            = 'space'
-            PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
             IndentationSize = 4
         }
 

--- a/Engine/Settings/CodeFormattingAllman.psd1
+++ b/Engine/Settings/CodeFormattingAllman.psd1
@@ -26,7 +26,7 @@
         PSUseConsistentIndentation = @{
             Enable          = $true
             Kind            = 'space'
-            PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
             IndentationSize = 4
         }
 

--- a/Engine/Settings/CodeFormattingOTBS.psd1
+++ b/Engine/Settings/CodeFormattingOTBS.psd1
@@ -26,7 +26,7 @@
         PSUseConsistentIndentation = @{
             Enable          = $true
             Kind            = 'space'
-            PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
             IndentationSize = 4
         }
 

--- a/Engine/Settings/CodeFormattingStroustrup.psd1
+++ b/Engine/Settings/CodeFormattingStroustrup.psd1
@@ -27,7 +27,7 @@
         PSUseConsistentIndentation = @{
             Enable          = $true
             Kind            = 'space'
-            PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
             IndentationSize = 4
         }
 

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 if (String.IsNullOrWhiteSpace(value) ||
                     !Enum.TryParse(value, true, out pipelineIndentationStyle))
                 {
-                    pipelineIndentationStyle = PipelineIndentationStyle.IncreaseIndentationAfterEveryPipeline;
+                    pipelineIndentationStyle = PipelineIndentationStyle.IncreaseIndentationForFirstPipeline;
                 }
             }
         }
@@ -96,7 +96,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         // TODO make this configurable
         private IndentationKind indentationKind = IndentationKind.Space;
 
-        private PipelineIndentationStyle pipelineIndentationStyle = PipelineIndentationStyle.IncreaseIndentationAfterEveryPipeline;
+        private PipelineIndentationStyle pipelineIndentationStyle = PipelineIndentationStyle.IncreaseIndentationForFirstPipeline;
 
         /// <summary>
         /// Analyzes the given ast to find violations.


### PR DESCRIPTION
## PR Summary

The documentation and the setting default for the `PipelineIndentationStyle` option is `IncreaseIndentationForFirstPipeline` but the defaults used in the setting files and in some places in code were actually inconsistent. This PR makes them consistent.
The default was determined based on [this](https://twitter.com/CBergmeister/status/1062843776341864448) Twitter poll.
![image](https://user-images.githubusercontent.com/9250262/56165600-4ad53f80-5fcb-11e9-8610-7bda755b491a.png)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.