### PR TITLE
Change build script to install into a versioned directory

### DIFF
--- a/Tests/Engine/ModuleDependencyHandler.tests.ps1
+++ b/Tests/Engine/ModuleDependencyHandler.tests.ps1
@@ -8,7 +8,7 @@ Describe "Resolve DSC Resource Dependency" {
             $skipTest = $true
             return
         }
-        $SavedPSModulePath = $env:PSModulePath
+        $savedPSModulePath = $env:PSModulePath
         $violationFileName = 'MissingDSCResource.ps1'
         $violationFilePath = Join-Path $directory $violationFileName
         $testRootDirectory = Split-Path -Parent $directory
@@ -27,7 +27,7 @@ Describe "Resolve DSC Resource Dependency" {
     }
     AfterAll {
         if ( $skipTest ) { return }
-        $env:PSModulePath = $SavedPSModulePath
+        $env:PSModulePath = $savedPSModulePath
     }
 
     Context "Module handler class" {
@@ -58,7 +58,7 @@ Describe "Resolve DSC Resource Dependency" {
             $expectedPssaAppDataPath = Join-Path $depHandler.LocalAppDataPath "PSScriptAnalyzer"
             $depHandler.PSSAAppDataPath | Should -Be $expectedPssaAppDataPath
 
-            $expectedPSModulePath = $oldPSModulePath + [System.IO.Path]::PathSeparator + $depHandler.TempModulePath
+            $expectedPSModulePath = $savedPSModulePath + [System.IO.Path]::PathSeparator + $depHandler.TempModulePath
             $env:PSModulePath | Should -Be $expectedPSModulePath
 
             $depHandler.Dispose()
@@ -178,7 +178,7 @@ Describe "Resolve DSC Resource Dependency" {
             # Save the current environment variables
             $oldLocalAppDataPath = $env:LOCALAPPDATA
             $oldTempPath = $env:TEMP
-            $oldPSModulePath = $env:PSModulePath
+            $savedPSModulePath = $env:PSModulePath
 
             # set the environment variables
             $tempPath = Join-Path $oldTempPath ([guid]::NewGUID()).ToString()
@@ -208,7 +208,7 @@ Describe "Resolve DSC Resource Dependency" {
 
         AfterAll {
             if ( $skipTest ) { return }
-            $env:PSModulePath = $oldPSModulePath
+            $env:PSModulePath = $savedPSModulePath
         }
 
         It "has a single parse error" -skip:$skipTest {
@@ -222,7 +222,7 @@ Describe "Resolve DSC Resource Dependency" {
 
         It "Keeps PSModulePath unchanged before and after invocation" -skip:$skipTest {
             $dr = Invoke-ScriptAnalyzer -Path $violationFilePath -ErrorVariable parseErrors -ErrorAction SilentlyContinue
-            $env:PSModulePath | Should -Be $oldPSModulePath
+            $env:PSModulePath | Should -Be $savedPSModulePath
         }
 
         if (!$skipTest)

--- a/Tests/Engine/ModuleDependencyHandler.tests.ps1
+++ b/Tests/Engine/ModuleDependencyHandler.tests.ps1
@@ -35,7 +35,11 @@ Describe "Resolve DSC Resource Dependency" {
             if ( $skipTest ) { return }
             $moduleHandlerType = [Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.ModuleDependencyHandler]
             $oldEnvVars = Get-Item Env:\* | Sort-Object -Property Key
-            $oldPSModulePath = $env:PSModulePath
+            $savedPSModulePath = $env:PSModulePath
+        }
+        AfterAll {
+            if ( $skipTest ) { return }
+            $env:PSModulePath = $savedPSModulePath
         }
         It "Sets defaults correctly" -skip:$skipTest {
             $rsp = [runspacefactory]::CreateRunspace()
@@ -184,8 +188,8 @@ Describe "Resolve DSC Resource Dependency" {
             $env:TEMP = $newTempPath
 
             # create the temporary directories
-            New-Item -Type Directory -Path $newLocalAppDataPath
-            New-Item -Type Directory -Path $newTempPath
+            New-Item -Type Directory -Path $newLocalAppDataPath -force
+            New-Item -Type Directory -Path $newTempPath -force
 
             # create and dispose module dependency handler object
             # to setup the temporary module
@@ -203,6 +207,7 @@ Describe "Resolve DSC Resource Dependency" {
         }
 
         AfterAll {
+            if ( $skipTest ) { return }
             $env:PSModulePath = $oldPSModulePath
         }
 

--- a/Tests/Rules/DscExamplesPresent.tests.ps1
+++ b/Tests/Rules/DscExamplesPresent.tests.ps1
@@ -23,8 +23,8 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
     }
 
     Context "When examples present" {
-        New-Item -Path $examplesPath -ItemType Directory
-        New-Item -Path "$examplesPath\FileResource_Example.psm1" -ItemType File
+        New-Item -Path $examplesPath -ItemType Directory -force
+        New-Item -Path "$examplesPath\FileResource_Example.psm1" -ItemType File -force
 
         $noViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $classResourcePath | Where-Object {$_.RuleName -eq $ruleName}
 
@@ -57,8 +57,8 @@ Describe "DscExamplesPresent rule in regular (non-class) based resource" {
     }
 
     Context "When examples present" {
-        New-Item -Path $examplesPath -ItemType Directory
-        New-Item -Path "$examplesPath\MSFT_WaitForAll_Example.psm1" -ItemType File
+        New-Item -Path $examplesPath -ItemType Directory -force
+        New-Item -Path "$examplesPath\MSFT_WaitForAll_Example.psm1" -ItemType File -force
 
         $noViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $resourcePath | Where-Object {$_.RuleName -eq $ruleName}
 

--- a/Tests/Rules/DscTestsPresent.tests.ps1
+++ b/Tests/Rules/DscTestsPresent.tests.ps1
@@ -23,8 +23,8 @@ if ($PSVersionTable.PSVersion -ge [Version]'5.0.0') {
     }
 
     Context "When tests present" {
-        New-Item -Path $testsPath -ItemType Directory
-        New-Item -Path "$testsPath\FileResource_Test.psm1" -ItemType File
+        New-Item -Path $testsPath -ItemType Directory -force
+        New-Item -Path "$testsPath\FileResource_Test.psm1" -ItemType File -force
 
         $noViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $classResourcePath | Where-Object {$_.RuleName -eq $ruleName}
 
@@ -57,8 +57,8 @@ Describe "DscTestsPresent rule in regular (non-class) based resource" {
     }
 
     Context "When tests present" {
-        New-Item -Path $testsPath -ItemType Directory
-        New-Item -Path "$testsPath\MSFT_WaitForAll_Test.psm1" -ItemType File
+        New-Item -Path $testsPath -ItemType Directory -force
+        New-Item -Path "$testsPath\MSFT_WaitForAll_Test.psm1" -ItemType File -force
 
         $noViolations = Invoke-ScriptAnalyzer -ErrorAction SilentlyContinue $resourcePath | Where-Object {$_.RuleName -eq $ruleName}
 

--- a/Tests/Rules/UseIdenticalMandatoryParametersForDSC.tests.ps1
+++ b/Tests/Rules/UseIdenticalMandatoryParametersForDSC.tests.ps1
@@ -63,7 +63,7 @@ Describe "UseIdenticalMandatoryParametersForDSC" {
 }
 "@
             # and under it a directory called dscresources\something
-            New-Item -ItemType Directory -Path $noParentClassDir
+            New-Item -ItemType Directory -Path $noParentClassDir -force
             $noparentClassFilepath = Join-Path -Path $noParentClassDir -ChildPath 'ClassWithNoParent.psm1'
             $noparentClassMofFilepath = Join-Path -Path $noParentClassDir -ChildPath 'ClassWithNoParent.schema.mof'
 
@@ -102,7 +102,7 @@ class ClassWithNoParent
 }
 "@
             # and under it a directory called dscresources\something
-            New-Item -ItemType Directory -Path $noParentClassDir
+            New-Item -ItemType Directory -Path $noParentClassDir -force
             $noparentClassFilepath = Join-Path -Path $noParentClassDir -ChildPath 'MSFT_ClassWithNoParent.psm1'
             $noparentClassMofFilepath = Join-Path -Path $noParentClassDir -ChildPath 'MSFT_ClassWithNoParent.schema.mof'
 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -56,14 +56,9 @@ function Invoke-AppveyorTest {
     $majorVersion = ([System.Version]$analyzerVersion).Major
     $psMajorVersion = $PSVersionTable.PSVersion.Major
 
-    Get-ChildItem -rec -file -name "${CheckoutPath}/out" | Write-Verbose -Verbose
-    Write-Verbose -verbose "version is $majorVersion"
     if ( $psMajorVersion -lt 5 ) {
         $versionModuleDir = "${CheckoutPath}\out\PSScriptAnalyzer\${analyzerVersion}"
         $renameTarget = "${CheckoutPath}\out\PSScriptAnalyzer\PSScriptAnalyzer"
-        Write-Verbose -Verbose "versionModuleDir: ${versionModuleDir}"
-        Write-Verbose -Verbose "renameTarget: ${renameTarget}"
-        Write-Verbose -Verbose "target exists: $(Test-Path $renameTarget)"
         Rename-Item "${versionModuleDir}" "${renameTarget}"
         $moduleDir = "${CheckoutPath}\out\PSScriptAnalyzer"
     }
@@ -73,7 +68,6 @@ function Invoke-AppveyorTest {
 
     $env:PSModulePath = "${moduleDir}","${env:PSModulePath}" -join [System.IO.Path]::PathSeparator
     Write-Verbose -Verbose "module path: ${env:PSModulePath}"
-
 
     # Set up testing assets
     $testResultsPath = Join-Path ${CheckoutPath} TestResults.xml

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -54,11 +54,17 @@ function Invoke-AppveyorTest {
     # set up env:PSModulePath to the build location, don't copy it to the "normal place"
     $analyzerVersion = ([xml](Get-Content "${CheckoutPath}\Engine\Engine.csproj")).SelectSingleNode(".//VersionPrefix")."#text".Trim()
     $majorVersion = ([System.Version]$analyzerVersion).Major
+    $psMajorVersion = $PSVersionTable.PSVersion.Major
 
     Get-ChildItem -rec -file -name "${CheckoutPath}/out" | Write-Verbose -Verbose
-    if ( $majorVersion -lt 5 ) {
+    Write-Verbose -verbose "version is $majorVersion"
+    if ( $psMajorVersion -lt 5 ) {
         $versionModuleDir = "${CheckoutPath}\out\PSScriptAnalyzer\${analyzerVersion}"
-        Rename-Item "${versionModuleDir}" "${CheckoutPath}\out\PSScriptAnalyzer\PSScriptAnalyzer"
+        $renameTarget = "${CheckoutPath}\out\PSScriptAnalyzer\PSScriptAnalyzer"
+        Write-Verbose -Verbose "versionModuleDir: ${versionModuleDir}"
+        Write-Verbose -Verbose "renameTarget: ${renameTarget}"
+        Write-Verbose -Verbose "target exists: $(Test-Path $renameTarget)"
+        Rename-Item "${versionModuleDir}" "${renameTarget}"
         $moduleDir = "${CheckoutPath}\out\PSScriptAnalyzer"
     }
     else{

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -53,8 +53,10 @@ function Invoke-AppveyorTest {
 
     # set up env:PSModulePath to the build location, don't copy it to the "normal place"
     $analyzerVersion = ([xml](Get-Content "${CheckoutPath}\Engine\Engine.csproj")).SelectSingleNode(".//VersionPrefix")."#text".Trim()
+    $majorVersion = ([System.Version]$analyzerVersion).Major
 
-    if ( $analyzerVersion -lt 5 ) {
+    Get-ChildItem -rec -file -name "${CheckoutPath}/out" | Write-Verbose -Verbose
+    if ( $majorVersion -lt 5 ) {
         $versionModuleDir = "${CheckoutPath}\out\PSScriptAnalyzer\${analyzerVersion}"
         Rename-Item "${versionModuleDir}" "${CheckoutPath}\out\PSScriptAnalyzer\PSScriptAnalyzer"
         $moduleDir = "${CheckoutPath}\out\PSScriptAnalyzer"


### PR DESCRIPTION
instead of installing into out/PSScriptAnalyzer it will be out/PSScriptAnalyzer/<version>
I also added some `-force` to a number of the `New-item -type directory` tests because they cause misleading screen output because the directory already existed.
I fixed one of the tests which was not setting `$env:PSModulePath` back correctly to its original state.

## PR Summary

A number of infrastructure and test fixes

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.