### PR TITLE
Make it possible to build ScriptAnalyzer with PowerShell7

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -7,7 +7,7 @@ param(
     [switch]$All,
 
     [Parameter(ParameterSetName="BuildOne")]
-    [ValidateRange(3, 6)]
+    [ValidateRange(3, 7)]
     [int]$PSVersion = $PSVersionTable.PSVersion.Major,
 
     [Parameter(ParameterSetName="BuildOne")]
@@ -36,6 +36,12 @@ param(
     [Parameter(ParameterSetName='Bootstrap')]
     [switch] $Bootstrap
 )
+BEGIN {
+    if ($PSVersion -gt 6) {
+        # due to netstandard2.0 we do not need to treat PS version 7 differently
+        $PSVersion = 6
+    }
+}
 
 END {
     Import-Module -Force (Join-Path $PSScriptRoot build.psm1)

--- a/build.psm1
+++ b/build.psm1
@@ -144,6 +144,8 @@ function Start-ScriptAnalyzerBuild
     param (
         [switch]$All,
 
+        # Note that 6 should also be chosen for PowerShell7 as both implement netstandard2.0
+        # and we do not use features from netstandard2.1
         [ValidateRange(3, 6)]
         [int]$PSVersion = $PSVersionTable.PSVersion.Major,
 


### PR DESCRIPTION
## PR Summary

Because PS7 implements netstandard2.0 we do not need to change anything apart from redirecting 7 to 6.
In the future we could hypothetically use `netstandard2.1` features and only then we would need a PS7 specific build.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.