### PR TITLE
Change helper to implement IDisposable and clean up the runspace pool

### DIFF
--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
     /// <summary>
     /// Provides threadsafe caching around CommandInfo lookups with `Get-Command -Name ...`.
     /// </summary>
-    internal class CommandInfoCache
+    internal class CommandInfoCache : IDisposable
     {
         private readonly ConcurrentDictionary<CommandLookupKey, Lazy<CommandInfo>> _commandInfoCache;
         private readonly Helper _helperInstance;
@@ -21,11 +21,17 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// <summary>
         /// Create a fresh command info cache instance.
         /// </summary>
-        public CommandInfoCache(Helper pssaHelperInstance, RunspacePool runspacePool)
+        public CommandInfoCache(Helper pssaHelperInstance)
         {
             _commandInfoCache = new ConcurrentDictionary<CommandLookupKey, Lazy<CommandInfo>>();
             _helperInstance = pssaHelperInstance;
-            _runspacePool = runspacePool;
+            _runspacePool = RunspaceFactory.CreateRunspacePool(1, 10);
+            _runspacePool.Open();
+        }
+
+        public void Dispose()
+        {
+            _runspacePool.Dispose();
         }
 
         /// <summary>

--- a/Tests/Engine/Helper.tests.ps1
+++ b/Tests/Engine/Helper.tests.ps1
@@ -26,4 +26,11 @@ Describe "Test Directed Graph" {
             $digraph.IsConnected('v1', 'v4') | Should -BeTrue
         }
     }
+
+    Context "Runspaces should be disposed" {
+        It "Running analyzer 100 times should not result in additional runspaces" {
+        $null = 1..100 | %{ Invoke-ScriptAnalyzer -ScriptDefinition 'gci' }
+        (Get-Runspace).Count | Should -BeLessThan 10
+        }
+    }
 }


### PR DESCRIPTION
## PR Summary

The Helper is recreated with every invocation of Invoke-ScriptAnalyzer which essentially results in a runspace which was not cleaned up for every invocation. I saw 100s of runspaces (ia get-runspace) in my session. I also gave the CommandInfoCache it's own runspace pool and implemented IDisposable in it. Lastly, I've added a test to catch this in the future.

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.