### PR TITLE
AppVeyor Ubutnu Build Faling - Potential Fix

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -94,9 +94,10 @@ function Invoke-AppveyorTest {
 # Implements AppVeyor 'on_finish' step
 function Invoke-AppveyorFinish {
     $stagingDirectory = (Resolve-Path ..).Path
-    $zipFile = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
+    $zipFile = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath((Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"))
     Add-Type -AssemblyName 'System.IO.Compression.FileSystem'
-    [System.IO.Compression.ZipFile]::CreateFromDirectory((Join-Path $pwd 'out'), $zipFile)
+    $sourceDirectory = (Resolve-Path -Path (Join-Path -Path $pwd -ChildPath 'out')).Path
+    [System.IO.Compression.ZipFile]::CreateFromDirectory($sourceDirectory, $zipFile)
     @(
         # add test results as an artifact
         (Get-ChildItem TestResults.xml)


### PR DESCRIPTION
## PR Summary

The Ubuntu build is currently failing with the below exception / [example here:](https://ci.appveyor.com/project/PowerShell/psscriptanalyzer/builds/26600683/job/26ju29rqww40xk6y) 

```
Running "on_finish" scripts
Import-Module "${env:APPVEYOR_BUILD_FOLDER}\tools\appveyor.psm1"; Invoke-AppveyorFinish
iex : Exception calling "CreateFromDirectory" with "2" argument(s): "Could not find a part of the path '/home/appveyor/projects/psscriptanalyzer/out'."
At /opt/appveyor/build-agent/ps-shell.ps1:114 char:2
+     iex $command
+     ~~~~~~~~~~~~
+ CategoryInfo          : NotSpecified: (:) [Invoke-Expression], MethodInvocationException
+ FullyQualifiedErrorId : DirectoryNotFoundException,Microsoft.PowerShell.Commands.InvokeExpressionCommand
 
Build failed
```
