### PR TITLE
WIP: Improve the performance of the formatter

### DIFF
--- a/Engine/EditableText.cs
+++ b/Engine/EditableText.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         {
             ValidateTextEdit(textEdit);
 
-            var editLines = textEdit.Lines;
+            string[] editLines = textEdit.Lines;
 
             // Get the first fragment of the first line
             string firstLineFragment =

--- a/Engine/Generic/CorrectionExtent.cs
+++ b/Engine/Generic/CorrectionExtent.cs
@@ -130,6 +130,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
                 return -1;
             }
 
+            if (x.Text.Length > y.Text.Length)
+            {
+                return 1;
+            }
+
+            if (x.Text.Length < y.Text.Length)
+            {
+                return -1;
+            }
+
             return 0;
         }
 

--- a/Engine/Generic/CorrectionExtent.cs
+++ b/Engine/Generic/CorrectionExtent.cs
@@ -105,4 +105,44 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
 
         }
     }
+
+    internal struct CorrectionComparer : IComparer<CorrectionExtent>, IEqualityComparer<CorrectionExtent>
+    {
+        public int Compare(CorrectionExtent x, CorrectionExtent y)
+        {
+            if (x.StartLineNumber > y.StartLineNumber)
+            {
+                return 1;
+            }
+
+            if (x.StartLineNumber < y.StartLineNumber)
+            {
+                return -1;
+            }
+
+            if (x.StartColumnNumber > y.StartColumnNumber)
+            {
+                return 1;
+            }
+
+            if (x.StartColumnNumber < y.StartColumnNumber)
+            {
+                return -1;
+            }
+
+            return 0;
+        }
+
+        public bool Equals(CorrectionExtent x, CorrectionExtent y)
+        {
+            return Compare(x, y) == 0;
+        }
+
+        public int GetHashCode(CorrectionExtent obj)
+        {
+            return obj != null
+                ? obj.GetHashCode()
+                : 0;
+        }
+    }
 }

--- a/Engine/text.cs
+++ b/Engine/text.cs
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
+{
+    internal struct TextPosition
+    {
+        public TextPosition(int line, int column)
+        {
+            Line = line;
+            Column = column;
+        }
+
+        public int Line { get; }
+
+        public int Column { get; }
+    }
+
+    internal struct TextRange
+    {
+        public TextRange(TextPosition start, TextPosition end)
+        {
+            Start = start;
+            End = end;
+        }
+
+        public TextPosition Start { get; }
+
+        public TextPosition End { get; }
+    }
+
+    internal class TextDocumentBuilder
+    {
+        private class CharBuffer
+        {
+            private char[] _charArray;
+
+            private int _validLength;
+
+            public CharBuffer()
+            {
+                _charArray = new char[128];
+                _validLength = 0;
+            }
+
+            public void CopyFrom(string content, int startIndex, int length)
+            {
+                while (length > _charArray.Length)
+                {
+                    _charArray = new char[_charArray.Length * 2];
+                }
+
+                content.CopyTo(startIndex, _charArray, 0, length);
+                _validLength = length;
+            }
+
+            public void CopyTo(StringBuilder buffer)
+            {
+                buffer.Append(_charArray, 0, _validLength);
+            }
+        }
+
+        private readonly static char s_newlineStart = Environment.NewLine[0];
+
+        private readonly CharBuffer _spanBuffer;
+
+        private string _content;
+
+        public TextDocumentBuilder(string content)
+        {
+            _content = content;
+            _spanBuffer = new CharBuffer();
+        }
+
+        public override string ToString()
+        {
+            return _content;
+        }
+
+        public TextRange GetValidColumnIndexRange(TextRange textRange)
+        {
+            return new TextRange(
+                new TextPosition(textRange.Start.Line - 1, Math.Min(1, textRange.Start.Column - 1)),
+                new TextPosition(textRange.End.Line - 1, Math.Max(textRange.End.Column - 1, GetLastColumnLength())));
+        }
+
+        public bool IsValidRange(TextRange range)
+        {
+            return range.Start.Line <= range.End.Line
+                && range.End.Line <= GetLineCount() + 1
+                && range.Start.Column <= GetColumnLength(range.Start.Line) + 1
+                && range.End.Column <= GetColumnLength(range.End.Line) + 1;
+        }
+
+        public void ApplyCorrections(IReadOnlyList<CorrectionExtent> corrections)
+        {
+            var newContent = new StringBuilder(_content.Length);
+            var effectiveOldPosition = new TextPosition(0, 0);
+            int currentIndex = 0;
+
+            foreach (CorrectionExtent correction in corrections)
+            {
+                var correctionStartPosition = new TextPosition(correction.StartLineNumber - 1, correction.StartColumnNumber - 1);
+                ReadNextSpan(ref currentIndex, effectiveOldPosition, correctionStartPosition);
+                _spanBuffer.CopyTo(newContent);
+                newContent.Append(correction.Text);
+                currentIndex += correction.Text.Length;
+                effectiveOldPosition = new TextPosition(correction.EndLineNumber - 1, correction.EndColumnNumber - 1);
+            }
+            ReadToEnd(currentIndex);
+            _spanBuffer.CopyTo(newContent);
+            _content = newContent.ToString();
+        }
+
+        private void ReadNextSpan(ref int index, TextPosition effectiveOldPosition, TextPosition correctionStartPosition)
+        {
+            int linesToRead = correctionStartPosition.Line - effectiveOldPosition.Line;
+            int nextIndex = _content.IndexOf(Environment.NewLine, index, linesToRead) + correctionStartPosition.Column;
+            _spanBuffer.CopyFrom(_content, index, nextIndex - index);
+            index = nextIndex;
+        }
+
+        private void ReadToEnd(int currentIndex)
+        {
+            _spanBuffer.CopyFrom(_content, currentIndex, _content.Length - currentIndex);
+        }
+
+        private int GetColumnLength(int lineNumber)
+        {
+            int lineIndex = GetLineIndex(lineNumber);
+            return _content.IndexOf(Environment.NewLine, lineIndex);
+        }
+
+        private int GetLastColumnLength()
+        {
+            return _content.Length - _content.LastIndexOf(Environment.NewLine);
+        }
+
+        private int GetLineCount()
+        {
+            int lineCount = 0;
+            foreach (char c in _content)
+            {
+                if (c == '\n') { lineCount++; }
+            }
+            return lineCount;
+        }
+
+        private int GetLineIndex(int lineNumber)
+        {
+            return _content.IndexOf(Environment.NewLine, 0, lineNumber);
+        }
+    }
+}

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/RuntimeData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/RuntimeData.cs
@@ -128,7 +128,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Query
             IReadOnlyDictionary<string, JsonDictionary<Version, Data.ModuleData>> modules,
             IReadOnlyDictionary<string, IReadOnlyList<CommandData>> commands)
         {
-            var aliasTable = new Dictionary<string, IReadOnlyList<CommandData>>();
+            var aliasTable = new Dictionary<string, IReadOnlyList<CommandData>>(StringComparer.OrdinalIgnoreCase);
             foreach (KeyValuePair<string, JsonDictionary<Version, Data.ModuleData>> module in modules)
             {
                 foreach (KeyValuePair<Version, Data.ModuleData> moduleVersion in module.Value)


### PR DESCRIPTION
## PR Summary

@mattpwhite noted in [a comment](https://github.com/PowerShell/vscode-powershell/issues/1256#issuecomment-504842937) in the PS extension repo that the formatter is one of the big causes for performance problems in the PowerShell extension.

With that in mind, I want to see what I can do to drive down some of those performance issues.

In this particular PR, I've rewritten the way formatting occurs, so that:
- Rather than running each formatting rule in its own invocation, they are all run together
- Rather than using a lot of LINQ and an array of strings to represent a text file, we perform edits in a cleverer way and amortise allocations to some extent

This doesn't directly address @mattpwhite's issue where the formatter likes to import modules, but it goes to some extent.

I'll say that when I first saw the formatting code I was a bit horrified, and I really don't like the idea of the module import stuff either, so I'm going to do my best on that.

Here's an indicative performance result on a pathological case:

```powershell
$s = 'gci;'*1000
Measure-Command { Invoke-Formatter $s }
```

Output in PSSA 1.18.1
```Output
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 15
Milliseconds      : 339
Ticks             : 153390477
TotalDays         : 0.00017753527430555555
TotalHours        : 0.0042608465833333335
TotalMinutes      : 0.255650795
TotalSeconds      : 15.3390477
TotalMilliseconds : 15339.047700000001
```

Output with the changes in this branch:
```Output
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 61
Ticks             : 619337
TotalDays         : 7.168252314814815E-07
TotalHours        : 1.7203805555555554E-05
TotalMinutes      : 0.0010322283333333334
TotalSeconds      : 0.061933699999999994
TotalMilliseconds : 61.9337
```

(A ~250x speedup)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes) **Hard to guarantee this, but it shouldn't be**
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.