### PR TITLE
Retry Test-Module manifest calls to avoid sporadic failures due to concurrency/thread safety issue in  PowerShell itself

### DIFF
--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -311,7 +311,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 catch (CmdletInvocationException exception)
                 {
                     cmdletInvocationException = exception;
-                    Console.WriteLine($"Catch: {attempt}");
                 }
             }
             throw cmdletInvocationException;

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -292,6 +292,31 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             return false;
         }
 
+
+        /// <summary>
+        /// Gets the module manifest with retries to compensate for sporadic faiures to thread safety bugs in PowerShell.
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <param name="errorRecord"></param>
+        /// <returns>Returns a object of type PSModuleInfo</returns>
+        public PSModuleInfo GetModuleManifestWithRetry(string filePath, out IEnumerable<ErrorRecord> errorRecord)
+        {
+            CmdletInvocationException cmdletInvocationException = null;
+            for (int attempt = 0; attempt < 3; attempt++)
+            {
+                try
+                {
+                    return GetModuleManifest(filePath, out errorRecord);
+                }
+                catch (CmdletInvocationException exception)
+                {
+                    cmdletInvocationException = exception;
+                    Console.WriteLine($"Catch: {attempt}");
+                }
+            }
+            throw cmdletInvocationException;
+        }
+
         /// <summary>
         /// Gets the module manifest
         /// </summary>

--- a/Rules/MissingModuleManifestField.cs
+++ b/Rules/MissingModuleManifestField.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             if (Helper.IsModuleManifest(fileName))
             {
                 IEnumerable<ErrorRecord> errorRecords;
-                var psModuleInfo = Helper.Instance.GetModuleManifest(fileName, out errorRecords);
+                var psModuleInfo = Helper.Instance.GetModuleManifestWithRetry(fileName, out errorRecords);
                 if (errorRecords != null)
                 {
                     foreach (var errorRecord in errorRecords)

--- a/Rules/UseToExportFieldsInManifest.cs
+++ b/Rules/UseToExportFieldsInManifest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             // check if valid module manifest
             IEnumerable<ErrorRecord> errorRecord = null;
-            PSModuleInfo psModuleInfo = Helper.Instance.GetModuleManifest(fileName, out errorRecord);            
+            PSModuleInfo psModuleInfo = Helper.Instance.GetModuleManifestWithRetry(fileName, out errorRecord);            
             if ((errorRecord != null && errorRecord.Count() > 0) || psModuleInfo == null)
             {                
                 yield break;


### PR DESCRIPTION
## PR Summary

Fixes #901
Fixes #902

Retry `Test-ModuleManifest` that can sometimes throw due to a thread safety issue in PowerShell itself (I can repro in versions 5-7 and maybe later I want to look into fixing it in PS itself).
This makes PSSA more stable by retrying the operation and resolves the issue as I manually tested. I am keeping the existing method that it calls public to not break the public API although I don't think anyone is using it.
I tried to write a test for it but although I can reproduce locally, it is hard to write test that reproduces this race condition.
I also opened a PR in PowerShell itself to get it fixed in v7: https://github.com/PowerShell/PowerShell/pull/9860

UPDATE: I opened PR #1258 which might be a better alternative by locking the calls of `Test-ModuleManifest`

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.