### PR TITLE
Fix PSCloseBrace rule to not wrongly flag closing brace of one-line hashtable, which lead to incorrect formatting

### DIFF
--- a/Engine/TokenOperations.cs
+++ b/Engine/TokenOperations.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         public IEnumerable<Tuple<Token, Token>> GetBracePairs()
         {
             var openBraceStack = new Stack<Token>();
-            var hashtableAsts = ast.FindAll(oneAst => oneAst is HashtableAst, searchNestedScriptBlocks: true);
+            IEnumerable<Ast> hashtableAsts = ast.FindAll(oneAst => oneAst is HashtableAst, searchNestedScriptBlocks: true);
             foreach (var token in tokens)
             {
                 if (token.Kind == TokenKind.LCurly)
@@ -85,11 +85,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 if (token.Kind == TokenKind.RCurly
                     && openBraceStack.Count > 0)
                 {
-                    var closeBraceBelongsToHashTable = hashtableAsts.Any(hashtableAst =>
+                    bool closeBraceBelongsToHashTable = hashtableAsts.Any(hashtableAst =>
                     {
                         return hashtableAst.Extent.EndLineNumber == token.Extent.EndLineNumber
                             && hashtableAst.Extent.EndColumnNumber == token.Extent.EndColumnNumber;
                     });
+
                     if (!closeBraceBelongsToHashTable)
                     {
                         yield return new Tuple<Token, Token>(openBraceStack.Pop(), token);

--- a/Engine/TokenOperations.cs
+++ b/Engine/TokenOperations.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         public IEnumerable<Tuple<Token, Token>> GetBracePairs()
         {
             var openBraceStack = new Stack<Token>();
-            var hashtableAsts = ast.FindAll(oneAst => oneAst is HashtableAst, searchNestedScriptBlocks: true); // todo: cache
+            var hashtableAsts = ast.FindAll(oneAst => oneAst is HashtableAst, searchNestedScriptBlocks: true);
             foreach (var token in tokens)
             {
                 if (token.Kind == TokenKind.LCurly)

--- a/Engine/TokenOperations.cs
+++ b/Engine/TokenOperations.cs
@@ -104,6 +104,18 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
         }
 
+        public bool CloseBraceBelongsToHashTable(Token token)
+        {
+            var hashtableAsts = ast.FindAll(oneAst => oneAst is HashtableAst, searchNestedScriptBlocks: true); // todo: cache
+            if (hashtableAsts.Any(oneAst =>
+                oneAst.Extent.EndLineNumber == token.Extent.EndLineNumber &&
+                oneAst.Extent.EndColumnNumber == token.Extent.EndColumnNumber))
+            {
+                return true;
+            }
+            return false;
+        }
+
         private IEnumerable<Token> GetBraceInCommandElement(TokenKind tokenKind)
         {
             var cmdElemAsts = ast.FindAll(x => x is CommandElementAst && x is ScriptBlockExpressionAst, true);

--- a/Engine/TokenOperations.cs
+++ b/Engine/TokenOperations.cs
@@ -113,7 +113,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
         }
 
-
         private IEnumerable<Token> GetBraceInCommandElement(TokenKind tokenKind)
         {
             var cmdElemAsts = ast.FindAll(x => x is CommandElementAst && x is ScriptBlockExpressionAst, true);

--- a/Engine/TokenOperations.cs
+++ b/Engine/TokenOperations.cs
@@ -17,18 +17,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         private readonly Token[] tokens;
         private LinkedList<Token> tokensLL;
         private readonly Ast ast;
-        private IEnumerable<Ast> hashtableAsts
-        {
-            get
-            {
-                if (_hashtableAsts == null)
-                {
-                    _hashtableAsts = ast.FindAll(oneAst => oneAst is HashtableAst, searchNestedScriptBlocks: true);
-                }
-                return _hashtableAsts;
-            }
-        }
-        private IEnumerable<Ast> _hashtableAsts;
 
         public Ast Ast { get { return ast; } }
 

--- a/Engine/TokenOperations.cs
+++ b/Engine/TokenOperations.cs
@@ -104,16 +104,24 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
         }
 
-        public bool CloseBraceBelongsToHashTable(Token token)
+        public bool CloseBraceBelongsToSingleLineHashTable(Token token)
         {
             var hashtableAsts = ast.FindAll(oneAst => oneAst is HashtableAst, searchNestedScriptBlocks: true); // todo: cache
-            if (hashtableAsts.Any(oneAst =>
-                oneAst.Extent.EndLineNumber == token.Extent.EndLineNumber &&
-                oneAst.Extent.EndColumnNumber == token.Extent.EndColumnNumber))
+
+            var closeBraceBelongsToSingleLineHashTable = hashtableAsts.Any(oneAst =>
             {
-                return true;
+                bool closeBraceBelongsToHashTable = oneAst.Extent.EndLineNumber == token.Extent.EndLineNumber
+                                                 && oneAst.Extent.EndColumnNumber == token.Extent.EndColumnNumber;
+                if (!closeBraceBelongsToHashTable)
+                {
+                    return false;
+                }
+                bool isSingleLineHashtable = oneAst.Extent.StartLineNumber == oneAst.Extent.EndLineNumber;
+                return isSingleLineHashtable;
             }
-            return false;
+            );
+
+            return closeBraceBelongsToSingleLineHashTable;
         }
 
         private IEnumerable<Token> GetBraceInCommandElement(TokenKind tokenKind)

--- a/Rules/PlaceCloseBrace.cs
+++ b/Rules/PlaceCloseBrace.cs
@@ -412,7 +412,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 var closeBraceToken = tokens[closeBracePos];
                 if (tokens[closeBracePos - 1].Kind != TokenKind.NewLine
                     && !tokensToIgnore.Contains(closeBraceToken)
-                    && _tokenOperations.CloseBraceBelongsToHashTable(closeBraceToken)
+                    && !_tokenOperations.CloseBraceBelongsToSingleLineHashTable(closeBraceToken)
                    )
                 {
                     return new DiagnosticRecord(

--- a/Rules/PlaceCloseBrace.cs
+++ b/Rules/PlaceCloseBrace.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         private List<Func<Token[], int, int, string, DiagnosticRecord>> violationFinders
             = new List<Func<Token[], int, int, string, DiagnosticRecord>>();
 
-        private TokenOperations _tokenOperations;
-
         /// <summary>
         /// Indicates if there should or should not be an empty line before a close brace.
         ///
@@ -105,14 +103,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             var curlyStack = new Stack<Tuple<Token, int>>();
 
             // TODO move part common with PlaceOpenBrace to one place
-            _tokenOperations = new TokenOperations(tokens, ast);
-            tokensToIgnore = new HashSet<Token>(_tokenOperations.GetCloseBracesInCommandElements());
+            var tokenOps = new TokenOperations(tokens, ast);
+            tokensToIgnore = new HashSet<Token>(tokenOps.GetCloseBracesInCommandElements());
 
             // Ignore close braces that are part of a one line if-else statement
             // E.g. $x = if ($true) { "blah" } else { "blah blah" }
             if (IgnoreOneLineBlock)
             {
-                foreach (var pair in _tokenOperations.GetBracePairsOnSameLine())
+                foreach (var pair in tokenOps.GetBracePairsOnSameLine())
                 {
                     tokensToIgnore.Add(pair.Item2);
                 }

--- a/Rules/PlaceCloseBrace.cs
+++ b/Rules/PlaceCloseBrace.cs
@@ -411,9 +411,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 var closeBraceToken = tokens[closeBracePos];
                 if (tokens[closeBracePos - 1].Kind != TokenKind.NewLine
-                    && !tokensToIgnore.Contains(closeBraceToken)
-                    && !_tokenOperations.CloseBraceBelongsToSingleLineHashTable(closeBraceToken)
-                   )
+                    && !tokensToIgnore.Contains(closeBraceToken))
                 {
                     return new DiagnosticRecord(
                         GetError(Strings.PlaceCloseBraceErrorShouldBeOnNewLine),

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -80,14 +80,12 @@ $hashtable = @{a = 1; b = 2}
 
     Context "When there is a one line hashtable inside a one line statement" {
         BeforeAll {
-            $def = 'if ($true) { $test = @{ } }'
-            $ruleConfiguration.'NoEmptyLineBefore' = $false
+            $scriptDefinition = 'if ($true) { $test = @{ } }'
             $ruleConfiguration.'IgnoreOneLineBlock' = $true
-            $ruleConfiguration.'NewLineAfter' = $false
         }
 
         It "Should not find a violation" {
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings
             $violations.Count | Should -Be 0
         }
     }

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -78,6 +78,20 @@ $hashtable = @{a = 1; b = 2}
         }
     }
 
+    Context "When there is a one line hashtable inside a one line statement" {
+        BeforeAll {
+            $def = 'if ($true) { $test = @{ } }'
+            $ruleConfiguration.'NoEmptyLineBefore' = $false
+            $ruleConfiguration.'IgnoreOneLineBlock' = $true
+            $ruleConfiguration.'NewLineAfter' = $false
+        }
+
+        It "Should not find a violation" {
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should -Be 0
+        }
+    }
+
     Context "When there is a multi-line hashtable" {
         BeforeAll {
 


### PR DESCRIPTION
## PR Summary

Fixes #1284

This fixes a bug (that must've been long-standing) in the `GetBracePairs` method (which returns all pairs of braces except for hashtables) of the `TokenOperations` class where it can wrongly pair an `RBrace` of an hashtable with the `LCurly` of a braced expression. This caused incorrect formatting of the script definition `if ($true) { $test = @{ } }` where the selected `RBrace` was the one of the hashtable and not the `if`expression, therefore leading to an incorrectly added newline before the final brace by the `PSCloseBrace` rule used by `Invoke-Formatter` (default rules settings are such that one-line expressions do not require a newline before the closing brace).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.