### PR TITLE
Don't sign the compatability collector catalog

### DIFF
--- a/tools/releaseBuild/FileCatalogSigning.xml
+++ b/tools/releaseBuild/FileCatalogSigning.xml
@@ -4,7 +4,7 @@
  <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Script Analyzer File Catalog" approvers="vigarg;gstolt">
     <file src="__INPATHROOT__\PSScriptAnalyzer\1.18.2\PSScriptAnalyzer.cat" signType="Authenticode" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.18.2\PSScriptAnalyzer.cat" />
  </job>
- <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Compatibility Analyzer File Catalog" approvers="vigarg;gstolt">
+<!-- <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Compatibility Analyzer File Catalog" approvers="vigarg;gstolt">
     <file src="__INPATHROOT__\PSCompatibilityCollector\PSCompatibilityCollector.cat" signType="Authenticode" dest="__OUTPATHROOT__\PSCompatibilityCollector\PSCompatibilityAnalzyer.cat" />
- </job>
+ </job> -->
 </SignConfigXML>


### PR DESCRIPTION
Do not attempt to sign the catalog for the compatibility profile module

## PR Summary

Don't sign the catalog for the compatibility, we are not shipping this module in the gallery yet, and it's causing some difficulties in the vsts sign build process.

# PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.