### PR TITLE
Added rule: AvoidLongLines

### DIFF
--- a/RuleDocumentation/AvoidLongLines.md
+++ b/RuleDocumentation/AvoidLongLines.md
@@ -4,4 +4,27 @@
 
 ## Description
 
-Lines should be no longer than 120 characters, including leading whitespace (indentation).
+Lines should be no longer than a configured number of characters (default: 120), including leading whitespace (indentation).
+
+**Note**: This rule is not enabled by default. The user needs to enable it through settings.
+
+## Configuration
+
+```powershell
+    Rules = @{
+        PSAvoidLongLines  = @{
+            Enable     = $true
+            LineLength = 120
+        }
+    }
+```
+
+### Parameters
+
+#### Enable: bool (Default value is `$false`)
+
+Enable or disable the rule during ScriptAnalyzer invocation.
+
+#### LineLength: int (Default value is 120)
+
+Optional parameter do override the default line length.

--- a/RuleDocumentation/AvoidLongLines.md
+++ b/RuleDocumentation/AvoidLongLines.md
@@ -25,6 +25,6 @@ Lines should be no longer than a configured number of characters (default: 120),
 
 Enable or disable the rule during ScriptAnalyzer invocation.
 
-#### LineLength: int (Default value is 120)
+#### MaximumLineLength: int (Default value is 120)
 
-Optional parameter do override the default line length.
+Optional parameter to override the default maximum line length.

--- a/RuleDocumentation/AvoidLongLines.md
+++ b/RuleDocumentation/AvoidLongLines.md
@@ -1,0 +1,7 @@
+# AvoidLongLines
+
+**Severity Level: Warning**
+
+## Description
+
+Lines should be longer than 120 characters, including leading whitespace (indentation).

--- a/RuleDocumentation/AvoidLongLines.md
+++ b/RuleDocumentation/AvoidLongLines.md
@@ -4,4 +4,4 @@
 
 ## Description
 
-Lines should be longer than 120 characters, including leading whitespace (indentation).
+Lines should be no longer than 120 characters, including leading whitespace (indentation).

--- a/RuleDocumentation/README.md
+++ b/RuleDocumentation/README.md
@@ -12,6 +12,7 @@
 |[AvoidGlobalFunctions](./AvoidGlobalFunctions.md) | Warning | |
 |[AvoidGlobalVars](./AvoidGlobalVars.md) | Warning | |
 |[AvoidInvokingEmptyMembers](./AvoidInvokingEmptyMembers.md) | Warning | |
+|[AvoidLongLines](./AvoidLongLines.md) | Warning | |
 |[AvoidNullOrEmptyHelpMessageAttribute](./AvoidNullOrEmptyHelpMessageAttribute.md) | Warning | |
 |[AvoidShouldContinueWithoutForce](./AvoidShouldContinueWithoutForce.md) | Warning | |
 |[AvoidUsingCmdletAliases](./AvoidUsingCmdletAliases.md) | Warning | Yes |

--- a/Rules/AvoidLongLines.cs
+++ b/Rules/AvoidLongLines.cs
@@ -14,7 +14,7 @@ using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
     /// <summary>
-    /// AvoidTrailingWhitespace: Checks for trailing whitespaces
+    /// AvoidLongLines: Checks for lines longer than 120 characters
     /// </summary>
 #if !CORECLR
     [Export(typeof(IScriptRule))]

--- a/Rules/AvoidLongLines.cs
+++ b/Rules/AvoidLongLines.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+#if !CORECLR
+using System.ComponentModel.Composition;
+#endif
+using System.Globalization;
+using System.Management.Automation.Language;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
+{
+    /// <summary>
+    /// AvoidTrailingWhitespace: Checks for trailing whitespaces
+    /// </summary>
+#if !CORECLR
+    [Export(typeof(IScriptRule))]
+#endif
+    public class AvoidLongLines : IScriptRule
+    {
+        /// <summary>
+        /// Analyzes the given ast to find violations.
+        /// </summary>
+        /// <param name="ast">AST to be analyzed. This should be non-null</param>
+        /// <param name="fileName">Name of file that corresponds to the input AST.</param>
+        /// <returns>A an enumerable type containing the violations</returns>
+        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
+            if (ast == null)
+            {
+                throw new ArgumentNullException("ast");
+            }
+
+            var diagnosticRecords = new List<DiagnosticRecord>();
+
+            string[] lines = Regex.Split(ast.Extent.Text, @"\r?\n");
+
+            for (int lineNumber = 0; lineNumber < lines.Length; lineNumber++)
+            {
+                var line = lines[lineNumber];
+
+                if (line.Length > 120)
+                {
+                    var startLine = lineNumber + 1;
+                    var endLine = startLine;
+                    var startColumn = 1;
+                    var endColumn = line.Length;
+
+                    var violationExtent = new ScriptExtent(
+                        new ScriptPosition(
+                            ast.Extent.File,
+                            startLine,
+                            startColumn,
+                            line
+                        ),
+                        new ScriptPosition(
+                            ast.Extent.File,
+                            endLine,
+                            endColumn,
+                            line
+                        ));
+
+                    var record = new DiagnosticRecord(
+                            String.Format(CultureInfo.CurrentCulture, Strings.AvoidLongLinesError),
+                            violationExtent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            ast.Extent.File,
+                            null
+                        );
+                    diagnosticRecords.Add(record);
+                }
+            }
+
+            return diagnosticRecords;
+        }
+
+        /// <summary>
+        /// Retrieves the common name of this rule.
+        /// </summary>
+        public string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidLongLinesCommonName);
+        }
+
+        /// <summary>
+        /// Retrieves the description of this rule.
+        /// </summary>
+        public string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidLongLinesDescription);
+        }
+
+        /// <summary>
+        /// Retrieves the name of this rule.
+        /// </summary>
+        public string GetName()
+        {
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.NameSpaceFormat,
+                GetSourceName(),
+                Strings.AvoidLongLinesName);
+        }
+
+        /// <summary>
+        /// Retrieves the severity of the rule: error, warning or information.
+        /// </summary>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
+
+        /// <summary>
+        /// Gets the severity of the returned diagnostic record: error, warning, or information.
+        /// </summary>
+        /// <returns></returns>
+        public DiagnosticSeverity GetDiagnosticSeverity()
+        {
+            return DiagnosticSeverity.Warning;
+        }
+
+        /// <summary>
+        /// Retrieves the name of the module/assembly the rule is from.
+        /// </summary>
+        public string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+
+        /// <summary>
+        /// Retrieves the type of the rule, Builtin, Managed or Module.
+        /// </summary>
+        public SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
+        }
+    }
+}

--- a/Rules/AvoidLongLines.cs
+++ b/Rules/AvoidLongLines.cs
@@ -19,15 +19,26 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 #if !CORECLR
     [Export(typeof(IScriptRule))]
 #endif
-    public class AvoidLongLines : IScriptRule
+    public class AvoidLongLines : ConfigurableRule
     {
+        /// <summary>
+        /// Construct an object of AvoidLongLines type.
+        /// </summary>
+        public AvoidLongLines() : base()
+        {
+            // Enable the rule by default
+            Enable = false;
+        }
+
+        [ConfigurableRuleProperty(defaultValue: 120)]
+        public int LineLength { get; set; }
         /// <summary>
         /// Analyzes the given ast to find violations.
         /// </summary>
         /// <param name="ast">AST to be analyzed. This should be non-null</param>
         /// <param name="fileName">Name of file that corresponds to the input AST.</param>
         /// <returns>A an enumerable type containing the violations</returns>
-        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        public override IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
         {
             if (ast == null)
             {
@@ -42,7 +53,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 var line = lines[lineNumber];
 
-                if (line.Length > 120)
+                if (line.Length > LineLength)
                 {
                     var startLine = lineNumber + 1;
                     var endLine = startLine;
@@ -81,7 +92,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// Retrieves the common name of this rule.
         /// </summary>
-        public string GetCommonName()
+        public override string GetCommonName()
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.AvoidLongLinesCommonName);
         }
@@ -89,7 +100,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// Retrieves the description of this rule.
         /// </summary>
-        public string GetDescription()
+        public override string GetDescription()
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.AvoidLongLinesDescription);
         }
@@ -97,7 +108,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// Retrieves the name of this rule.
         /// </summary>
-        public string GetName()
+        public override string GetName()
         {
             return string.Format(
                 CultureInfo.CurrentCulture,
@@ -109,7 +120,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// Retrieves the severity of the rule: error, warning or information.
         /// </summary>
-        public RuleSeverity GetSeverity()
+        public override RuleSeverity GetSeverity()
         {
             return RuleSeverity.Warning;
         }
@@ -126,7 +137,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// Retrieves the name of the module/assembly the rule is from.
         /// </summary>
-        public string GetSourceName()
+        public override string GetSourceName()
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
         }
@@ -134,7 +145,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// Retrieves the type of the rule, Builtin, Managed or Module.
         /// </summary>
-        public SourceType GetSourceType()
+        public override SourceType GetSourceType()
         {
             return SourceType.Builtin;
         }

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -536,6 +536,61 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
                 return ResourceManager.GetString("AvoidTrailingWhitespaceName", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidLongLines.
+        /// </summary>
+        internal static string AvoidLongLinesName
+        {
+            get
+            {
+                return ResourceManager.GetString("AvoidLongLinesName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Avoid long lines.
+        /// </summary>
+        internal static string AvoidLongLinesCommonName
+        {
+            get
+            {
+                return ResourceManager.GetString("AvoidLongLinesCommonName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Each line should be under 120 characters.
+        /// </summary>
+        internal static string AvoidLongLinesDescription
+        {
+            get
+            {
+                return ResourceManager.GetString("AvoidLongLinesDescription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Line is longer than 120 characters.
+        /// </summary>
+        internal static string AvoidLongLinesError
+        {
+            get
+            {
+                return ResourceManager.GetString("AvoidLongLinesError", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidLongLines.
+        /// </summary>
+        internal static string AvoidLongLinesWhitespaceName
+        {
+            get
+            {
+                return ResourceManager.GetString("AvoidLongLinesName", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Module Must Be Loadable.

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -904,10 +904,10 @@
     <value>Avoid long lines</value>
   </data>
   <data name="AvoidLongLinesDescription" xml:space="preserve">
-    <value>Each line should be no longer than 120 characters.</value>
+    <value>Each line should be not be too long.</value>
   </data>
   <data name="AvoidLongLinesError" xml:space="preserve">
-    <value>Line is longer than 120 characters which is too long</value>
+    <value>Line is too long</value>
   </data>
   <data name="PlaceOpenBraceName" xml:space="preserve">
     <value>PlaceOpenBrace</value>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -904,10 +904,10 @@
     <value>Avoid long lines</value>
   </data>
   <data name="AvoidLongLinesDescription" xml:space="preserve">
-    <value>Each line should be not be too long.</value>
+    <value>Line lengths should be less than the configured maximum</value>
   </data>
   <data name="AvoidLongLinesError" xml:space="preserve">
-    <value>Line is too long</value>
+    <value>Line exceeds the configured maximum length of {0} characters</value>
   </data>
   <data name="PlaceOpenBraceName" xml:space="preserve">
     <value>PlaceOpenBrace</value>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -897,6 +897,18 @@
   <data name="AvoidTrailingWhitespaceError" xml:space="preserve">
     <value>Line has trailing whitespace</value>
   </data>
+  <data name="AvoidLongLinesName" xml:space="preserve">
+    <value>AvoidLongLines</value>
+  </data>
+  <data name="AvoidLongLinesCommonName" xml:space="preserve">
+    <value>Avoid long lines</value>
+  </data>
+  <data name="AvoidLongLinesDescription" xml:space="preserve">
+    <value>Each line should be no longer than 120 characters.</value>
+  </data>
+  <data name="AvoidLongLinesError" xml:space="preserve">
+    <value>Line is longer than 120 characters which is too long</value>
+  </data>
   <data name="PlaceOpenBraceName" xml:space="preserve">
     <value>PlaceOpenBrace</value>
   </data>

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -59,7 +59,7 @@ Describe "Test Name parameters" {
 
         It "get Rules with no parameters supplied" {
 			$defaultRules = Get-ScriptAnalyzerRule
-            $expectedNumRules = 59
+            $expectedNumRules = 60
             if ((Test-PSEditionCoreClr) -or (Test-PSVersionV3) -or (Test-PSVersionV4))
             {
                 # for PSv3 PSAvoidGlobalAliases is not shipped because

--- a/Tests/Rules/AvoidLongLines.tests.ps1
+++ b/Tests/Rules/AvoidLongLines.tests.ps1
@@ -1,10 +1,20 @@
 $ruleName = "PSAvoidLongLines"
 
+$ruleSettings = @{
+    Enable = $true
+}
 $settings = @{
     IncludeRules = @($ruleName)
+    Rules = @{ $ruleName = $ruleSettings }
 }
 
 Describe "AvoidLongLines" {
+    it 'Should be off by default' {
+        $def = "a" * 500
+        $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def
+        $violations.Count | Should -Be 0
+    }
+
     it 'Should find a violation when a line is longer than 120 characters (no whitespace)' {
         $def = "a" * 125
         $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
@@ -21,5 +31,13 @@ Describe "AvoidLongLines" {
         $def = "a" * 120
         $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
         $violations.Count | Should -Be 0
+    }
+
+    it 'Should find a violation with a configured line length' {
+        $ruleSettings.Add('LineLength', 10)
+        $settings['Rules'] = @{ $ruleName = $ruleSettings }
+        $def = "a" * 15
+        $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+        $violations.Count | Should -Be 1
     }
 }

--- a/Tests/Rules/AvoidLongLines.tests.ps1
+++ b/Tests/Rules/AvoidLongLines.tests.ps1
@@ -16,13 +16,19 @@ Describe "AvoidLongLines" {
     }
 
     it 'Should find a violation when a line is longer than 120 characters (no whitespace)' {
-        $def = "a" * 125
+        $def = @"
+$("a" * 500)
+this line is short enough
+"@
         $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
         $violations.Count | Should -Be 1
     }
 
     it 'Should find a violation when a line is longer than 120 characters (leading whitespace)' {
-        $def = " " * 100 + "a" * 25
+        $def = @"
+$(" " * 100 + "a" * 25)
+this line is short enough
+"@
         $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
         $violations.Count | Should -Be 1
     }
@@ -34,7 +40,7 @@ Describe "AvoidLongLines" {
     }
 
     it 'Should find a violation with a configured line length' {
-        $ruleSettings.Add('LineLength', 10)
+        $ruleSettings.Add('MaximumLineLength', 10)
         $settings['Rules'] = @{ $ruleName = $ruleSettings }
         $def = "a" * 15
         $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings

--- a/Tests/Rules/AvoidLongLines.tests.ps1
+++ b/Tests/Rules/AvoidLongLines.tests.ps1
@@ -1,0 +1,25 @@
+$ruleName = "PSAvoidLongLines"
+
+$settings = @{
+    IncludeRules = @($ruleName)
+}
+
+Describe "AvoidLongLines" {
+    it 'Should find a violation when a line is longer than 120 characters (no whitespace)' {
+        $def = "a" * 125
+        $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+        $violations.Count | Should -Be 1
+    }
+
+    it 'Should find a violation when a line is longer than 120 characters (leading whitespace)' {
+        $def = " " * 100 + "a" * 25
+        $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+        $violations.Count | Should -Be 1
+    }
+
+    it 'Should not find a violation for lines under 120 characters' {
+        $def = "a" * 120
+        $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+        $violations.Count | Should -Be 0
+    }
+}

--- a/Tests/Rules/AvoidLongLines.tests.ps1
+++ b/Tests/Rules/AvoidLongLines.tests.ps1
@@ -5,7 +5,7 @@ $ruleSettings = @{
 }
 $settings = @{
     IncludeRules = @($ruleName)
-    Rules = @{ $ruleName = $ruleSettings }
+    Rules        = @{ $ruleName = $ruleSettings }
 }
 
 Describe "AvoidLongLines" {
@@ -22,6 +22,18 @@ this line is short enough
 "@
         $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
         $violations.Count | Should -Be 1
+    }
+
+    it 'Should get the correct extent of the violation' {
+        $def = @"
+this line is short enough
+$("a" * 500)
+"@
+        $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+        $violations[0].Extent.StartLineNumber | Should -Be 2
+        $violations[0].Extent.EndLineNumber | Should -Be 2
+        $violations[0].Extent.StartColumnNumber | Should -Be 1
+        $violations[0].Extent.EndColumnNumber | Should -Be 500
     }
 
     it 'Should find a violation when a line is longer than 120 characters (leading whitespace)' {


### PR DESCRIPTION
## PR Summary

Addresses #1243. This rule issues a warning for lines that are longer than 120 characters. This default value can be override and the rule is not enabled by default.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.