### PR TITLE
Add ImplementingType to RuleInfo object

### DIFF
--- a/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
+++ b/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                 foreach (IRule rule in rules)
                 {
                     WriteObject(new RuleInfo(rule.GetName(), rule.GetCommonName(), rule.GetDescription(),
-                        rule.GetSourceType(), rule.GetSourceName(), rule.GetSeverity()));
+                        rule.GetSourceType(), rule.GetSourceName(), rule.GetSeverity(), rule.GetType()));
                 }
             }
         }

--- a/Engine/Generic/RuleInfo.cs
+++ b/Engine/Generic/RuleInfo.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
@@ -16,6 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         private SourceType sourceType;
         private string sourceName;
         private RuleSeverity ruleSeverity;
+        private Type implementingType;
 
         /// <summary>
         /// Name: The name of the rule.
@@ -50,7 +52,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <summary>
         /// SourceType: The source type of the rule.
         /// </summary>
-        /// 
+        ///
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public SourceType SourceType
         {
@@ -79,6 +81,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         }
 
         /// <summary>
+        /// ImplementingType : The type which implements the rule.
+        /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
+        public Type ImplementingType
+        {
+            get { return implementingType; }
+            private set { implementingType = value; }
+        }
+
+        /// <summary>
         /// Constructor for a RuleInfo.
         /// </summary>
         /// <param name="name">Name of the rule.</param>
@@ -93,12 +105,32 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             Description = description;
             SourceType  = sourceType;
             SourceName  = sourceName;
-            Severity = severity;      
+            Severity = severity;
+        }
+
+        /// <summary>
+        /// Constructor for a RuleInfo.
+        /// </summary>
+        /// <param name="name">Name of the rule.</param>
+        /// <param name="commonName">Common Name of the rule.</param>
+        /// <param name="description">Description of the rule.</param>
+        /// <param name="sourceType">Source type of the rule.</param>
+        /// <param name="sourceName">Source name of the rule.</param>
+        /// <param name="implementingType">The dotnet type of the rule.</param>
+        public RuleInfo(string name, string commonName, string description, SourceType sourceType, string sourceName, RuleSeverity severity, Type implementingType)
+        {
+            RuleName        = name;
+            CommonName  = commonName;
+            Description = description;
+            SourceType  = sourceType;
+            SourceName  = sourceName;
+            Severity = severity;
+            ImplementingType = implementingType;
         }
 
         public override string ToString()
         {
             return RuleName;
-        }      
+        }
     }
 }

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -177,3 +177,11 @@ Describe "TestWildCard" {
         $rules.Count | Should -Be 4
     }
 }
+
+Describe "TestImplementingType" {
+    It "retrieves rule which have an implementing type" {
+        $rule = Get-ScriptAnalyzerRule PSPlaceCloseBrace
+        $type = $rule.ImplementingType
+        $type.BaseType.Name | Should -Be "ConfigurableRule"
+    }
+}


### PR DESCRIPTION

## PR Summary

This will enable easier creation of settings file validation and settings file template creation.
Navigating to the actual implementation of the rule is quite difficult, by providing the implementing type of the rule, this becomes much easier. This is similar to how `CmdletInfo` works in PowerShell where there is an ImplementingType property on the CmdletInfo object.

This will enable a couple of things; first, we'll be able to create validation of settings file without translating the rule name to the type that implements (so you can very easily retrieve the configurable properties). Second, it will also be possible to write tools to create templates for settings.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.