### PR TITLE
Update engine resource string 'WrongKeyHashTable' to include all valid settings hashtable keys

### DIFF
--- a/Engine/Strings.Designer.cs
+++ b/Engine/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -646,7 +646,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} is not a valid key in the settings hashtable. Valid keys are ExcludeRules, IncludeRules and Severity..
+        ///   Looks up a localized string similar to {0} is not a valid key in the settings hashtable. Valid keys are CustomRulePath, ExcludeRules, IncludeRules, IncludeDefaultRules, RecurseCustomRulePath, Rules and Severity..
         /// </summary>
         internal static string WrongKeyHashTable {
             get {

--- a/Engine/Strings.resx
+++ b/Engine/Strings.resx
@@ -238,7 +238,7 @@
     <value>Key {0} in the settings is not a string.</value>
   </data>
   <data name="WrongKeyHashTable" xml:space="preserve">
-    <value>{0} is not a valid key in the settings hashtable. Valid keys are Severity, IncludeRules, ExcludeRules, Rules, CustomRulePath, RecurseCustomRulePath, and IncludeDefaultRules.</value>
+    <value>{0} is not a valid key in the settings hashtable. Valid keys are CustomRulePath, ExcludeRules, IncludeRules, IncludeDefaultRules, RecurseCustomRulePath, Rules and Severity.</value>
   </data>
   <data name="WrongValueHashTable" xml:space="preserve">
     <value>Value {0} for key {1} has the wrong data type.</value>

--- a/Engine/Strings.resx
+++ b/Engine/Strings.resx
@@ -238,7 +238,7 @@
     <value>Key {0} in the settings is not a string.</value>
   </data>
   <data name="WrongKeyHashTable" xml:space="preserve">
-    <value>{0} is not a valid key in the settings hashtable. Valid keys are ExcludeRules, IncludeRules and Severity.</value>
+    <value>{0} is not a valid key in the settings hashtable. Valid keys are Severity, IncludeRules, ExcludeRules, Rules, CustomRulePath, RecurseCustomRulePath, and IncludeDefaultRules.</value>
   </data>
   <data name="WrongValueHashTable" xml:space="preserve">
     <value>Value {0} for key {1} has the wrong data type.</value>


### PR DESCRIPTION
Fixes #1269 "Resource string WrongKeyHashTable is out-of-date".