### PR TITLE
Fix edge case when PipelineIndentationStyle is not set to NoIndentation

### DIFF
--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -220,14 +220,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // Check if the current token matches the end of a PipelineAst
                 var matchingPipeLineAstEnd = pipelineAsts.FirstOrDefault(pipelineAst =>
                         PositionIsEqual(pipelineAst.Extent.EndScriptPosition, token.Extent.EndScriptPosition)) as PipelineAst;
-
                 if (matchingPipeLineAstEnd == null)
                 {
                     continue;
                 }
-
-                bool pipelineSpansOnlyOneLine = matchingPipeLineAstEnd.Extent.StartLineNumber == matchingPipeLineAstEnd.Extent.EndLineNumber;
-                if (pipelineSpansOnlyOneLine)
+                bool pipelinesSpansOnlyOneLine = matchingPipeLineAstEnd.PipelineElements[0].Extent.StartLineNumber ==
+                    matchingPipeLineAstEnd.PipelineElements[matchingPipeLineAstEnd.PipelineElements.Count-1].Extent.StartLineNumber;
+                if (pipelinesSpansOnlyOneLine)
                 {
                     continue;
                 }

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -224,9 +224,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     continue;
                 }
-                bool pipelinesSpansOnlyOneLine = matchingPipeLineAstEnd.PipelineElements[0].Extent.StartLineNumber ==
+                bool pipelinesSpanOnlyOneLine = matchingPipeLineAstEnd.PipelineElements[0].Extent.StartLineNumber ==
                     matchingPipeLineAstEnd.PipelineElements[matchingPipeLineAstEnd.PipelineElements.Count-1].Extent.StartLineNumber;
-                if (pipelinesSpansOnlyOneLine)
+                if (pipelinesSpanOnlyOneLine)
                 {
                     continue;
                 }

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -191,6 +191,24 @@ function hello {
             Invoke-Formatter -ScriptDefinition $idempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
         }
 
+        It "Should preserve script when using PipelineIndentation <PipelineIndentation>" -TestCases @(
+            @{ PipelineIndentation = 'IncreaseIndentationForFirstPipeline' }
+            @{ PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline' }
+            @{ PipelineIndentation = 'NoIndentation' }
+            ) {
+        param ($PipelineIndentation)
+        $idempotentScriptDefinition = @'
+function foo {
+    function bar {
+        Invoke-Something | ForEach-Object {
+        }
+    }
+}
+'@
+        $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+        Invoke-Formatter -ScriptDefinition $idempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
+    }
+
         It "Should indent pipelines correctly using NoIndentation option" {
             $def = @'
 foo |


### PR DESCRIPTION
## PR Summary

Fixes #1236
Note that the originally reported issue was fixed in 1.18.1 but the issue creator posted another edge case after the release [here](https://github.com/PowerShell/PSScriptAnalyzer/issues/1236#issuecomment-502004113), which is the issue that the author addresses.

When PipelineIndentationStyle  is set to IncreaseIndentationForFirstPipeline or IncreaseIndentationAfterEveryPipeline:
The determination if the pipelineAst is on one line needs to be tweaked to include the case where pipelines are on the same line but a multi-line expressions follows. This lead to the next brace having one level of indentation too little.

Context: 1.18.1 fixed most PipelineIndentationStyle  bugs when it is not set to NoIndentation (which is the default in VS Code at the moment), but this edge case was missed out.

Linux failure is due to the recent AppVeyor image update and affects development branch as well

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.