### PR TITLE
WIP: Check for case sensitivity rather than branching on OS type

### DIFF
--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -12,12 +12,14 @@ try
     foreach ( $f in "file1","FILE2","fIlE3" ) {
         $null = new-item -type file (Join-Path $d.root $f)
     }
+    Write-Verbose -Verbose ("temp drive: " + $d.root)
     $count = @(get-childitem (Join-Path $d.root "file?")).Count
     if ( $count -eq 1 ) {
-        $CaseSensitiveFS = $true
-    }
-    else {
-        $CaseSensitiveFS = $false
+        Write-Verbose -Verbose "Case Sensitive FS"
+        $script:CaseSensitiveFS = $true
+    } else {
+        Write-Verbose -Verbose "Case Insensitive FS"
+        $script:CaseSensitiveFS = $false
     }
 }
 finally {
@@ -120,7 +122,7 @@ Describe "Test importing correct customized rules" {
 		It "will show the custom rules when given a glob" {
 			# needs fixing for Linux
 			$expectedNumRules = 4
-			if ($CaseSensitiveFS)
+			if ($script:CaseSensitiveFS)
 			{
 				$expectedNumRules = 3
 			}
@@ -135,7 +137,7 @@ Describe "Test importing correct customized rules" {
 
 		It "will show the custom rules when given glob with recurse switch" {
 			$expectedNumRules = 5
-			if ($CaseSensitiveFS)
+			if ($script:CaseSensitiveFS)
 			{
 				$expectedNumRules = 4
 			}


### PR DESCRIPTION
## PR Summary

A couple of tests use the OS type to make a determination as to whether there's a case sensitive file system. In some environment (say a Linux container, or a specific configuration of Linux), this is not sufficient. I've added some direct checks for determining case sensitivity on the file system, and then use that in the tests.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.