### PR TITLE
PipelineIndentationStyle: Fix edge case where pipeline was incorrectly detected to span mutliple lines due to backticks in the command leading up to the pipeline

### DIFF
--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -224,8 +224,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     continue;
                 }
-                var firstPipelineElementExtent = matchingPipeLineAstEnd.PipelineElements[0].Extent;
-                var lastPipelineElementExtent = matchingPipeLineAstEnd.PipelineElements[matchingPipeLineAstEnd.PipelineElements.Count - 1].Extent;
+                IScriptExtent firstPipelineElementExtent = matchingPipeLineAstEnd.PipelineElements[0].Extent;
+                IScriptExtent lastPipelineElementExtent = matchingPipeLineAstEnd.PipelineElements[matchingPipeLineAstEnd.PipelineElements.Count - 1].Extent;
                 bool pipelinesSpanOnlyOneLine = firstPipelineElementExtent.EndLineNumber == lastPipelineElementExtent.EndLineNumber
                                              || firstPipelineElementExtent.StartLineNumber == lastPipelineElementExtent.StartLineNumber;
                 if (pipelinesSpanOnlyOneLine)

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -224,8 +224,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     continue;
                 }
-                bool pipelinesSpanOnlyOneLine = matchingPipeLineAstEnd.PipelineElements[0].Extent.EndLineNumber ==
-                    matchingPipeLineAstEnd.PipelineElements[matchingPipeLineAstEnd.PipelineElements.Count-1].Extent.EndLineNumber;
+                var firstPipelineElementExtent = matchingPipeLineAstEnd.PipelineElements[0].Extent;
+                var lastPipelineElementExtent = matchingPipeLineAstEnd.PipelineElements[matchingPipeLineAstEnd.PipelineElements.Count - 1].Extent;
+                bool pipelinesSpanOnlyOneLine = firstPipelineElementExtent.EndLineNumber == lastPipelineElementExtent.EndLineNumber
+                                             || firstPipelineElementExtent.StartLineNumber == lastPipelineElementExtent.StartLineNumber;
                 if (pipelinesSpanOnlyOneLine)
                 {
                     continue;

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -224,8 +224,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     continue;
                 }
-                bool pipelinesSpanOnlyOneLine = matchingPipeLineAstEnd.PipelineElements[0].Extent.StartLineNumber ==
-                    matchingPipeLineAstEnd.PipelineElements[matchingPipeLineAstEnd.PipelineElements.Count-1].Extent.StartLineNumber;
+                bool pipelinesSpanOnlyOneLine = matchingPipeLineAstEnd.PipelineElements[0].Extent.EndLineNumber ==
+                    matchingPipeLineAstEnd.PipelineElements[matchingPipeLineAstEnd.PipelineElements.Count-1].Extent.EndLineNumber;
                 if (pipelinesSpanOnlyOneLine)
                 {
                     continue;

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -209,6 +209,24 @@ function foo {
         Invoke-Formatter -ScriptDefinition $idempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
     }
 
+    It "Should preserve script when using PipelineIndentation <PipelineIndentation> for multi-line pipeline due to backtick" -TestCases @(
+        @{ PipelineIndentation = 'IncreaseIndentationForFirstPipeline' }
+        @{ PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline' }
+        @{ PipelineIndentation = 'NoIndentation' }
+        ) {
+    param ($PipelineIndentation)
+    $idempotentScriptDefinition = @'
+Describe 'describe' {
+    It 'it' {
+        { 'To be,' -or `
+                -not 'to be' } | Should -Be 'the question'
+    }
+}
+'@
+    $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+    Invoke-Formatter -ScriptDefinition $idempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
+}
+
         It "Should indent pipelines correctly using NoIndentation option" {
             $def = @'
 foo |


### PR DESCRIPTION
## PR Summary

Fixes #1311 by refining the logic to determine if a pipeline spans one line or not. Previously it compared only the `StartLineNumber` of the first and last pipeline to be equal. Now the logic needs to be tweaked with an `OR` condition where also the `EndLineNumber` of the first and last pipeline is checked for equality.
Code was also made more readable.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.