### PR TITLE
UseCorrectCasing: Do not correct applications or script paths at all

### DIFF
--- a/Rules/UseCorrectCasing.cs
+++ b/Rules/UseCorrectCasing.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
 
                 var commandInfo = Helper.Instance.GetCommandInfo(commandName);
-                if (commandInfo == null || commandInfo.CommandType == CommandTypes.ExternalScript)
+                if (commandInfo == null || commandInfo.CommandType == CommandTypes.ExternalScript || commandInfo.CommandType == CommandTypes.Application)
                 {
                     continue;
                 }
@@ -60,12 +60,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 var fullyqualifiedName = $"{commandInfo.ModuleName}\\{shortName}";
                 var isFullyQualified = commandName.Equals(fullyqualifiedName, StringComparison.OrdinalIgnoreCase);
                 var correctlyCasedCommandName = isFullyQualified ? fullyqualifiedName : shortName;
-                if (isWindows && commandInfo.CommandType == CommandTypes.Application && !Path.HasExtension(commandName))
-                {
-                    // For binaries that could exist on both Windows and Linux like e.g. git we do not want to expand
-                    // git to git.exe to keep the script cross-platform compliant
-                    correctlyCasedCommandName = Path.GetFileNameWithoutExtension(correctlyCasedCommandName);
-                }
 
                 if (!commandName.Equals(correctlyCasedCommandName, StringComparison.Ordinal))
                 {

--- a/Rules/UseCorrectCasing.cs
+++ b/Rules/UseCorrectCasing.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
 
                 var commandInfo = Helper.Instance.GetCommandInfo(commandName);
-                if (commandInfo == null)
+                if (commandInfo == null || commandInfo.CommandType == CommandTypes.ExternalScript)
                 {
                     continue;
                 }

--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -39,7 +39,14 @@ Describe "UseCorrectCasing" {
         Invoke-Formatter 'invoke-dummyFunction' | Should -Be 'Invoke-DummyFunction'
     }
 
-    It "preserves script paths" -Skip:($IsLinux -or $IsMacOS) {
+    It "preserves script path" {
+        $path = Join-Path $TestDrive "$([guid]::NewGuid()).ps1"
+        New-Item -ItemType File -Path $path
+        $scriptDefinition = ". $path"
+        Invoke-Formatter $scriptDefinition | Should -Be $scriptDefinition
+    }
+
+    It "preserves UNC script path" -Skip:($IsLinux -or $IsMacOS) {
         $uncPath = [System.IO.Path]::Combine("\\$(HOSTNAME.EXE)\C$\", $TestDrive, "$([guid]::NewGuid()).ps1")
         New-Item -ItemType File -Path $uncPath
         $scriptDefinition = ". $uncPath"

--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -40,7 +40,7 @@ Describe "UseCorrectCasing" {
     }
 
     It "preserves script paths" -Skip:($IsLinux -or $IsMacOS) {
-        $uncPath = [System.IO.Path]::Combine("\\$(HOSTNAME.EXE)\C$\", $TestDrive, "$(New-Guid).ps1")
+        $uncPath = [System.IO.Path]::Combine("\\$(HOSTNAME.EXE)\C$\", $TestDrive, "$([guid]::NewGuid()).ps1")
         New-Item -ItemType File -Path $uncPath
         $scriptDefinition = ". $uncPath"
         Invoke-Formatter $scriptDefinition | Should -Be $scriptDefinition

--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -31,7 +31,7 @@ Describe "UseCorrectCasing" {
             $applicationPath = '. /bin/ls'
         }
         else {
-            $applicationPath = 'C:\Windows\System32\cmd.exe'
+            $applicationPath = "${env:WINDIR}\System32\cmd.exe"
         }
         Invoke-Formatter ". $applicationPath" | Should -Be ". $applicationPath"
     }

--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -38,4 +38,11 @@ Describe "UseCorrectCasing" {
         }
         Invoke-Formatter 'invoke-dummyFunction' | Should -Be 'Invoke-DummyFunction'
     }
+
+    It "preserves script paths" -Skip:($IsLinux -or $IsMacOS) {
+        $uncPath = [System.IO.Path]::Combine("\\$(HOSTNAME.EXE)\C$\", $TestDrive, "$(New-Guid).ps1")
+        New-Item -ItemType File -Path $uncPath
+        $scriptDefinition = ". $uncPath"
+        Invoke-Formatter $scriptDefinition | Should -Be $scriptDefinition
+    }
 }


### PR DESCRIPTION
## PR Summary

Fixes #1206 
When PowerShell starts at a directory and a script has an expression like the dot operator to a relative path that exists, Get-Command returns an object and makes it correct the path to the file name in the new UseCorrectCasing formatting rule (this rule is turned off by default in the vs code editor). We do not want to change paths at all (there could even be path casing issues if someone develops on Windows for example), therefore the exclusion applies. It was hard to write a test case for this but the same bug also occurs when using a UNC file path and this was chosen to be the test case for the written regression test.

In general we also found more edge cases of application paths being corrected as well and takie this logic out as well due to the time pressure of shipping 1.18.1 It seemed something easy  for free at first but that was actually not the intent of the rule and it seems it is anon-trivial feature that someone might want to add later but not now.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.