### PR TITLE
Fix Indentation of mulitline command with backticks after comment line

### DIFF
--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -196,13 +196,20 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 ++tempIndentationLevel;
                             }
 
-                            // TODO: check if not just line before but further back
-                            if (k > 2 &&
-                                tokens[k - 1].Kind == TokenKind.NewLine &&
-                                tokens[k - 2].Kind == TokenKind.Comment &&
-                                tokens[k - 3].Kind == TokenKind.LineContinuation)
+                            // check for comments in between multi-line commands with line continuation
+                            if (k > 2 && tokens[k - 1].Kind == TokenKind.NewLine
+                                && tokens[k - 2].Kind == TokenKind.Comment)
                             {
-                                ++tempIndentationLevel;
+                                int j = k - 2;
+                                while (j > 0 && tokens[j].Kind == TokenKind.Comment)
+                                {
+                                    --j;
+                                }
+
+                                if (j >= 0 && tokens[j].Kind == TokenKind.LineContinuation)
+                                {
+                                    ++tempIndentationLevel;
+                                }
                             }
 
                             var lineHasPipelineBeforeToken = tokens.Any(oneToken =>

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -131,9 +131,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             var indentationLevel = 0;
             var onNewLine = true;
             var pipelineAsts = ast.FindAll(testAst => testAst is PipelineAst && (testAst as PipelineAst).PipelineElements.Count > 1, true);
-            for (int k = 0; k < tokens.Length; k++)
+            for (int tokenIndex = 0; tokenIndex < tokens.Length; tokenIndex++)
             {
-                var token = tokens[k];
+                var token = tokens[tokenIndex];
 
                 if (token.Kind == TokenKind.EndOfInput)
                 {
@@ -151,8 +151,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         break;
 
                     case TokenKind.Pipe:
-                        bool pipelineIsFollowedByNewlineOrLineContinuation = k < tokens.Length - 1 && k > 0 &&
-                              (tokens[k + 1].Kind == TokenKind.NewLine || tokens[k + 1].Kind == TokenKind.LineContinuation);
+                        bool pipelineIsFollowedByNewlineOrLineContinuation = tokenIndex < tokens.Length - 1 && tokenIndex > 0 &&
+                              (tokens[tokenIndex + 1].Kind == TokenKind.NewLine || tokens[tokenIndex + 1].Kind == TokenKind.LineContinuation);
                         if (!pipelineIsFollowedByNewlineOrLineContinuation)
                         {
                             break;
@@ -164,7 +164,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         }
                         if (pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationForFirstPipeline)
                         {
-                            bool isFirstPipeInPipeline = pipelineAsts.Any(pipelineAst => PositionIsEqual(((PipelineAst)pipelineAst).PipelineElements[0].Extent.EndScriptPosition, tokens[k - 1].Extent.EndScriptPosition));
+                            bool isFirstPipeInPipeline = pipelineAsts.Any(pipelineAst => PositionIsEqual(((PipelineAst)pipelineAst).PipelineElements[0].Extent.EndScriptPosition, tokens[tokenIndex - 1].Extent.EndScriptPosition));
                             if (isFirstPipeInPipeline)
                             {
                                 AddViolation(token, indentationLevel++, diagnosticRecords, ref onNewLine);
@@ -191,22 +191,22 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                             var tempIndentationLevel = indentationLevel;
 
                             // Check if the preceding character is an escape character
-                            if (k > 0 && tokens[k - 1].Kind == TokenKind.LineContinuation)
+                            if (tokenIndex > 0 && tokens[tokenIndex - 1].Kind == TokenKind.LineContinuation)
                             {
                                 ++tempIndentationLevel;
                             }
 
                             // check for comments in between multi-line commands with line continuation
-                            if (k > 2 && tokens[k - 1].Kind == TokenKind.NewLine
-                                && tokens[k - 2].Kind == TokenKind.Comment)
+                            if (tokenIndex > 2 && tokens[tokenIndex - 1].Kind == TokenKind.NewLine
+                                && tokens[tokenIndex - 2].Kind == TokenKind.Comment)
                             {
-                                int j = k - 2;
-                                while (j > 0 && tokens[j].Kind == TokenKind.Comment)
+                                int searchForPrecedingLineContinuationIndex = tokenIndex - 2;
+                                while (searchForPrecedingLineContinuationIndex  > 0 && tokens[searchForPrecedingLineContinuationIndex].Kind == TokenKind.Comment)
                                 {
-                                    j--;
+                                    searchForPrecedingLineContinuationIndex--;
                                 }
 
-                                if (j >= 0 && tokens[j].Kind == TokenKind.LineContinuation)
+                                if (searchForPrecedingLineContinuationIndex >= 0 && tokens[searchForPrecedingLineContinuationIndex].Kind == TokenKind.LineContinuation)
                                 {
                                     tempIndentationLevel++;
                                 }

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -201,9 +201,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 // Since the previous token is a newline token we start
                                 // looking for comments at the token before the newline token.
                                 int j = k - 2;
-                                while (j > 0 && tokens[j].Kind == TokenKind.Comment)
+                                if (j > 0 && tokens[j].Kind == TokenKind.Comment)
                                 {
-                                    --j;
+                                    ++tempIndentationLevel;
                                 }
                             }
 

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -203,12 +203,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 int j = k - 2;
                                 while (j > 0 && tokens[j].Kind == TokenKind.Comment)
                                 {
-                                    --j;
+                                    j--;
                                 }
 
                                 if (j >= 0 && tokens[j].Kind == TokenKind.LineContinuation)
                                 {
-                                    ++tempIndentationLevel;
+                                    tempIndentationLevel++;
                                 }
                             }
 

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -195,16 +195,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                             {
                                 ++tempIndentationLevel;
                             }
-                            else
+
+                            // TODO: check if not just line before but further back
+                            if (k > 2 &&
+                                tokens[k - 1].Kind == TokenKind.NewLine &&
+                                tokens[k - 2].Kind == TokenKind.Comment &&
+                                tokens[k - 3].Kind == TokenKind.LineContinuation)
                             {
-                                // Ignore comments
-                                // Since the previous token is a newline token we start
-                                // looking for comments at the token before the newline token.
-                                int j = k - 2;
-                                if (j > 0 && tokens[j].Kind == TokenKind.Comment)
-                                {
-                                    ++tempIndentationLevel;
-                                }
+                                ++tempIndentationLevel;
                             }
 
                             var lineHasPipelineBeforeToken = tokens.Any(oneToken =>

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -107,6 +107,41 @@ function foo {
     }
 
     Context "When a multi-line command is given" {
+
+        It "When a comment is in the middle of a multi-line statement with line continuations" {
+            $scriptDefinition = @'
+foo `
+# comment
+-bar
+'@
+            $expected = @'
+foo `
+    # comment
+    -bar
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings
+            $violations.Count | Should -Be 2
+            Invoke-Formatter -ScriptDefinition $scriptDefinition | Should -Be $expected
+        }
+
+        It "When a comment is in the middle of a multi-line statement with line continuations 2" {
+            $scriptDefinition = @'
+foo `
+# comment
+-bar
+-baz
+'@
+            $expected = @'
+foo `
+    # comment
+    -bar `
+    -baz
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings
+            $violations.Count | Should -Be 2
+            Invoke-Formatter -ScriptDefinition $scriptDefinition | Should -Be $expected
+        }
+
         It "Should find a violation if a pipleline element is not indented correctly" {
             $def = @'
 get-process |

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -3,7 +3,25 @@ $testRootDirectory = Split-Path -Parent $directory
 
 Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
+
 Describe "UseConsistentIndentation" {
+    BeforeAll {
+        function Invoke-FormatterAssertion {
+            param(
+                [string] $ScriptDefinition,
+                [string] $ExcpectedScriptDefinition,
+                [int] $NumberOfExpectedWarnings,
+                [hashtable] $Settings
+            )
+
+            # Unit test just using this rule only
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings
+            $violations.Count | Should -Be $NumberOfExpectedWarnings -Because $ScriptDefinition
+            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be $expected -Because $ScriptDefinition
+            # Integration test with all default formatting rules
+            Invoke-Formatter -ScriptDefinition $scriptDefinition | Should -Be $expected -Because $ScriptDefinition
+        }
+    }
     BeforeEach {
         $indentationUnit = ' '
         $indentationSize = 4
@@ -108,24 +126,7 @@ function foo {
 
     Context "When a multi-line command is given" {
 
-        It "When a comment is in the middle of a multi-line statement with line continuations" {
-            $scriptDefinition = @'
-foo `
-# comment
--bar
-'@
-            $expected = @'
-foo `
-    # comment
-    -bar
-'@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings
-            $violations.Count | Should -Be 2
-            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be $expected
-            Invoke-Formatter -ScriptDefinition $scriptDefinition | Should -Be $expected
-        }
-
-        It "When a comment is in the middle of a multi-line statement with line continuations 2" {
+        It "When a comment is in the middle of a multi-line statement with preceding and succeeding line continuations" {
             $scriptDefinition = @'
 foo `
 # comment
@@ -138,10 +139,23 @@ foo `
     -bar `
     -baz
 '@
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings
-            $violations.Count | Should -Be 3
-            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be $expected
-            Invoke-Formatter -ScriptDefinition $scriptDefinition | Should -Be $expected
+            Invoke-FormatterAssertion $scriptDefinition $expected 3 $settings
+        }
+
+        It "When a comment is in the middle of a multi-line statement with preceding pipeline and succeeding line continuation " {
+            $scriptDefinition = @'
+foo |
+# comment
+bar `
+-baz
+'@
+            $expected = @'
+foo |
+    # comment
+    bar `
+        -baz
+'@
+            Invoke-FormatterAssertion $scriptDefinition $expected 3 $settings
         }
 
         It "Should find a violation if a pipleline element is not indented correctly" {

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -121,6 +121,7 @@ foo `
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings
             $violations.Count | Should -Be 2
+            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be $expected
             Invoke-Formatter -ScriptDefinition $scriptDefinition | Should -Be $expected
         }
 
@@ -128,7 +129,7 @@ foo `
             $scriptDefinition = @'
 foo `
 # comment
--bar
+-bar `
 -baz
 '@
             $expected = @'
@@ -138,7 +139,8 @@ foo `
     -baz
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings
-            $violations.Count | Should -Be 2
+            $violations.Count | Should -Be 3
+            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be $expected
             Invoke-Formatter -ScriptDefinition $scriptDefinition | Should -Be $expected
         }
 


### PR DESCRIPTION
## PR Summary

Fixes #1290  where I discovered an issue as part of it that has actually been present all the time but never flagged before.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.