### PR TITLE
Fix logic errors in AvoidAlias rule

### DIFF
--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
 
                 var commdNameWithGetPrefix = $"Get-{commandName}";
-                var cmdletNameIfCommandWasMissingGetPrefix = Helper.Instance.GetCommandInfo($"Get-{commandName}");
+                var cmdletNameIfCommandWasMissingGetPrefix = Helper.Instance.GetCommandInfo(commdNameWithGetPrefix);
                 if (cmdletNameIfCommandWasMissingGetPrefix != null)
                 {
                     yield return new DiagnosticRecord(

--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -126,25 +126,29 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         fileName,
                         commandName,
                         suggestedCorrections: GetCorrectionExtent(cmdAst, cmdletNameIfCommandNameWasAlias));
+                    // do not continue the search, but go to the next command
+                    continue;
                 }
 
-                var isNativeCommand = Helper.Instance.GetCommandInfo(commandName, CommandTypes.Application | CommandTypes.ExternalScript) != null;
-                if (!isNativeCommand)
-                {
-                    var commdNameWithGetPrefix = $"Get-{commandName}";
-                    var cmdletNameIfCommandWasMissingGetPrefix = Helper.Instance.GetCommandInfo($"Get-{commandName}");
-                    if (cmdletNameIfCommandWasMissingGetPrefix != null)
-                    {
-                        yield return new DiagnosticRecord(
-                            string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingCmdletAliasesMissingGetPrefixError, commandName, commdNameWithGetPrefix),
-                            GetCommandExtent(cmdAst),
-                            GetName(),
-                            DiagnosticSeverity.Warning,
-                            fileName,
-                            commandName,
-                            suggestedCorrections: GetCorrectionExtent(cmdAst, commdNameWithGetPrefix));
-                    }
+                // If we find match of any kind, do not continue with the Get-{commandname} check
+                if ( Helper.Instance.GetCommandInfo(commandName) != null ) {
+                    continue;
                 }
+
+                var commdNameWithGetPrefix = $"Get-{commandName}";
+                var cmdletNameIfCommandWasMissingGetPrefix = Helper.Instance.GetCommandInfo($"Get-{commandName}");
+                if (cmdletNameIfCommandWasMissingGetPrefix != null)
+                {
+                    yield return new DiagnosticRecord(
+                        string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingCmdletAliasesMissingGetPrefixError, commandName, commdNameWithGetPrefix),
+                        GetCommandExtent(cmdAst),
+                        GetName(),
+                        DiagnosticSeverity.Warning,
+                        fileName,
+                        commandName,
+                        suggestedCorrections: GetCorrectionExtent(cmdAst, commdNameWithGetPrefix));
+                }
+
             }
         }
 


### PR DESCRIPTION
## PR Summary

The first fix is that after the yield return, we should move on to the next command
The second fix is that if we find _any_ command, we should not move on to the 'Get-<command>' variant.
These changes mean that we do not run a pipeline (twice!) to find something that was a cache miss. Previously in the pathological case of a script made up of only unique aliases, we would run 2 pipelines for each found alias. This fix avoids both of those pipeline invocations.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.