### PR TITLE
Update documentation for parameter "Settings" of command "Invoke-ScriptAnalyzer" to include the key "RecurseCustomRulesPath"

### DIFF
--- a/docs/markdown/Invoke-ScriptAnalyzer.md
+++ b/docs/markdown/Invoke-ScriptAnalyzer.md
@@ -437,11 +437,13 @@ If the path, the file's or hashtable's content are invalid, it is ignored.
 The parameters and values in the profile take precedence over the same parameter and values specified at the command line.
 
 A Script Analyzer profile file is a text file that contains a hash table with one or more of the following keys:
+
 -- Severity
 -- IncludeRules
 -- ExcludeRules
 -- Rules
 -- CustomRulePath
+-- RecurseCustomRulePath
 -- IncludeDefaultRules
 
 The keys and values in the profile are interpreted as if they were standard parameters and parameter values of Invoke-ScriptAnalyzer.

--- a/docs/markdown/Invoke-ScriptAnalyzer.md
+++ b/docs/markdown/Invoke-ScriptAnalyzer.md
@@ -438,13 +438,13 @@ The parameters and values in the profile take precedence over the same parameter
 
 A Script Analyzer profile file is a text file that contains a hash table with one or more of the following keys:
 
--- Severity
--- IncludeRules
--- ExcludeRules
--- Rules
 -- CustomRulePath
--- RecurseCustomRulePath
+-- ExcludeRules
 -- IncludeDefaultRules
+-- IncludeRules
+-- RecurseCustomRulePath
+-- Rules
+-- Severity
 
 The keys and values in the profile are interpreted as if they were standard parameters and parameter values of Invoke-ScriptAnalyzer.
 


### PR DESCRIPTION
Fixes #1270 "Documentation for `Invoke-ScriptAnalyzer -Settings` is out-of-date".