### PR TITLE
Enable suppression of custom rules when used together with -IncludeDefaultRules

### DIFF
--- a/Engine/Generic/RuleSuppression.cs
+++ b/Engine/Generic/RuleSuppression.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
     /// </summary>
     public class RuleSuppression
     {
-        private string _ruleName;
 
         /// <summary>
         /// The start offset of the rule suppression attribute (not where it starts to apply)
@@ -49,28 +48,32 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// </summary>
         public string RuleName
         {
-            get
-            {
-                return _ruleName;
-            }
+            get;
+            set;
+        }
 
-            set
-            {
-                _ruleName = value;
+            //get
+            //{
+            //    return _ruleName;
+            //}
 
-                if (!String.IsNullOrWhiteSpace(_ruleName)
-                    && (ScriptAnalyzer.Instance.ScriptRules != null
-                        && ScriptAnalyzer.Instance.ScriptRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
-                    && (ScriptAnalyzer.Instance.TokenRules != null
-                        && ScriptAnalyzer.Instance.TokenRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
-                    && (ScriptAnalyzer.Instance.ExternalRules != null
-                        && ScriptAnalyzer.Instance.ExternalRules.Count(item => String.Equals(item.GetFullName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
-                    && (ScriptAnalyzer.Instance.DSCResourceRules != null
-                        && ScriptAnalyzer.Instance.DSCResourceRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0))
-                {
-                    Error = String.Format(Strings.RuleSuppressionRuleNameNotFound, _ruleName);
-                }
-            }
+            //set
+            //{
+            //    _ruleName = value;
+
+            //    //if (!String.IsNullOrWhiteSpace(_ruleName)
+            //    //    && (ScriptAnalyzer.Instance.ScriptRules != null
+            //    //        && ScriptAnalyzer.Instance.ScriptRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
+            //    //    && (ScriptAnalyzer.Instance.TokenRules != null
+            //    //        && ScriptAnalyzer.Instance.TokenRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
+            //    //    //&& (ScriptAnalyzer.Instance.ExternalRules != null
+            //    //    //    && ScriptAnalyzer.Instance.ExternalRules.Count(item => String.Equals(item.GetFullName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
+            //    //    && (ScriptAnalyzer.Instance.DSCResourceRules != null
+            //    //        && ScriptAnalyzer.Instance.DSCResourceRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0))
+            //    //{
+            //    //    Error = String.Format(Strings.RuleSuppressionRuleNameNotFound, _ruleName);
+            //    //}
+            //}
         }
 
         /// <summary>

--- a/Engine/Generic/RuleSuppression.cs
+++ b/Engine/Generic/RuleSuppression.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             //    //    Error = String.Format(Strings.RuleSuppressionRuleNameNotFound, _ruleName);
             //    //}
             //}
-        }
+        //}
 
         /// <summary>
         /// ID of the violation instance

--- a/Engine/Generic/RuleSuppression.cs
+++ b/Engine/Generic/RuleSuppression.cs
@@ -52,30 +52,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             set;
         }
 
-            //get
-            //{
-            //    return _ruleName;
-            //}
-
-            //set
-            //{
-            //    _ruleName = value;
-
-            //    //if (!String.IsNullOrWhiteSpace(_ruleName)
-            //    //    && (ScriptAnalyzer.Instance.ScriptRules != null
-            //    //        && ScriptAnalyzer.Instance.ScriptRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
-            //    //    && (ScriptAnalyzer.Instance.TokenRules != null
-            //    //        && ScriptAnalyzer.Instance.TokenRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
-            //    //    //&& (ScriptAnalyzer.Instance.ExternalRules != null
-            //    //    //    && ScriptAnalyzer.Instance.ExternalRules.Count(item => String.Equals(item.GetFullName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0)
-            //    //    && (ScriptAnalyzer.Instance.DSCResourceRules != null
-            //    //        && ScriptAnalyzer.Instance.DSCResourceRules.Count(item => String.Equals(item.GetName(), _ruleName, StringComparison.OrdinalIgnoreCase)) == 0))
-            //    //{
-            //    //    Error = String.Format(Strings.RuleSuppressionRuleNameNotFound, _ruleName);
-            //    //}
-            //}
-        //}
-
         /// <summary>
         /// ID of the violation instance
         /// </summary>

--- a/Engine/Strings.Designer.cs
+++ b/Engine/Strings.Designer.cs
@@ -439,15 +439,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Rule {0} cannot be found..
-        /// </summary>
-        internal static string RuleSuppressionRuleNameNotFound {
-            get {
-                return ResourceManager.GetString("RuleSuppressionRuleNameNotFound", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Found {0}. Will use it to provide settings for this invocation..
         /// </summary>
         internal static string SettingsAutoDiscovered {

--- a/Engine/Strings.resx
+++ b/Engine/Strings.resx
@@ -165,9 +165,6 @@
   <data name="RuleSuppressionErrorFormat" xml:space="preserve">
     <value>Suppression Message Attribute error at line {0} in {1} : {2}</value>
   </data>
-  <data name="RuleSuppressionRuleNameNotFound" xml:space="preserve">
-    <value>Rule {0} cannot be found.</value>
-  </data>
   <data name="StringConstantArgumentsSuppressionAttributeError" xml:space="preserve">
     <value>All the arguments of the Suppress Message Attribute should be string constants.</value>
   </data>

--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -192,15 +192,8 @@ Describe "Test importing correct customized rules" {
 				)
 
 				if ($ast.GetCommandName() -eq 'Invoke-Something') {
-					$correctionExtent = New-Object 'Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.CorrectionExtent' $ast.Extent.StartLineNumber,$ast.Extent.EndLineNumber,$ast.Extent.StartColumnNumber,$ast.Extent.EndColumnNumber,'correction','description'
-
-					# rule name has to match function name (1.18)
-					[Microsoft.Windows.Powershell.ScriptAnalyzer.Generic.DiagnosticRecord]@{
-						RuleName               = REPLACE_WITH_RULE_NAME_EXPRESSION
-						Message                = 'Message about usage of Invoke-Something'
-						Extent                 = $ast.Extent
-						"Severity"             = "Warning"
-					}
+					New-Object -Typename 'Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticRecord' `
+								-ArgumentList 'This is help',$ast.Extent,REPLACE_WITH_RULE_NAME_EXPRESSION,Warning,$ast.Extent.File,$null,$null
 				}
 			}
 '@


### PR DESCRIPTION
## PR Summary

Fixes #1237
cc @Jaykul 
In PSSA 1.17.1 and 1.18.1 I went through 3 test cases of using the following expressions as a custom rule name returned in the `DiagnosticRecord` of a custom rule:
- `$MyInvocation.MyCommand.Name` (the name of the function name that returns the `DiagnosticRecord`)
- `'$MyInvocation.InvocationName` (same as above but fully qualified, i.e. module name pre-pended to it
- A custom string

All those scenarios are possible in both versions but when the `-IncludeDefaultRules` switch was used, then in PSSA 1.17.1 the 2nd test case and in PSSA 1.18.0 the 1st and 3rd test case were not working because PSSA throws a red-herring error. This PR makes PSSA not throw an error any more and therefore enabling all 3 scenarios.
The check that used to throw the error tried to check the rule name in the suppression against the available rule names. Unfortunately the conditional logic itself is a bit broken (this is why the errors only surfaced when the `-IncludeDefaultRules` was used due to properties like `ScriptAnalyzer.Instance.ScriptRules` not being null any more). The problem with the check is that only at runtime will we know the returned `RuleName` of the `DiagnosticRecord`. People are encouraged to use expressions that mirror the function name that returns the `DiagnosticRecord` so that there is a match with what `Get-ScriptAnalyzer` returns but the reality is that people can return what they want and actively want to do so, see [here](https://github.com/PowerShell/PSScriptAnalyzer/issues/1140#issuecomment-488251888). Therefore the check is removed as we cannot determine at this point in time if there is a match or not.
Comparing the functionality with C#: the compiler similarly cannot throw an error either when a suppression attribute does not match an existing code style rule violation, therefore we are removing a feature that was never meant to be complete.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.