### PR TITLE
Enhance UseDeclaredVarsMoreThanAssignments to detect also take into account the usage of Get-Variable with an array of variables and usage of named parameter -Name

### DIFF
--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -215,13 +215,28 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             foreach (CommandAst getVariableCommandAst in getVariableCommandAsts)
             {
                 var commandElements = getVariableCommandAst.CommandElements.ToList();
-                // The following extracts the variable name only in the simplest possibe case 'Get-Variable variableName'
+                // The following extracts the variable name only in the simplest possible cases
+                // 'Get-Variable variableName' and 'Get-Variable variableName1, variableName2'
                 if (commandElements.Count == 2 && commandElements[1] is StringConstantExpressionAst constantExpressionAst)
                 {
                     var variableName = constantExpressionAst.Value;
                     if (assignmentsDictionary_OrdinalIgnoreCase.ContainsKey(variableName))
                     {
                         assignmentsDictionary_OrdinalIgnoreCase.Remove(variableName);
+                    }
+                }
+                if (commandElements.Count == 2 && commandElements[1] is ArrayLiteralAst arrayLiteralAst)
+                {
+                    foreach (var expressionAst in arrayLiteralAst.Elements)
+                    {
+                        if (expressionAst is StringConstantExpressionAst constantExpressionAstOfArray)
+                        {
+                            var variableName = constantExpressionAstOfArray.Value;
+                            if (assignmentsDictionary_OrdinalIgnoreCase.ContainsKey(variableName))
+                            {
+                                assignmentsDictionary_OrdinalIgnoreCase.Remove(variableName);
+                            }
+                        }
                     }
                 }
             }

--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -246,8 +246,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 var commandElementAstOfVariableName = commandElements[commandElements.Count - 1];
                 if (commandElements.Count == 3)
                 {
-                    var commandParameterAst = commandElements[1] as CommandParameterAst;
-                    if (commandParameterAst == null) { continue; }
+                    if (!(commandElements[1] is CommandParameterAst commandParameterAst)) { continue; }
                     // Check if the named parameter -Name is used (PowerShell does not need the full
                     // parameter name and there is no other parameter of Get-Variable starting with n).
                     if (!commandParameterAst.ParameterName.StartsWith("n", StringComparison.OrdinalIgnoreCase))
@@ -258,25 +257,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 if (commandElementAstOfVariableName is StringConstantExpressionAst constantExpressionAst)
                 {
-                    MarkVariableAsAssigned(constantExpressionAst.Value);
+                    assignmentsDictionary_OrdinalIgnoreCase.Remove(constantExpressionAst.Value);
                     continue;
                 }
 
-                var arrayLiteralAst = commandElementAstOfVariableName as ArrayLiteralAst;
-                if (arrayLiteralAst == null) { continue; }
+                if (!(commandElementAstOfVariableName is ArrayLiteralAst arrayLiteralAst)) { continue; }
                 foreach (var expressionAst in arrayLiteralAst.Elements)
                 {
                     if (expressionAst is StringConstantExpressionAst constantExpressionAstOfArray)
                     {
-                        MarkVariableAsAssigned(constantExpressionAstOfArray.Value);
-                    }
-                }
-
-                void MarkVariableAsAssigned(string variableName)
-                {
-                    if (assignmentsDictionary_OrdinalIgnoreCase.ContainsKey(variableName))
-                    {
-                        assignmentsDictionary_OrdinalIgnoreCase.Remove(variableName);
+                        assignmentsDictionary_OrdinalIgnoreCase.Remove(constantExpressionAstOfArray.Value);
                     }
                 }
             }

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -72,7 +72,7 @@ function MyFunc2() {
         It "returns no violations" {
             $noViolations.Count | Should -Be 0
         }
-        
+
         It "Does not flag += operator" {
             $results = Invoke-ScriptAnalyzer -ScriptDefinition '$array=@(); $list | ForEach-Object { $array += $c }' | Where-Object { $_.RuleName -eq $violationName }
             $results.Count | Should -Be 0
@@ -90,6 +90,11 @@ function MyFunc2() {
 
         It "Using a variable via 'Get-Variable' does not trigger a warning" {
             $noViolations = Invoke-ScriptAnalyzer -ScriptDefinition '$a=4; get-variable a'
+            $noViolations.Count | Should -Be 0
+        }
+
+        It "Using a variable via 'Get-Variable' does not trigger a warning" {
+            $noViolations = Invoke-ScriptAnalyzer -ScriptDefinition '$a=4; $b = 8; get-variable a, b'
             $noViolations.Count | Should -Be 0
         }
     }

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -88,14 +88,36 @@ function MyFunc2() {
             $results.Count | Should -Be 0
         }
 
-        It "Using a variable via 'Get-Variable' does not trigger a warning" {
-            $noViolations = Invoke-ScriptAnalyzer -ScriptDefinition '$a=4; get-variable a'
-            $noViolations.Count | Should -Be 0
-        }
-
-        It "Using a variable via 'Get-Variable' does not trigger a warning" {
-            $noViolations = Invoke-ScriptAnalyzer -ScriptDefinition '$a=4; $b = 8; get-variable a, b'
-            $noViolations.Count | Should -Be 0
+        It "No warning when using 'Get-Variable' with variables declaration '<DeclareVariables>' and command paramter <GetVariableCommandParameter>" -TestCases @(
+            @{
+                DeclareVariables = '$a = 1'; GetVariableCommandParameter = 'a';
+            }
+            @{
+                DeclareVariables = '$a = 1'; GetVariableCommandParameter = '-Name a';
+            }
+            @{
+                DeclareVariables = '$a = 1'; GetVariableCommandParameter = '-n a';
+            }
+            @{
+                DeclareVariables = '$a = 1; $b = 2'; GetVariableCommandParameter = 'a,b'
+            }
+            @{
+                DeclareVariables = '$a = 1; $b = 2'; GetVariableCommandParameter = '-Name a,b'
+            }
+            @{
+                DeclareVariables = '$a = 1; $b = 2'; GetVariableCommandParameter = '-n a,b'
+            }
+            @{
+                DeclareVariables = '$a = 1; $b = 2'; GetVariableCommandParameter = 'A,B'
+            }
+        ) {
+            Param(
+                $DeclareVariables,
+                $GetVariableCommandParameter
+            )
+            $scriptDefinition = "$DeclareVariables; Get-Variable $GetVariableCommandParameter"
+            $noViolations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition
+            $noViolations.Count | Should -Be 0 -Because $scriptDefinition
         }
     }
 }

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -88,7 +88,7 @@ function MyFunc2() {
             $results.Count | Should -Be 0
         }
 
-        It "No warning when using 'Get-Variable' with variables declaration '<DeclareVariables>' and command paramter <GetVariableCommandParameter>" -TestCases @(
+        It "No warning when using 'Get-Variable' with variables declaration '<DeclareVariables>' and command parameter <GetVariableCommandParameter>" -TestCases @(
             @{
                 DeclareVariables = '$a = 1'; GetVariableCommandParameter = 'a';
             }
@@ -118,6 +118,11 @@ function MyFunc2() {
             $scriptDefinition = "$DeclareVariables; Get-Variable $GetVariableCommandParameter"
             $noViolations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition
             $noViolations.Count | Should -Be 0 -Because $scriptDefinition
+        }
+
+        It "Does not misinterpret switch parameter of Get-Variable as variable" {
+            $scriptDefinition = '$ArbitrarySwitchParameter = 1; Get-Variable -ArbitrarySwitchParameter'
+            (Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition).Count | Should -Be 1 -Because $scriptDefinition
         }
     }
 }


### PR DESCRIPTION
## PR Summary

Fixes #1301 by enhancing the parsing of the `Get-Variable` AST to also check if an array is passed or if the `-Name`  parameter is used as a named parameter (including cases where it is shortened to `-n`).
Also refactored logic into it's own static method for better readability and performance.
Since reverse engineering a `CommandAst` into the used parameters is quite complex, I am not going to further enhance it.  

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.