### PR TITLE
Added instruction to get public modules from PSGallery

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -108,7 +108,7 @@ function Start-DocumentationBuild
     if ($null -eq $platyPS -or ($platyPS | Sort-Object Version -Descending | Select-Object -First 1).Version -lt [version]0.12)
     {
         Write-Verbose -verbose "platyPS module not found or below required version of 0.12, installing the latest version."
-        Install-Module -Force -Name platyPS -Scope CurrentUser
+        Install-Module -Force -Name platyPS -Scope CurrentUser -Repository PSGallery
     }
     if (-not (Test-Path $markdownDocsPath))
     {

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -16,7 +16,7 @@ function Invoke-AppVeyorInstall {
         else {
             # Visual Studio 2017 build (has already Pester v3, therefore a different installation mechanism is needed to make it also use the new version 4)
             Write-Verbose -Verbose "Installing Pester via Install-Module"
-            Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser
+            Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser -Repository PSGallery
         }
     }
 
@@ -28,7 +28,7 @@ function Invoke-AppVeyorInstall {
     }
     else {
         Write-Verbose -Verbose "Installing platyPS via Install-Module"
-        Install-Module -Name platyPS -Force -Scope CurrentUser -RequiredVersion $platyPSVersion
+        Install-Module -Name platyPS -Force -Scope CurrentUser -RequiredVersion $platyPSVersion -Repository PSGallery
     }
 
     # the build script sorts out the problems of WMF4 and earlier versions of dotnet CLI

--- a/tools/releaseBuild/Image/DockerFile
+++ b/tools/releaseBuild/Image/DockerFile
@@ -16,7 +16,7 @@ RUN Import-Module PackageManagement; `
     Import-Module ./containerFiles/dockerInstall.psm1; `
     Install-ChocolateyPackage -PackageName git -Executable git.exe; `
     Install-ChocolateyPackage -PackageName nuget.commandline -Executable nuget.exe -Cleanup; `
-    Install-Module -Force -Name platyPS; `
+    Install-Module -Force -Name platyPS -Repository PSGallery; `
     Invoke-WebRequest -Uri https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1 -outfile C:/dotnet-install.ps1; `
     C:/dotnet-install.ps1 -Channel Release -Version 2.1.4; `
     Add-Path C:/Users/ContainerAdministrator/AppData/Local/Microsoft/dotnet;


### PR DESCRIPTION
## PR Summary

Fixes #1326 . An error occurs while building PSScriptAnalyzer if one is missing dependencies and has a private repository added.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.