### PR TITLE
UseApprovedVerbs.md: Improving Documentation

### DIFF
--- a/RuleDocumentation/UseApprovedVerbs.md
+++ b/RuleDocumentation/UseApprovedVerbs.md
@@ -8,7 +8,7 @@ All CMDLets must used approved verbs.
 
 Approved verbs can be found by running the command `Get-Verb`.
 
-Additional documentation on approved verbs can be found in the microsoft docs page [Approved Verbs for PowerShell Commands](https://docs.microsoft.com/en-us/powershell/developer/cmdlet/approved-verbs-for-windows-powershell-commands). If you find the verb you are using is unapproved, try searching the page for the approved equivalent. For example, if you search in the documentation for `Read`, `Open`, or `Search` you will find that the approved verb for those situations is `Get`.
+Additional documentation on approved verbs can be found in the microsoft docs page [Approved Verbs for PowerShell Commands](https://docs.microsoft.com/powershell/developer/cmdlet/approved-verbs-for-windows-powershell-commands). If you find the verb you are using is unapproved, try searching the page for the approved equivalent. For example, if you search in the documentation for `Read`, `Open`, or `Search` you will find that the approved verb for those situations is `Get`.
 
 ## How
 

--- a/RuleDocumentation/UseApprovedVerbs.md
+++ b/RuleDocumentation/UseApprovedVerbs.md
@@ -8,7 +8,11 @@ All CMDLets must used approved verbs.
 
 Approved verbs can be found by running the command `Get-Verb`.
 
-Additional documentation on approved verbs can be found in the microsoft docs page [Approved Verbs for PowerShell Commands](https://docs.microsoft.com/powershell/developer/cmdlet/approved-verbs-for-windows-powershell-commands). If you find the verb you are using is unapproved, try searching the page for the approved equivalent. For example, if you search in the documentation for `Read`, `Open`, or `Search` you will find that the approved verb for those situations is `Get`.
+Additional documentation on approved verbs can be found in the microsoft docs page
+[Approved Verbs for PowerShell Commands](https://docs.microsoft.com/powershell/developer/cmdlet/approved-verbs-for-windows-powershell-commands).
+Some unapproved verbs are documented on the approved verbs page and point to approved alternatives;
+try searching for the verb you used to find its approved form.
+For example, searching for `Read`, `Open`, or `Search` will lead you to `Get`.
 
 ## How
 

--- a/RuleDocumentation/UseApprovedVerbs.md
+++ b/RuleDocumentation/UseApprovedVerbs.md
@@ -8,6 +8,8 @@ All CMDLets must used approved verbs.
 
 Approved verbs can be found by running the command `Get-Verb`.
 
+Additional documentation on approved verbs can be found in the microsoft docs page [Approved Verbs for PowerShell Commands](https://docs.microsoft.com/en-us/powershell/developer/cmdlet/approved-verbs-for-windows-powershell-commands). If you find the verb you are using is unapproved, try searching the page for the approved equivalent. For example, if you search in the documentation for `Read`, `Open`, or `Search` you will find that the approved verb for those situations is `Get`.
+
 ## How
 
 Change the verb in the cmdlet's name to an approved verb.


### PR DESCRIPTION
## PR Summary
I have come to this documentation a few times in the past. Get-Verb is very helpful, but the additional insight, and examples of unapproved verbs in the Microsoft docs are very helpful and make it easier to decide on a suitable replacement for an unapproved verb. I think it would be helpful to have a link to that documentation here.

The contribution guidelines say "Submit your own fixes or features as a pull request but please discuss it beforehand in an issue if the change is substantial." This change is not substantial and therefore I did not open an issue first.
<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.