### PR TITLE
Add PS 7 to UseCompatibleSyntax

### DIFF
--- a/Rules/CompatibilityRules/UseCompatibleSyntax.cs
+++ b/Rules/CompatibilityRules/UseCompatibleSyntax.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             s_v4,
             s_v5,
             s_v6,
-            s_v7
+            s_v7,
         };
 
         /// <summary>

--- a/Rules/CompatibilityRules/UseCompatibleSyntax.cs
+++ b/Rules/CompatibilityRules/UseCompatibleSyntax.cs
@@ -29,12 +29,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         private static readonly Version s_v6 = new Version(6,0);
 
+        private static readonly Version s_v7 = new Version(7,0);
+
         private static readonly IReadOnlyList<Version> s_targetableVersions = new []
         {
             s_v3,
             s_v4,
             s_v5,
-            s_v6
+            s_v6,
+            s_v7
         };
 
         /// <summary>
@@ -123,7 +126,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             if (versionSettings == null || versionSettings.Length <= 0)
             {
-                return new HashSet<Version>(){ s_v5, s_v6 };
+                return new HashSet<Version>(){ s_v5, s_v6, s_v7 };
             }
 
             var targetVersions = new HashSet<Version>();
@@ -278,7 +281,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 // Look for PowerShell workflows in the script
 
-                if (!_targetVersions.Contains(s_v6))
+                if (!(_targetVersions.Contains(s_v6) || _targetVersions.Contains(s_v7)))
                 {
                     return AstVisitAction.Continue;
                 }


### PR DESCRIPTION
## PR Summary

Adds PS 7 recognition to UseCompatibleSyntax

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.