### PR TITLE
Revert accidentally added test from PR #1323

### DIFF
--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -158,36 +158,6 @@ foo |
             Invoke-FormatterAssertion $scriptDefinition $expected 3 $settings
         }
 
-        It "When a comment is in the middle of a multi-line statement with preceding pipeline and succeeding line continuation 2" {
-            $scriptDefinition = @'
-foo `
--bar |
-baz
-'@
-            $expected = @'
-foo `
-    -bar |
-        baz
-'@
-            Invoke-FormatterAssertion $scriptDefinition $expected 2 $settings
-        }
-
-        It "When a comment is in the middle of a multi-line statement with preceding pipeline and succeeding line continuation 3" {
-            $scriptDefinition = @'
-foo `
-# comment
--bar |
-baz
-'@
-            $expected = @'
-foo `
-    # comment
-    -bar |
-        baz
-'@
-            Invoke-FormatterAssertion $scriptDefinition $expected 3 $settings
-        }
-
         It "Should find a violation if a pipleline element is not indented correctly" {
             $def = @'
 get-process |


### PR DESCRIPTION
## PR Summary

This is a test that I will add in the future (as I still need to work on the functionality itself, unfortunately I committed the test already by accident when updating the changelog.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.