### PR TITLE
Cleanup using statements and namespaces in C# code

### DIFF
--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Management.Automation;
 using System.Linq;
+using System.Management.Automation;
 using System.Management.Automation.Runspaces;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
@@ -39,12 +39,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
         protected virtual void Dispose(bool disposing)
         {
-            if ( disposed )
+            if (disposed)
             {
                 return;
             }
 
-            if ( disposing )
+            if (disposing)
             {
                 _runspacePool.Dispose();
             }

--- a/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
+++ b/Engine/Commands/GetScriptAnalyzerRuleCommand.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             {
                 if (severity != null)
                 {
-                    var ruleSeverity = severity.Select(item => Enum.Parse(typeof (RuleSeverity), item, true));
+                    var ruleSeverity = severity.Select(item => Enum.Parse(typeof(RuleSeverity), item, true));
                     rules = rules.Where(item => ruleSeverity.Contains(item.GetSeverity())).ToList();
                 }
 

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -319,11 +319,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                         settingsObj?.CustomRulePath?.ToArray(),
                         this.SessionState,
                         combRecurseCustomRulePath);
-                    combRulePaths = rulePaths == null
-                                                ? settingsCustomRulePath
-                                                : settingsCustomRulePath == null
-                                                    ? rulePaths
-                                                    : rulePaths.Concat(settingsCustomRulePath).ToArray();
+                combRulePaths = rulePaths == null
+                                            ? settingsCustomRulePath
+                                            : settingsCustomRulePath == null
+                                                ? rulePaths
+                                                : rulePaths.Concat(settingsCustomRulePath).ToArray();
             }
             catch (Exception exception)
             {

--- a/Engine/Generic/AvoidCmdletGeneric.cs
+++ b/Engine/Generic/AvoidCmdletGeneric.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// GetSourceType: Retrieves the source type of the rule.
         /// </summary>
         /// <returns>The source type of the rule.</returns>
-        public abstract  SourceType GetSourceType();
+        public abstract SourceType GetSourceType();
 
         /// <summary>
         /// GetSeverity: Retrieves the severity of the rule: error, warning of information.

--- a/Engine/Generic/AvoidParameterGeneric.cs
+++ b/Engine/Generic/AvoidParameterGeneric.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// GetSourceType: Retrieves the source type of the rule.
         /// </summary>
         /// <returns>The source type of the rule.</returns>
-        public abstract  SourceType GetSourceType();
+        public abstract SourceType GetSourceType();
 
         /// <summary>
         /// RuleSeverity: Returns the severity of the rule.

--- a/Engine/Generic/CorrectionExtent.cs
+++ b/Engine/Generic/CorrectionExtent.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             }
         }
 
-       private string file;
-       private string description;
+        private string file;
+        private string description;
 
         public CorrectionExtent(
             int startLineNumber,

--- a/Engine/Generic/DiagnosticRecord.cs
+++ b/Engine/Generic/DiagnosticRecord.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// </summary>
         public string ScriptName
         {
-            get { return string.IsNullOrEmpty(scriptPath) ? string.Empty : System.IO.Path.GetFileName(scriptPath);}
+            get { return string.IsNullOrEmpty(scriptPath) ? string.Empty : System.IO.Path.GetFileName(scriptPath); }
         }
 
         /// <summary>
@@ -88,7 +88,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// </summary>
         public IEnumerable<CorrectionExtent> SuggestedCorrections
         {
-            get { return suggestedCorrections;  }            
+            get { return suggestedCorrections; }
             set { suggestedCorrections = value; }
         }
 
@@ -99,7 +99,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         {
 
         }
-        
+
         /// <summary>
         /// DiagnosticRecord: The constructor for DiagnosticRecord class that takes in suggestedCorrection
         /// </summary>
@@ -111,9 +111,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <param name="suggestedCorrections">The correction suggested by the rule to replace the extent text</param>
         public DiagnosticRecord(string message, IScriptExtent extent, string ruleName, DiagnosticSeverity severity, string scriptPath, string ruleId = null, IEnumerable<CorrectionExtent> suggestedCorrections = null)
         {
-            Message  = message;
+            Message = message;
             RuleName = ruleName;
-            Extent   = extent;
+            Extent = extent;
             Severity = severity;
             ScriptPath = scriptPath;
             RuleSuppressionID = ruleId;
@@ -131,21 +131,21 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <summary>
         /// Information: This diagnostic is trivial, but may be useful.
         /// </summary>
-        Information   = 0,
+        Information = 0,
 
         /// <summary>
         /// WARNING: This diagnostic may cause a problem or does not follow PowerShell's recommended guidelines.
         /// </summary>
-        Warning  = 1,
+        Warning = 1,
 
         /// <summary>
         /// ERROR: This diagnostic is likely to cause a problem or does not follow PowerShell's required guidelines.
         /// </summary>
-        Error    = 2,
+        Error = 2,
 
         /// <summary>
         /// ERROR: This diagnostic is caused by an actual parsing error, and is generated only by the engine.
         /// </summary>
-        ParseError    = 3,
+        ParseError = 3,
     };
 }

--- a/Engine/Generic/ExternalRule.cs
+++ b/Engine/Generic/ExternalRule.cs
@@ -9,10 +9,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
     {
         #region Methods
 
-        string name    = string.Empty;
+        string name = string.Empty;
         string commonName = string.Empty;
-        string desc    = string.Empty;
-        string param   = string.Empty;
+        string desc = string.Empty;
+        string param = string.Empty;
         string srcName = string.Empty;
         string modPath = string.Empty;
         string paramType = string.Empty;
@@ -71,7 +71,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         #endregion
 
         #region Constructors
-        
+
         public ExternalRule()
         {
 
@@ -79,10 +79,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
 
         public ExternalRule(string name, string commonName, string desc, string param, string paramType, string srcName, string modPath)
         {
-            this.name    = name;
+            this.name = name;
             this.commonName = commonName;
-            this.desc    = desc;
-            this.param   = param;
+            this.desc = desc;
+            this.param = param;
             this.srcName = srcName;
             this.modPath = modPath;
             this.paramType = paramType;

--- a/Engine/Generic/IDSCResourceRule.cs
+++ b/Engine/Generic/IDSCResourceRule.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <returns>The results of the analysis</returns>
         IEnumerable<DiagnosticRecord> AnalyzeDSCResource(Ast ast, string fileName);
 
-        #if !PSV3
+#if !PSV3
 
         /// <summary>
         /// Analyze dsc classes (if any) in the file
@@ -29,7 +29,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <returns></returns>
         IEnumerable<DiagnosticRecord> AnalyzeDSCClass(Ast ast, string fileName);
 
-        #endif
+#endif
 
     }
 }

--- a/Engine/Generic/ILogger.cs
+++ b/Engine/Generic/ILogger.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands;
+using System;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
 {

--- a/Engine/Generic/ModuleDependencyHandler.cs
+++ b/Engine/Generic/ModuleDependencyHandler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
     // TODO Support for verbose mode    
     public class ModuleDependencyHandler : IDisposable
     {
-#region Private Variables
+        #region Private Variables
         private Runspace runspace;
         private string moduleRepository;
         private string tempPath; // path to the user temporary directory 
@@ -30,9 +30,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         private string symLinkPath;
         private string oldPSModulePath;
         private string curPSModulePath;
-#endregion Private Variables
+        #endregion Private Variables
 
-#region Properties
+        #region Properties
         /// <summary>
         /// Path where the object stores the modules
         /// </summary>
@@ -84,7 +84,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
                     : value;
 #endif
             }
-        }        
+        }
 
         /// <summary>
         /// Module Respository
@@ -114,7 +114,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             {
                 return pssaAppDataPath;
             }
-        }        
+        }
 
         /// <summary>
         /// Module Paths
@@ -123,26 +123,26 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         {
             get { return curPSModulePath; }
         }
-       
+
         /// <summary>
         /// Runspace in which the object invokes powershell cmdlets
         /// </summary>
-        public Runspace Runspace    
+        public Runspace Runspace
         {
             get { return runspace; }
             set { runspace = value; }
         }
 
 
-#endregion Properties
+        #endregion Properties
 
-#region Private Methods
+        #region Private Methods
         private static void ThrowIfNull<T>(T obj, string name)
         {
             if (obj == null)
             {
                 throw new ArgumentNullException(name);
-            }            
+            }
         }
 
         private void SetupPSSAAppData()
@@ -154,17 +154,17 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
                 if (File.Exists(symLinkPath))
                 {
                     tempModulePath = GetTempModulePath(symLinkPath);
-                    
+
                     // check if the temp dir exists
                     if (Directory.Exists(tempModulePath))
                     {
                         return;
                     }
-                }                          
+                }
             }
             else
             {
-                Directory.CreateDirectory(pssaAppDataPath);                
+                Directory.CreateDirectory(pssaAppDataPath);
             }
             SetupTempDir();
         }
@@ -203,7 +203,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         // Return the first line of the file
         private string GetTempModulePath(string symLinkPath)
         {
-            string line; 
+            string line;
             using (var file = File.Open(symLinkPath, FileMode.Open))
             using (var fileStream = new StreamReader(file))
             {
@@ -232,9 +232,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             Environment.SetEnvironmentVariable("PSModulePath", oldPSModulePath, EnvironmentVariableTarget.Process);
 #endif
         }
-#endregion Private Methods
+        #endregion Private Methods
 
-#region Public Methods
+        #region Public Methods
 
         /// <summary>
         /// Creates an instance of the ModuleDependencyHandler class
@@ -271,13 +271,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
                         ? "PSScriptAnalyzer"
                         : pssaAppDataPath);
 
-            modulesFound = new Dictionary<string, PSObject>(StringComparer.OrdinalIgnoreCase);            
+            modulesFound = new Dictionary<string, PSObject>(StringComparer.OrdinalIgnoreCase);
 
             // TODO Add PSSA Version in the path
             symLinkPath = Path.Combine(pssaAppDataPath, symLinkName);
             SetupPSSAAppData();
             SetupPSModulePath();
-            
+
         }
 
         /// <summary>
@@ -309,7 +309,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         {
             ThrowIfNull(moduleName, "moduleName");
             if (IsModulePresentInTempModulePath(moduleName))
-            {                
+            {
                 return;
             }
             using (var ps = System.Management.Automation.PowerShell.Create())
@@ -411,7 +411,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             ThrowIfNull(ast, "ast");
             var statement = ast.Find(x => x.Extent.Equals(error.Extent), true);
             var dynamicKywdAst = statement as DynamicKeywordStatementAst;
-                if (dynamicKywdAst == null)
+            if (dynamicKywdAst == null)
             {
                 return null;
             }
@@ -455,14 +455,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
                     continue;
                 }
             }
-            
+
             var modules = new List<string>();
-            
+
             var paramValAst = dynamicKywdAst.CommandElements[positionOfModuleNameParamter];
 
             // import-dscresource -ModuleName module1
             if (paramValAst is StringConstantExpressionAst paramValStrConstExprAst)
-            {                
+            {
                 modules.Add(paramValStrConstExprAst.Value);
 
                 // import-dscresource -ModuleName module1 -ModuleVersion major.minor.patch.build
@@ -520,7 +520,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             RestorePSModulePath();
         }
 
-#endregion Public Methods
+        #endregion Public Methods
     }
 }
 #endif // !PSV3

--- a/Engine/Generic/RuleInfo.cs
+++ b/Engine/Generic/RuleInfo.cs
@@ -100,11 +100,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <param name="sourceName">Source name of the rule.</param>
         public RuleInfo(string name, string commonName, string description, SourceType sourceType, string sourceName, RuleSeverity severity)
         {
-            RuleName        = name;
-            CommonName  = commonName;
+            RuleName = name;
+            CommonName = commonName;
             Description = description;
-            SourceType  = sourceType;
-            SourceName  = sourceName;
+            SourceType = sourceType;
+            SourceName = sourceName;
             Severity = severity;
         }
 
@@ -119,11 +119,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <param name="implementingType">The dotnet type of the rule.</param>
         public RuleInfo(string name, string commonName, string description, SourceType sourceType, string sourceName, RuleSeverity severity, Type implementingType)
         {
-            RuleName        = name;
-            CommonName  = commonName;
+            RuleName = name;
+            CommonName = commonName;
             Description = description;
-            SourceType  = sourceType;
-            SourceName  = sourceName;
+            SourceType = sourceType;
+            SourceName = sourceName;
             Severity = severity;
             ImplementingType = implementingType;
         }

--- a/Engine/Generic/RuleSeverity.cs
+++ b/Engine/Generic/RuleSeverity.cs
@@ -26,6 +26,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <summary>
         /// ERROR: This diagnostic is caused by an actual parsing error, and is generated only by the engine.
         /// </summary>
-        ParseError    = 3,
+        ParseError = 3,
     };
 }

--- a/Engine/Generic/RuleSuppression.cs
+++ b/Engine/Generic/RuleSuppression.cs
@@ -333,12 +333,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
                     {
                         targetAsts = scopeAst.FindAll(ast => ast is FunctionDefinitionAst && reg.IsMatch((ast as FunctionDefinitionAst).Name), true);
                     }
-                    #if !(PSV3 || PSV4)
+#if !(PSV3 || PSV4)
                     else if (scope.Equals("class", StringComparison.OrdinalIgnoreCase))
                     {
                         targetAsts = scopeAst.FindAll(ast => ast is TypeDefinitionAst && reg.IsMatch((ast as TypeDefinitionAst).Name), true);
                     }
-                    #endif
+#endif
 
                     if (targetAsts != null)
                     {

--- a/Engine/Generic/SourceType.cs
+++ b/Engine/Generic/SourceType.cs
@@ -21,6 +21,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <summary>
         /// MODULE: Indicates the script analyzer rule is contributed as a Windows PowerShell module rule.
         /// </summary>
-        Module  = 2,
+        Module = 2,
     };
 }

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -11,7 +11,6 @@ using System.IO;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Language;
-using System.Management.Automation.Runspaces;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 {
@@ -99,9 +98,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// </summary>
         private Dictionary<Ast, VariableAnalysis> VariableAnalysisDictionary;
 
-        private string[] functionScopes = new string[] { "global:", "local:", "script:", "private:"};
+        private string[] functionScopes = new string[] { "global:", "local:", "script:", "private:" };
 
-        private string[] variableScopes = new string[] { "global:", "local:", "script:", "private:", "variable:", ":"};
+        private string[] variableScopes = new string[] { "global:", "local:", "script:", "private:", "variable:", ":" };
 
         /// <summary>
         /// Store of command info objects for commands. Memoizes results.
@@ -518,7 +517,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 return false;
             }
 
-            #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
 
             List<string> dscResourceFunctionNames = new List<string>(new string[] { "Test", "Get", "Set" });
 
@@ -534,7 +533,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 return true;
             }
 
-            #endif
+#endif
 
             return false;
         }
@@ -650,8 +649,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             int argumentsWithoutProcedingParameters = 0;
 
             var commandElementCollection = cmdAst.CommandElements;
-            for (int i = 1; i < commandElementCollection.Count(); i++) {
-                if (!(commandElementCollection[i] is CommandParameterAst) && !(commandElementCollection[i-1] is CommandParameterAst))
+            for (int i = 1; i < commandElementCollection.Count(); i++)
+            {
+                if (!(commandElementCollection[i] is CommandParameterAst) && !(commandElementCollection[i - 1] is CommandParameterAst))
                 {
                     argumentsWithoutProcedingParameters++;
                 }
@@ -1087,7 +1087,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
 #else
 
-                return GetTypeFromMemberExpressionAstHelper(memberAst, psClass, details);
+            return GetTypeFromMemberExpressionAstHelper(memberAst, psClass, details);
 
 #endif
         }
@@ -1433,9 +1433,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             return result;
         }
 
-        private Tuple<int,int>[] GetOffsetArray(List<DiagnosticRecord> diagnostics)
+        private Tuple<int, int>[] GetOffsetArray(List<DiagnosticRecord> diagnostics)
         {
-            Func<int,int,Tuple<int,int>> GetTuple = (x, y) => new Tuple<int, int>(x, y);
+            Func<int, int, Tuple<int, int>> GetTuple = (x, y) => new Tuple<int, int>(x, y);
             Func<Tuple<int, int>> GetDefaultTuple = () => GetTuple(0, 0);
             var offsets = new Tuple<int, int>[diagnostics.Count];
             for (int k = 0; k < diagnostics.Count; k++)
@@ -1867,7 +1867,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             return psVersionTable == null ? null : psVersionTable.PSVersion;
         }
 
-#endregion Methods
+        #endregion Methods
     }
 
 
@@ -3752,11 +3752,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 return true;
             }
 
-            foreach(var vertexIdx in graph[fromIdx])
+            foreach (var vertexIdx in graph[fromIdx])
             {
                 if (!visited[vertexIdx])
                 {
-                    if(IsConnected(vertexIdx, toIdx, ref visited))
+                    if (IsConnected(vertexIdx, toIdx, ref visited))
                     {
                         return true;
                     }

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -45,9 +45,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 #if !PSV3
         ModuleDependencyHandler moduleHandler;
 #endif
-#endregion
+        #endregion
 
-#region Singleton
+        #region Singleton
         private static object syncRoot = new Object();
         private static ScriptAnalyzer instance;
         public static ScriptAnalyzer Instance
@@ -91,7 +91,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         internal List<ExternalRule> ExternalRules { get; set; }
 
 #if !PSV3
-        public ModuleDependencyHandler ModuleHandler {
+        public ModuleDependencyHandler ModuleHandler
+        {
             get
             {
                 return moduleHandler;
@@ -104,9 +105,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         }
 #endif
 
-#endregion
+        #endregion
 
-#region Methods
+        #region Methods
 
         /// <summary>
         /// Initialize : Initializes default rules, loggers and helper.
@@ -684,7 +685,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             this.outputWriter = outputWriter;
 
-#region Verifies rule extensions
+            #region Verifies rule extensions
 
             List<string> paths = this.GetValidCustomRulePaths(customizedRulePath, path);
 
@@ -794,9 +795,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                         ErrorCategory.NotSpecified, this));
             }
 
-#endregion
+            #endregion
 
-#region Verify rules
+            #region Verify rules
 
             // Safely get one non-duplicated list of rules
             IEnumerable<IRule> rules =
@@ -819,7 +820,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                         this));
             }
 
-#endregion
+            #endregion
         }
 
         private List<string> GetValidCustomRulePaths(string[] customizedRulePath, PathIntrinsics path)
@@ -1118,7 +1119,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                             // Retrieve "Description" field in the help content
                             string desc = String.Empty;
 
-                            if ((null != helpContent) && ( 1 == helpContent.Count))
+                            if ((null != helpContent) && (1 == helpContent.Count))
                             {
                                 dynamic description = helpContent[0].Properties["Description"];
 
@@ -1184,7 +1185,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 // Defines the command results.
                 List<IAsyncResult> powerShellCommandResults = new List<IAsyncResult>();
 
-#region Builds and invokes commands list
+                #region Builds and invokes commands list
 
                 foreach (KeyValuePair<string, List<ExternalRule>> tokenRuleGroup in tokenRuleGroups)
                 {
@@ -1237,8 +1238,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     }
                 }
 
-#endregion
-#region Collects the results from commands.
+                #endregion
+                #region Collects the results from commands.
                 List<DiagnosticRecord> diagnostics = new List<DiagnosticRecord>();
                 try
                 {
@@ -1303,7 +1304,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 }
 
                 return diagnostics;
-#endregion
+                #endregion
             }
         }
 
@@ -1350,7 +1351,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                                 && loadedModules.Count > 0
                                 && loadedModules.First().ExportedFunctions.Count > 0)
                         {
-                                validModPaths.Add(resolvedPath);
+                            validModPaths.Add(resolvedPath);
                         }
                     }
                 }
@@ -1520,10 +1521,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             var relevantParseErrors = RemoveTypeNotFoundParseErrors(errors, out List<DiagnosticRecord> diagnosticRecords);
 
             // Add parse errors first if requested!
-            if ( relevantParseErrors != null && (severity == null || severity.Contains("ParseError", StringComparer.OrdinalIgnoreCase)))
+            if (relevantParseErrors != null && (severity == null || severity.Contains("ParseError", StringComparer.OrdinalIgnoreCase)))
             {
                 var results = new List<DiagnosticRecord>();
-                foreach ( ParseError parseError in relevantParseErrors )
+                foreach (ParseError parseError in relevantParseErrors)
                 {
                     string parseErrorMessage = String.Format(CultureInfo.CurrentCulture, Strings.ParseErrorFormatForScriptDefinition, parseError.Message.TrimEnd('.'), parseError.Extent.StartLineNumber, parseError.Extent.StartColumnNumber);
                     results.Add(new DiagnosticRecord(
@@ -1805,7 +1806,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 {
                     continue;
                 }
-                foreach(var moduleName in moduleNames)
+                foreach (var moduleName in moduleNames)
                 {
                     this.outputWriter.WriteVerbose(
                         String.Format(
@@ -1836,7 +1837,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             var diagnosticRecords = new List<DiagnosticRecord>();
 
             // If the file doesn't exist, return
-            if (! File.Exists(filePath))
+            if (!File.Exists(filePath))
             {
                 this.outputWriter.ThrowTerminatingError(new ErrorRecord(new FileNotFoundException(),
                     string.Format(CultureInfo.CurrentCulture, Strings.InvalidPath, filePath),
@@ -1847,7 +1848,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             // short-circuited processing for a help file
             // no parsing can really be done, but there are other rules to run (specifically encoding).
-            if ( s_aboutHelpRegex.IsMatch(Path.GetFileName(filePath)) )
+            if (s_aboutHelpRegex.IsMatch(Path.GetFileName(filePath)))
             {
                 return diagnosticRecords.Concat(this.AnalyzeSyntaxTree(scriptAst, scriptTokens, filePath));
             }
@@ -1872,10 +1873,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             IEnumerable<ParseError> relevantParseErrors = RemoveTypeNotFoundParseErrors(errors, out diagnosticRecords);
 
             // First, add all parse errors if they've been requested
-            if ( relevantParseErrors != null && (severity == null || severity.Contains("ParseError", StringComparer.OrdinalIgnoreCase)))
+            if (relevantParseErrors != null && (severity == null || severity.Contains("ParseError", StringComparer.OrdinalIgnoreCase)))
             {
                 List<DiagnosticRecord> results = new List<DiagnosticRecord>();
-                foreach ( ParseError parseError in relevantParseErrors )
+                foreach (ParseError parseError in relevantParseErrors)
                 {
                     string parseErrorMessage = String.Format(CultureInfo.CurrentCulture, Strings.ParseErrorFormatForScriptDefinition, parseError.Message.TrimEnd('.'), parseError.Extent.StartLineNumber, parseError.Extent.StartColumnNumber);
                     results.Add(new DiagnosticRecord(
@@ -2024,7 +2025,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             Token[] scriptTokens,
             string filePath)
         {
-            Dictionary<string, List<RuleSuppression>> ruleSuppressions = new Dictionary<string,List<RuleSuppression>>();
+            Dictionary<string, List<RuleSuppression>> ruleSuppressions = new Dictionary<string, List<RuleSuppression>>();
             ConcurrentBag<DiagnosticRecord> diagnostics = new ConcurrentBag<DiagnosticRecord>();
             ConcurrentBag<SuppressedRecord> suppressed = new ConcurrentBag<SuppressedRecord>();
             BlockingCollection<List<object>> verboseOrErrors = new BlockingCollection<List<object>>();
@@ -2053,18 +2054,18 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     }
                 }
 
-#region Run VariableAnalysis
+                #region Run VariableAnalysis
                 try
                 {
                     Helper.Instance.InitializeVariableAnalysis(scriptAst);
                 }
                 catch { }
-#endregion
+                #endregion
 
                 Helper.Instance.Tokens = scriptTokens;
             }
 
-#region Run ScriptRules
+            #region Run ScriptRules
             //Trim down to the leaf element of the filePath and pass it to Diagnostic Record
             string fileName = filePathIsNullOrWhiteSpace ? String.Empty : System.IO.Path.GetFileName(filePath);
             if (this.ScriptRules != null)
@@ -2142,9 +2143,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 }
             }
 
-#endregion
+            #endregion
 
-#region Run Token Rules
+            #region Run Token Rules
 
             if (this.TokenRules != null && !helpFile)
             {
@@ -2177,9 +2178,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 }
             }
 
-#endregion
+            #endregion
 
-#region DSC Resource Rules
+            #region DSC Resource Rules
             if (this.DSCResourceRules != null && !helpFile)
             {
                 // Invoke AnalyzeDSCClass only if the ast is a class based resource
@@ -2258,9 +2259,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                 }
             }
-#endregion
+            #endregion
 
-#region Run External Rules
+            #region Run External Rules
 
             if (this.ExternalRules != null && !helpFile)
             {

--- a/Engine/SpecialVars.cs
+++ b/Engine/SpecialVars.cs
@@ -46,23 +46,23 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 OtherInitializedVariables))).ToArray();
         }
 
-        internal static readonly string[] AutomaticVariables = new string[]  
-                                                               {  
-                                                                   Underbar,  
-                                                                   Args,  
-                                                                   This,  
-                                                                   Input,  
-                                                                   PSCmdlet,  
-                                                                   PSBoundParameters,  
-                                                                   MyInvocation,  
-                                                                   PSScriptRoot,  
+        internal static readonly string[] AutomaticVariables = new string[]
+                                                               {
+                                                                   Underbar,
+                                                                   Args,
+                                                                   This,
+                                                                   Input,
+                                                                   PSCmdlet,
+                                                                   PSBoundParameters,
+                                                                   MyInvocation,
+                                                                   PSScriptRoot,
                                                                    PSCommandPath,
                                                                    ExecutionContext,
                                                                    Matches,
                                                                    PSVersionTable,
                                                                    OFS
                                                                };
-        internal static readonly Type[] AutomaticVariableTypes = new Type[]  
+        internal static readonly Type[] AutomaticVariableTypes = new Type[]
                                                                  {  
                                                                    /* Underbar */          typeof(object),  
                                                                    /* Args */              typeof(object[]),  

--- a/Engine/TextEdit.cs
+++ b/Engine/TextEdit.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Microsoft.Windows.PowerShell.ScriptAnalyzer.Extensions;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 {

--- a/Engine/VariableAnalysis.cs
+++ b/Engine/VariableAnalysis.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                             foreach (NamedAttributeArgumentAst arg in args)
                             {
                                 if (String.Equals(arg.ArgumentName, "mandatory", StringComparison.OrdinalIgnoreCase))
-                               {
+                                {
                                     // check for the case mandatory=$true and just mandatory
                                     if (arg.ExpressionOmitted || (!arg.ExpressionOmitted && String.Equals(arg.Argument.Extent.Text, "$true", StringComparison.OrdinalIgnoreCase)))
                                     {
@@ -134,15 +134,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         public void AnalyzeImpl(Ast ast, VariableAnalysis outerAnalysis)
         {
 
-            #if PSV3
+#if PSV3
 
             if (!(ast is ScriptBlockAst || ast is FunctionDefinitionAst))
             
-            #else            
+#else
 
             if (!(ast is ScriptBlockAst || ast is FunctionMemberAst || ast is FunctionDefinitionAst))
 
-            #endif
+#endif
             {
                 return;
             }
@@ -151,15 +151,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             Init();
 
-            #if PSV3
+#if PSV3
 
             if (ast is FunctionDefinitionAst)
 
-            #else
+#else
 
             if (ast is FunctionMemberAst || ast is FunctionDefinitionAst)
 
-            #endif
+#endif
             {
                 IEnumerable<ParameterAst> parameters = FindParameters(ast, ast.GetType());
                 if (parameters != null)
@@ -176,19 +176,19 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 }
             }
 
-            #if PSV3
+#if PSV3
 
             if (ast is FunctionDefinitionAst)
 
-            #else
+#else
 
             if (ast is FunctionMemberAst)
             {
                 (ast as FunctionMemberAst).Body.Visit(this.Decorator);
             }
             else if (ast is FunctionDefinitionAst)
-            
-            #endif
+
+#endif
 
             {
                 (ast as FunctionDefinitionAst).Body.Visit(this.Decorator);
@@ -205,13 +205,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 parent = parent.Parent;
             }
 
-            #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
 
             List<TypeDefinitionAst> classes = parent.FindAll(item =>
                 item is TypeDefinitionAst && (item as TypeDefinitionAst).IsClass, true)
                 .Cast<TypeDefinitionAst>().ToList();
 
-            #endif
+#endif
 
             if (outerAnalysis != null)
             {
@@ -250,15 +250,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 }
             }
 
-            #if PSV3
+#if PSV3
 
             var dictionaries = Block.SparseSimpleConstants(_variables, Entry);
 
-            #else
+#else
 
             var dictionaries = Block.SparseSimpleConstants(_variables, Entry, classes);
 
-            #endif
+#endif
             VariablesDictionary = dictionaries.Item1;
             InternalVariablesDictionary = new Dictionary<string, VariableAnalysisDetails>(StringComparer.OrdinalIgnoreCase);
 
@@ -365,8 +365,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
 
             return analysis.DefinedBlock == null
-                && !(SpecialVars.InitializedVariables.Contains(analysis.Name, StringComparer.OrdinalIgnoreCase) || 
-                SpecialVars.InitializedVariables.Contains(analysis.RealName, StringComparer.OrdinalIgnoreCase)) 
+                && !(SpecialVars.InitializedVariables.Contains(analysis.Name, StringComparer.OrdinalIgnoreCase) ||
+                SpecialVars.InitializedVariables.Contains(analysis.RealName, StringComparer.OrdinalIgnoreCase))
                 && !IsGlobalOrEnvironment(varTarget);
         }
 

--- a/Engine/VariableAnalysisBase.cs
+++ b/Engine/VariableAnalysisBase.cs
@@ -97,15 +97,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// <returns></returns>
         public static Dictionary<string, VariableAnalysisDetails> Visit(Ast ast)
         {
-            #if PSV3
+#if PSV3
 
             if (!(ast is ScriptBlockAst || ast is FunctionDefinitionAst))
 
-            #else
+#else
 
             if (!(ast is ScriptBlockAst || ast is FunctionMemberAst || ast is FunctionDefinitionAst))
 
-            #endif
+#endif
 
             {
                 return null;
@@ -123,25 +123,25 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 (ast as ScriptBlockAst).Visit(visitor);
             }
 
-            #if !PSV3
+#if !PSV3
 
             else if (ast is FunctionMemberAst)
             {
                 (ast as FunctionMemberAst).Body.Visit(visitor);
             }
 
-            #endif
+#endif
 
             else if (ast is FunctionDefinitionAst)
             {
                 (ast as FunctionDefinitionAst).Body.Visit(visitor);
             }
 
-            #if PSV3
+#if PSV3
 
             if (ast is FunctionDefinitionAst && (ast as FunctionDefinitionAst).Parameters != null)
 
-            #else
+#else
 
             if (ast is FunctionMemberAst && (ast as FunctionMemberAst).Parameters != null)
             {
@@ -149,7 +149,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
             else if (ast is FunctionDefinitionAst && (ast as FunctionDefinitionAst).Parameters != null)
 
-            #endif
+#endif
             {
                 visitor.VisitParameters((ast as FunctionDefinitionAst).Parameters);
             }
@@ -165,7 +165,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             _variables.Add("true", new VariableAnalysisDetails { Name = "true", RealName = "true", Type = typeof(bool) });
             _variables.Add("false", new VariableAnalysisDetails { Name = "false", RealName = "true", Type = typeof(bool) });
 
-            #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
 
             if (ast is FunctionMemberAst)
             {
@@ -176,7 +176,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 }
             }
 
-            #endif
+#endif
 
         }
 
@@ -808,16 +808,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// <param name="Entry"></param>
         /// <param name="Classes"></param>
         /// <returns></returns>        
-        #if (PSV3||PSV4)
+#if (PSV3 || PSV4)
 
         internal static Tuple<Dictionary<string, VariableAnalysisDetails>, Dictionary<string, VariableAnalysisDetails>> SparseSimpleConstants(
              Dictionary<string, VariableAnalysisDetails> Variables, Block Entry)
 
-        #else            
-            internal static Tuple<Dictionary<string, VariableAnalysisDetails>, Dictionary<string, VariableAnalysisDetails>> SparseSimpleConstants(
-            Dictionary<string, VariableAnalysisDetails> Variables, Block Entry, List<TypeDefinitionAst> Classes)
+#else
+        internal static Tuple<Dictionary<string, VariableAnalysisDetails>, Dictionary<string, VariableAnalysisDetails>> SparseSimpleConstants(
+        Dictionary<string, VariableAnalysisDetails> Variables, Block Entry, List<TypeDefinitionAst> Classes)
 
-        #endif
+#endif
         {
             List<Block> blocks = GenerateReverseDepthFirstOrder(Entry);
 
@@ -989,16 +989,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                             {
                                 VariableAnalysisDetails analysis = VariablesDictionary[VariableAnalysis.AnalysisDictionaryKey(memAst.Expression as VariableExpressionAst)];
 
-                                #if (PSV3||PSV4)
+#if (PSV3 || PSV4)
 
                                 Type possibleType = AssignmentTarget.GetTypeFromMemberExpressionAst(memAst, analysis);
 
-                                #else
+#else
 
                                 TypeDefinitionAst psClass = Classes.FirstOrDefault(item => String.Equals(item.Name, analysis.Type.FullName, StringComparison.OrdinalIgnoreCase));
                                 Type possibleType = AssignmentTarget.GetTypeFromMemberExpressionAst(memAst, analysis, psClass);
 
-                                #endif
+#endif
 
                                 if (possibleType != null && possibleType != assigned.Type)
                                 {
@@ -1370,23 +1370,23 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// <param name="memAst"></param>
         /// <param name="psClass"></param>
         /// <returns></returns>
-        
-        #if (PSV3||PSV4)
+
+#if (PSV3 || PSV4)
 
         internal static Type GetTypeFromMemberExpressionAst(MemberExpressionAst memAst, VariableAnalysisDetails analysis)
 
-        #else
+#else
 
         internal static Type GetTypeFromMemberExpressionAst(MemberExpressionAst memAst, VariableAnalysisDetails analysis, TypeDefinitionAst psClass)
 
-        #endif        
+#endif
         {
             if (memAst != null && memAst.Expression is VariableExpressionAst && memAst.Member is StringConstantExpressionAst
                 && !String.Equals((memAst.Expression as VariableExpressionAst).VariablePath.UserPath, "this", StringComparison.OrdinalIgnoreCase))
             {
                 string fieldName = (memAst.Member as StringConstantExpressionAst).Value;
 
-                #if !PSV3
+#if !PSV3
 
                 if (psClass == null && analysis.Constant == SpecialVars.ThisVariable)
                 {
@@ -1404,7 +1404,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     }
                 }
 
-                #endif
+#endif
 
                 // If the type is not a ps class or there are some types of the same name.
                 if (analysis != null && analysis.Type != null && analysis.Type != typeof(object)
@@ -1460,7 +1460,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                         // isStatic is true
                         result = GetTypeFromInvokeMemberAst(type, imeAst, methodName, true);
                     }
-                    #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
                     else
                     {
                         // Check for classes
@@ -1478,7 +1478,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                             }
                         }
                     }
-                    #endif
+#endif
                 }
 
                 #endregion
@@ -1498,7 +1498,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     {
                         result = GetPropertyOrFieldTypeFromMemberExpressionAst(expressionType, fieldName);
                     }
-                    #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
                     else
                     {
                         // check for class type
@@ -1514,7 +1514,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                             }
                         }
                     }
-                    #endif
+#endif
                 }
 
                 #endregion
@@ -1531,7 +1531,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             if (memberAst.Expression is VariableExpressionAst
                 && String.Equals((memberAst.Expression as VariableExpressionAst).VariablePath.UserPath, "this", StringComparison.OrdinalIgnoreCase))
             {
-                #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
 
                 // Check that we are in a class
                 TypeDefinitionAst psClass = FindClassAncestor(memberAst);
@@ -1539,7 +1539,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 // Is static is false for this case
                 result = GetTypeFromClass(psClass, memberAst);
 
-                #endif
+#endif
             }
 
             return result;

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Collection/CompatibilityProfileCollector.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Collection/CompatibilityProfileCollector.cs
@@ -1,15 +1,31 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Management.Automation;
-using System.Reflection;
 using Microsoft.PowerShell.Commands;
 using Microsoft.PowerShell.CrossCompatibility.Data;
 using Microsoft.PowerShell.CrossCompatibility.Utility;
+
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
+using System.Linq.Expressions;
+using System.Management.Automation;
+After:
+using System;
+using System.Collections.Automation;
+*/
+using System.Management.Generic;
+using System.Linq;
+
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
+using Microsoft.PowerShell.Commands;
+using Microsoft.PowerShell.CrossCompatibility.Data;
+After:
+using Microsoft.PowerShell.Expressions;
+using System.Management.Data;
+*/
+using System.Linq.CrossCompatibility.Automation;
+using System.Reflection;
 using SMA = System.Management.Automation;
 
 #if CoreCLR

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Collection/PlatformInformationCollector.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Collection/PlatformInformationCollector.cs
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Management.Infrastructure;
+using Microsoft.PowerShell.CrossCompatibility.Data;
+using Microsoft.PowerShell.CrossCompatibility.Utility;
+using Microsoft.Win32;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -10,10 +14,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.Management.Infrastructure;
-using Microsoft.PowerShell.CrossCompatibility.Data;
-using Microsoft.PowerShell.CrossCompatibility.Utility;
-using Microsoft.Win32;
 using SMA = System.Management.Automation;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Collection

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Collection/PowerShellDataCollector.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Collection/PowerShellDataCollector.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.Commands;
+using Microsoft.PowerShell.CrossCompatibility.Data;
+using Microsoft.PowerShell.CrossCompatibility.Utility;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -10,9 +13,6 @@ using System.Management.Automation.Internal;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using Microsoft.PowerShell.Commands;
-using Microsoft.PowerShell.CrossCompatibility.Data;
-using Microsoft.PowerShell.CrossCompatibility.Utility;
 using SMA = System.Management.Automation;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Collection
@@ -189,12 +189,12 @@ namespace Microsoft.PowerShell.CrossCompatibility.Collection
                 if (e.ErrorRecord.FullyQualifiedErrorId.Equals("FormatXmlUpdateException,Microsoft.PowerShell.Commands.ImportModuleCommand")
                     || e.ErrorRecord.FullyQualifiedErrorId.Equals("ErrorsUpdatingTypes"))
                 {
-                   foreach (string typeDataName in GetTypeDataNamesFromErrorMessage(e.Message))
-                   {
-                       _pwsh.AddCommand("Remove-TypeData")
-                            .AddParameter("TypeName", typeDataName)
-                            .InvokeAndClear();
-                   }
+                    foreach (string typeDataName in GetTypeDataNamesFromErrorMessage(e.Message))
+                    {
+                        _pwsh.AddCommand("Remove-TypeData")
+                             .AddParameter("TypeName", typeDataName)
+                             .InvokeAndClear();
+                    }
                 }
 
                 // Attempt to load the module in a new runspace instead
@@ -318,7 +318,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Collection
                             aliases.Add(alias.Name, GetSingleAliasData(alias));
                             continue;
 
-                        // Skip over other objects we get back, since there's no reason to throw
+                            // Skip over other objects we get back, since there's no reason to throw
                     }
                 }
 
@@ -440,7 +440,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Collection
             var parameterSetFlags = new List<ParameterSetFlag>();
 
             if (parameterSet.IsMandatory)
-            { 
+            {
                 parameterSetFlags.Add(ParameterSetFlag.Mandatory);
             }
 

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Collection/ProfileValidator.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Collection/ProfileValidator.cs
@@ -1,11 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
 using System;
 using System.Collections.Generic;
 using Microsoft.PowerShell.CrossCompatibility.Query;
+After:
+using Microsoft.PowerShell.CrossCompatibility.Query;
+using System;
+using System.PowerShell.CrossCompatibility.Query;
+*/
+using Microsoft.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Linq;
-using Data = Microsoft.PowerShell.CrossCompatibility.Data;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Collection
 {
@@ -34,14 +44,14 @@ namespace Microsoft.PowerShell.CrossCompatibility.Collection
     /// </summary>
     internal class QuickCheckValidator : ProfileValidator
     {
-        private static IReadOnlyCollection<string> s_commonParameters = new []
+        private static IReadOnlyCollection<string> s_commonParameters = new[]
         {
             "ErrorVariable",
             "WarningAction",
             "Verbose"
         };
 
-        private static IReadOnlyCollection<string> s_commonParameterAliases = new []
+        private static IReadOnlyCollection<string> s_commonParameterAliases = new[]
         {
             "ev",
             "wa",
@@ -50,7 +60,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Collection
 
         private static IReadOnlyDictionary<string, IReadOnlyDictionary<string, IReadOnlyCollection<string>>> s_modules = new Dictionary<string, IReadOnlyDictionary<string, IReadOnlyCollection<string>>>()
         {
-            { 
+            {
                 "Microsoft.PowerShell.Core", new Dictionary<string, IReadOnlyCollection<string>>()
                 {
                     { "Get-Module", new [] { "Name", "ListAvailable" } },
@@ -77,7 +87,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Collection
                 }
             }
         };
-        
+
         private static IReadOnlyDictionary<string, IReadOnlyDictionary<string, IReadOnlyCollection<string>>> s_ps4Modules = new Dictionary<string, IReadOnlyDictionary<string, IReadOnlyCollection<string>>>()
         {
             {
@@ -203,7 +213,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Collection
             }
             catch (Exception e)
             {
-                errors = new [] { e };
+                errors = new[] { e };
                 return false;
             }
 

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Collection/TypeDataCollector.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Collection/TypeDataCollector.cs
@@ -1,19 +1,44 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
 using System;
 using System.Collections.Generic;
+After:
+using Microsoft.PowerShell.CrossCompatibility.Data;
+using Microsoft.Collections.CrossCompatibility.Utility;
+*/
+using Microsoft.PowerShell.CrossCompatibility.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
-using System.Management.Automation;
-using System.Reflection;
-using System.Text;
+
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
 using System.Threading;
 using Microsoft.PowerShell.CrossCompatibility.Data;
 using Microsoft.PowerShell.CrossCompatibility.Utility;
 
 using SMA = System.Management.Automation;
+After:
+using System.Management.Automation;
+using System.Reflection;
 using System.Runtime.InteropServices;
+using SMA = System.Text;
+*/
+using System.Management.Automation;
+using System.Reflection;
+using System.Threading;
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
 using System.IO;
+After:
+using SMA = System.Management.Automation;
+*/
+
 
 namespace Microsoft.PowerShell.CrossCompatibility.Collection
 {
@@ -326,7 +351,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Collection
 
                         properties.Add(property.Name, AssembleProperty(property));
                         break;
-                    
+
                     case MethodInfo method:
                         if (!methods.TryGetValue(method.Name, out List<MethodInfo> overloads))
                         {
@@ -548,7 +573,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Collection
             // there's no need to override and we can just add the new overload
             existingMembers.Add(newMember);
         }
-        
+
         private static AccessorType[] GetAccessors(PropertyInfo propertyInfo)
         {
             var accessors = new List<AccessorType>();

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Commands/AssertPSCompatibilityProfileIsValidCommand.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Commands/AssertPSCompatibilityProfileIsValidCommand.cs
@@ -1,12 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
+using 
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
 using System.Collections.Generic;
 using System.Management.Automation;
 using Microsoft.PowerShell.CrossCompatibility.Collection;
+After:
+using System.Collections.CrossCompatibility.Collection;
 using Microsoft.PowerShell.CrossCompatibility.Data;
 using Microsoft.PowerShell.CrossCompatibility.Utility;
+using System;
+*/
+Microsoft.PowerShell.CrossCompatibility.Collection;
+using Microsoft.PowerShell.CrossCompatibility.Data;
+using System;
+using System.Collections.Generic;
+using System.Management.Automation;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Commands
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Commands/ConvertJsonCommands.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Commands/ConvertJsonCommands.cs
@@ -1,13 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
 using System;
 using System.IO;
 using System.Management.Automation;
 using Microsoft.PowerShell.CrossCompatibility.Data;
+After:
+using Microsoft.PowerShell.CrossCompatibility.Data;
+*/
 using Microsoft.PowerShell.CrossCompatibility.Retrieval;
-using Microsoft.PowerShell.CrossCompatibility.Utility;
 using Newtonsoft.Json;
+using System;
+using System.IO;
+using System.Management.Automation;
+using System;
+using System.IO;
+using System.Management.Automation;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Commands
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Commands/GetPSCompatibilityPlatformDataCommand.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Commands/GetPSCompatibilityPlatformDataCommand.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Management.Automation;
 using Microsoft.PowerShell.CrossCompatibility.Collection;
 using Microsoft.PowerShell.CrossCompatibility.Data;
+using System.Management.Automation;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Commands
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Commands/GetPSCompatibilityPlatformNameCommand.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Commands/GetPSCompatibilityPlatformNameCommand.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Management.Automation;
 using Microsoft.PowerShell.CrossCompatibility.Collection;
 using Microsoft.PowerShell.CrossCompatibility.Data;
-using Microsoft.PowerShell.CrossCompatibility.Utility;
+using System.Management.Automation;
+using System.Management.Automation;
 using SMA = System.Management.Automation;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Commands

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Commands/NewPSCompatibilityProfileCommand.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Commands/NewPSCompatibilityProfileCommand.cs
@@ -1,15 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.CrossCompatibility.Collection;
+using Microsoft.PowerShell.CrossCompatibility.Data;
+using Microsoft.PowerShell.CrossCompatibility.Retrieval;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
-using Microsoft.PowerShell.CrossCompatibility.Collection;
-using Microsoft.PowerShell.CrossCompatibility.Data;
-using Microsoft.PowerShell.CrossCompatibility.Retrieval;
-using Microsoft.PowerShell.CrossCompatibility.Utility;
-using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Management.Automation;
 using SMA = System.Management.Automation;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Commands

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/JsonDictionary.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/JsonDictionary.cs
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
 
 namespace Microsoft.PowerShell.CrossCompatibility
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/OSFamily.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/OSFamily.cs
@@ -26,7 +26,7 @@ namespace Microsoft.PowerShell.CrossCompatibility
         /// <summary>A macOS operating system.</summary>
         [EnumMember]
         MacOS,
-        
+
         /// <summary>A Linux operating system.</summary>
         [EnumMember]
         Linux,

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/PlatformNaming.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/PlatformNaming.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Microsoft.PowerShell.CrossCompatibility.Data;
+using System;
 
 namespace Microsoft.PowerShell.CrossCompatibility
 {
@@ -51,23 +51,23 @@ namespace Microsoft.PowerShell.CrossCompatibility
 
                     uint skuId = platform.OperatingSystem.SkuId.Value;
 
-                    platformNameComponents = new [] { $"win-{skuId}", osArch, osVersion, psVersion, pArch, dotnetVersion, dotnetEdition };
+                    platformNameComponents = new[] { $"win-{skuId}", osArch, osVersion, psVersion, pArch, dotnetVersion, dotnetEdition };
                     break;
 
                 case OSFamily.MacOS:
-                    platformNameComponents = new [] { "macos", osArch, osVersion, psVersion, pArch, dotnetVersion, dotnetEdition };
+                    platformNameComponents = new[] { "macos", osArch, osVersion, psVersion, pArch, dotnetVersion, dotnetEdition };
                     break;
 
                 case OSFamily.Linux:
                     string distroId = platform.OperatingSystem.DistributionId;
                     string distroVersion = platform.OperatingSystem.DistributionVersion;
 
-                    platformNameComponents = new [] { distroId, osArch, distroVersion, psVersion, pArch, dotnetVersion, dotnetEdition };
+                    platformNameComponents = new[] { distroId, osArch, distroVersion, psVersion, pArch, dotnetVersion, dotnetEdition };
                     break;
 
                 default:
                     // We shouldn't ever see anything like this
-                    platformNameComponents = new [] { "unknown", osArch, osVersion ?? "?", psVersion, pArch, dotnetVersion, dotnetEdition };
+                    platformNameComponents = new[] { "unknown", osArch, osVersion ?? "?", psVersion, pArch, dotnetVersion, dotnetEdition };
                     break;
             }
 

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/PowerShellVersion.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/PowerShellVersion.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Newtonsoft.Json;
 using System;
 using System.Text;
-using Newtonsoft.Json;
 
 namespace Microsoft.PowerShell.CrossCompatibility
 {
@@ -325,7 +325,7 @@ namespace Microsoft.PowerShell.CrossCompatibility
         /// <returns>True if the type can be converted, false otherwise.</returns>
         public override bool CanConvert(Type objectType)
         {
-            return 
+            return
                 objectType == typeof(Version)
                 || objectType == typeof(PowerShellVersion)
                 || objectType.FullName == "System.Management.Automation.SemanticVersion";

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/ProfileCombination.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/ProfileCombination.cs
@@ -1,11 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
 using System;
-using System.Collections;
+After:
+using Microsoft.PowerShell.CrossCompatibility.Data;
+using System;
+*/
+using Microsoft.PowerShell.CrossCompatibility.Data;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.PowerShell.CrossCompatibility.Data;
 
 namespace Microsoft.PowerShell.CrossCompatibility
 {
@@ -221,7 +228,7 @@ namespace Microsoft.PowerShell.CrossCompatibility
 
             CompatibilityProfileData mutProfileBase = (CompatibilityProfileData)profileEnumerator.Current.Clone();
 
-            while(profileEnumerator.MoveNext())
+            while (profileEnumerator.MoveNext())
             {
                 mutProfileBase = (CompatibilityProfileData)combinator(mutProfileBase, profileEnumerator.Current);
             }
@@ -319,7 +326,7 @@ namespace Microsoft.PowerShell.CrossCompatibility
 
         private static JsonDictionary<K, V> DictionaryUnion<K, V>(
             JsonDictionary<K, V> thisDict,
-            JsonDictionary<K, V> thatDict, 
+            JsonDictionary<K, V> thatDict,
             Func<V, V, object> valueUnionizer = null)
             where K : ICloneable where V : ICloneable
         {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Data/Modules/FunctionData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Data/Modules/FunctionData.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Data

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Data/Modules/ModuleData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Data/Modules/ModuleData.cs
@@ -14,34 +14,34 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data
     [DataContract]
     public class ModuleData : ICloneable
     {
-	/// <summary>
-	/// The GUID of the module.
-	/// </summary>
+        /// <summary>
+        /// The GUID of the module.
+        /// </summary>
         [DataMember]
         public Guid Guid { get; set; }
 
-	/// <summary>
-	/// Cmdlets exported by the module, keyed by name.
-	/// </summary>
+        /// <summary>
+        /// Cmdlets exported by the module, keyed by name.
+        /// </summary>
         [DataMember(EmitDefaultValue = false)]
         public JsonCaseInsensitiveStringDictionary<CmdletData> Cmdlets { get; set; }
 
-	/// <summary>
-	/// Functions exported by the module, keyed by name.
-	/// </summary>
+        /// <summary>
+        /// Functions exported by the module, keyed by name.
+        /// </summary>
         [DataMember(EmitDefaultValue = false)]
         public JsonCaseInsensitiveStringDictionary<FunctionData> Functions { get; set; }
 
-	/// <summary>
-	/// Variables exported by the module.
-	/// </summary>
+        /// <summary>
+        /// Variables exported by the module.
+        /// </summary>
         [DataMember(EmitDefaultValue = false)]
         public string[] Variables { get; set; }
 
-	/// <summary>
-	/// Aliases exported by the module, keyed by alias
-	/// name, with values being the resolved commands.
-	/// </summary>
+        /// <summary>
+        /// Aliases exported by the module, keyed by alias
+        /// name, with values being the resolved commands.
+        /// </summary>
         [DataMember(EmitDefaultValue = false)]
         public JsonCaseInsensitiveStringDictionary<string> Aliases { get; set; }
 

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Data/Platform/OperatingSystemData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Data/Platform/OperatingSystemData.cs
@@ -14,23 +14,23 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data
     [DataContract]
     public class OperatingSystemData : ICloneable
     {
-	/// <summary>
-	/// The name of the operating system.
-	/// </summary>
+        /// <summary>
+        /// The name of the operating system.
+        /// </summary>
         [DataMember]
         public string Name { get; set; }
 
-	/// <summary>
-	/// The description of the operating system as
-	/// reported by $PSVersionTable.
-	/// </summary>
+        /// <summary>
+        /// The description of the operating system as
+        /// reported by $PSVersionTable.
+        /// </summary>
         [DataMember]
         public string Description { get; set; }
 
-	/// <summary>
-	/// The platform as reported by
-	/// $PSVersionTable.
-	/// </summary>
+        /// <summary>
+        /// The platform as reported by
+        /// $PSVersionTable.
+        /// </summary>
         [DataMember]
         public string Platform { get; set; }
 
@@ -42,27 +42,27 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data
         [DataMember]
         public Architecture Architecture { get; set; }
 
-	/// <summary>
-	/// The broad kind of operating system
-	/// the target PowerShell runtime runs on.
-	/// </summary>
+        /// <summary>
+        /// The broad kind of operating system
+        /// the target PowerShell runtime runs on.
+        /// </summary>
         [DataMember]
         public OSFamily Family { get; set; }
 
-	/// <summary>
-	/// The version of the operating system.
-	/// On Windows and macOS this is given by
-	/// System.Environment.OSVersion.Version.
-	/// On Linux, this takes the output of uname -r
-	/// to track the kernel SKU.
-	/// </summary>
+        /// <summary>
+        /// The version of the operating system.
+        /// On Windows and macOS this is given by
+        /// System.Environment.OSVersion.Version.
+        /// On Linux, this takes the output of uname -r
+        /// to track the kernel SKU.
+        /// </summary>
         [DataMember(EmitDefaultValue = false)]
         public string Version { get; set; }
 
-	/// <summary>
-	/// If specified, the Windows Service Pack
-	/// of the operating system.
-	/// </summary>
+        /// <summary>
+        /// If specified, the Windows Service Pack
+        /// of the operating system.
+        /// </summary>
         [DataMember(EmitDefaultValue = false)]
         public string ServicePack { get; set; }
 
@@ -74,26 +74,26 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data
         [DataMember(EmitDefaultValue = false)]
         public uint? SkuId { get; set; }
 
-	/// <summary>
-	/// On Linux, the name of the distribution
-	/// family (e.g. "Ubuntu"). Taken from
-	/// "ID" in /etc/*-release
-	/// </summary>
+        /// <summary>
+        /// On Linux, the name of the distribution
+        /// family (e.g. "Ubuntu"). Taken from
+        /// "ID" in /etc/*-release
+        /// </summary>
         [DataMember(EmitDefaultValue = false)]
         public string DistributionId { get; set; }
 
-	/// <summary>
-	/// On Linux, the version of the particular
-	/// distribtion. Taken from "VERSION_ID" in
-	/// /etc/*-release.
-	/// </summary>
+        /// <summary>
+        /// On Linux, the version of the particular
+        /// distribtion. Taken from "VERSION_ID" in
+        /// /etc/*-release.
+        /// </summary>
         [DataMember(EmitDefaultValue = false)]
         public string DistributionVersion { get; set; }
 
-	/// <summary>
-	/// On Linux, the full name of the distribution
-	/// version. Taken from "PRETTY_NAME" in /etc/*-release.
-	/// </summary>
+        /// <summary>
+        /// On Linux, the full name of the distribution
+        /// version. Taken from "PRETTY_NAME" in /etc/*-release.
+        /// </summary>
         [DataMember(EmitDefaultValue = false)]
         public string DistributionPrettyName { get; set; }
 

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Data/Platform/PowerShellData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Data/Platform/PowerShellData.cs
@@ -41,7 +41,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Data
         /// </summary>
         [DataMember]
         public Version RemotingProtocolVersion { get; set; }
-        
+
         /// <summary>
         /// The PowerShell serialization protocol version
         /// supported, from $PSVersionTable.SerializationVersion.

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/CommonPowerShellData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/CommonPowerShellData.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Data = Microsoft.PowerShell.CrossCompatibility.Data;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/CompatibilityProfileData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/CompatibilityProfileData.cs
@@ -1,11 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using CompatibilityProfileDataMut = Microsoft.PowerShell.CrossCompatibility.Data.CompatibilityProfileData;
-using RuntimeDataMut = Microsoft.PowerShell.CrossCompatibility.Data.RuntimeData;
-using PlatformDataMut = Microsoft.PowerShell.CrossCompatibility.Data.ModuleData;
 using Microsoft.PowerShell.CrossCompatibility.Query;
 using System.Collections.Generic;
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
+using RuntimeDataMut = Microsoft.PowerShell.CrossCompatibility.Data.RuntimeData;
+After:
+using CompatibilityProfileDataMut = Microsoft.PowerShell.CrossCompatibility.Data.CompatibilityProfileData;
+*/
+
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
+using Microsoft.PowerShell.CrossCompatibility.Query;
+using System.Collections.Generic;
+After:
+using RuntimeDataMut = Microsoft.PowerShell.CrossCompatibility.Data.RuntimeData;
+*/
+
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/CmdletData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/CmdletData.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Data = Microsoft.PowerShell.CrossCompatibility.Data;
-
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {
     /// <summary>

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/CommandData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/CommandData.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Data = Microsoft.PowerShell.CrossCompatibility.Data;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/FunctionData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/FunctionData.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Data = Microsoft.PowerShell.CrossCompatibility.Data;
-
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {
     /// <summary>

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/ModuleData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/ModuleData.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using Data = Microsoft.PowerShell.CrossCompatibility.Data;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/ParameterData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Modules/ParameterData.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Data = Microsoft.PowerShell.CrossCompatibility.Data;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Platform/DotnetData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Platform/DotnetData.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using DotnetRuntime = Microsoft.PowerShell.CrossCompatibility.Data.DotnetRuntime;
 using DotnetDataMut = Microsoft.PowerShell.CrossCompatibility.Data.DotnetData;
+using DotnetRuntime = Microsoft.PowerShell.CrossCompatibility.Data.DotnetRuntime;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Platform/OperatingSystemData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Platform/OperatingSystemData.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using OperatingSystemDataMut = Microsoft.PowerShell.CrossCompatibility.Data.OperatingSystemData;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/RuntimeData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/RuntimeData.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Data = Microsoft.PowerShell.CrossCompatibility.Data;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Types/AssemblyData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Types/AssemblyData.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using Data = Microsoft.PowerShell.CrossCompatibility.Data;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Types/AvailableTypeData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Types/AvailableTypeData.cs
@@ -1,10 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
 using Microsoft.PowerShell.CrossCompatibility.Utility;
-using Data = Microsoft.PowerShell.CrossCompatibility.Data;
+using System;
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
+using Microsoft.PowerShell.CrossCompatibility.Utility;
+After:
+using System.Collections.Generic;
+*/
+
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Types/MemberData.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Query/Types/MemberData.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using data = Microsoft.PowerShell.CrossCompatibility.Data;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Query
 {

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Retrieval/CompatibilityProfileLoader.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Retrieval/CompatibilityProfileLoader.cs
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+
+/* Unmerged change from project 'Microsoft.PowerShell.CrossCompatibility (net452)'
+Before:
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,9 +12,26 @@ using CompatibilityProfileDataMut = Microsoft.PowerShell.CrossCompatibility.Data
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Linq;
-using System.Threading.Tasks;
-using System.Text.RegularExpressions;
+After:
+using Microsoft.PowerShell.CrossCompatibility.Query;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using Microsoft.IO;
+using CompatibilityProfileDataMut = Microsoft.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+*/
+using Microsoft.PowerShell.CrossCompatibility.Query;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CompatibilityProfileDataMut = Microsoft.PowerShell.CrossCompatibility.Data.CompatibilityProfileData;
 
 #if CORECLR
 using System.Runtime.InteropServices;
@@ -118,7 +138,8 @@ namespace Microsoft.PowerShell.CrossCompatibility.Retrieval
                 throw new ArgumentNullException(nameof(path));
             }
 
-            return _profileCache.GetOrAdd(path, new Lazy<Task<CompatibilityProfileCacheEntry>>(() => Task.Run(() => {
+            return _profileCache.GetOrAdd(path, new Lazy<Task<CompatibilityProfileCacheEntry>>(() => Task.Run(() =>
+            {
                 CompatibilityProfileDataMut compatibilityProfileMut = _jsonSerializer.DeserializeFromFile(path);
 
                 var compatibilityProfile = new CompatibilityProfileData(compatibilityProfileMut);
@@ -140,7 +161,8 @@ namespace Microsoft.PowerShell.CrossCompatibility.Retrieval
             string unionId = GetUnionIdFromProfiles(profiles);
             string unionPath = Path.Combine(profileDir.FullName, unionId + ".json");
 
-            return _profileCache.GetOrAdd(unionPath, new Lazy<Task<CompatibilityProfileCacheEntry>>(() => Task.Run(() => {
+            return _profileCache.GetOrAdd(unionPath, new Lazy<Task<CompatibilityProfileCacheEntry>>(() => Task.Run(() =>
+            {
                 try
                 {
                     // We read the ID first to avoid needing to rehydrate MBs of unneeded JSON
@@ -169,7 +191,8 @@ namespace Microsoft.PowerShell.CrossCompatibility.Retrieval
                 CompatibilityProfileDataMut generatedUnionProfile = ProfileCombination.UnionMany(unionId, profiles.Select(p => p.MutableProfileData));
 
                 // Write the union to the filesystem for faster startup later
-                Task.Run(() => {
+                Task.Run(() =>
+                {
                     _jsonSerializer.SerializeToFile(generatedUnionProfile, unionPath);
                 });
 

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Retrieval/JsonProfileSerializer.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Retrieval/JsonProfileSerializer.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.CrossCompatibility.Data;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using Microsoft.PowerShell.CrossCompatibility.Data;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Microsoft.PowerShell.CrossCompatibility.Retrieval
 {

--- a/Rules/AlignAssignmentStatement.cs
+++ b/Rules/AlignAssignmentStatement.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                             keyStartOffSetReached = true;
                         }
                         return false;
-                        }).FirstOrDefault();
+                    }).FirstOrDefault();
                 if (keyTokenNode == null || keyTokenNode.Value == null)
                 {
                     continue;

--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -10,7 +10,6 @@ using System.ComponentModel.Composition;
 #endif
 using System.Globalization;
 using System.Linq;
-using System.Management.Automation;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
@@ -131,7 +130,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
 
                 // If we find match of any kind, do not continue with the Get-{commandname} check
-                if ( Helper.Instance.GetCommandInfo(commandName) != null ) {
+                if (Helper.Instance.GetCommandInfo(commandName) != null)
+                {
                     continue;
                 }
 

--- a/Rules/AvoidAssignmentToAutomaticVariable.cs
+++ b/Rules/AvoidAssignmentToAutomaticVariable.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidAssignmentToAutomaticVariable: Checks for assignment to automatic variables.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidAssignmentToAutomaticVariable : IScriptRule
     {

--- a/Rules/AvoidDefaultTrueValueSwitchParameter.cs
+++ b/Rules/AvoidDefaultTrueValueSwitchParameter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidDefaultTrueValueSwitchParameter: Check that switch parameter does not default to true.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidDefaultTrueValueSwitchParameter : IScriptRule
     {

--- a/Rules/AvoidDefaultValueForMandatoryParameter.cs
+++ b/Rules/AvoidDefaultValueForMandatoryParameter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidDefaultValueForMandatoryParameter: Check if a mandatory parameter does not have a default value.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidDefaultValueForMandatoryParameter : IScriptRule
     {

--- a/Rules/AvoidEmptyCatchBlock.cs
+++ b/Rules/AvoidEmptyCatchBlock.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidEmptyCatchBlock: Check if any empty catch block is used.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidEmptyCatchBlock : IScriptRule
     {

--- a/Rules/AvoidGlobalAliases.cs
+++ b/Rules/AvoidGlobalAliases.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         public string GetCommonName()
         {
-             return string.Format(CultureInfo.CurrentCulture, Strings.AvoidGlobalAliasesCommonName);
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidGlobalAliasesCommonName);
         }
 
         public string GetDescription()

--- a/Rules/AvoidGlobalVars.cs
+++ b/Rules/AvoidGlobalVars.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidGlobalVars: Analyzes the ast to check that global variables are not used.
     /// </summary>
 #if !CORECLR
-    [Export(typeof (IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidGlobalVars : IScriptRule
     {

--- a/Rules/AvoidInvokingEmptyMembers.cs
+++ b/Rules/AvoidInvokingEmptyMembers.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidInvokingEmptyMembers: Analyzes the script to check if any non-constant members have been invoked.
     /// </summary>    
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidInvokingEmptyMembers : IScriptRule
     {
@@ -54,11 +54,22 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         }
                     }
                 }
+
+/* Unmerged change from project 'Rules (net452)'
+Before:
             }
         
         }
+After:
+            }
 
-        
+        }
+*/
+            }
+
+        }
+
+
         /// <summary>
         /// GetName: Retrieves the name of this rule.
         /// </summary>

--- a/Rules/AvoidNullOrEmptyHelpMessageAttribute.cs
+++ b/Rules/AvoidNullOrEmptyHelpMessageAttribute.cs
@@ -16,10 +16,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidUsingNullOrEmptyHelpMessageAttribute: Check if the HelpMessage parameter is set to a non-empty string.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidNullOrEmptyHelpMessageAttribute : IScriptRule
-    {               
+    {
         /// <summary>
         /// AvoidUsingNullOrEmptyHelpMessageAttribute: Check if the HelpMessage parameter is set to a non-empty string.
         /// </summary>
@@ -36,7 +36,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     continue;
                 }
-                                           
+
                 foreach (ParameterAst paramAst in funcAst.Body.ParamBlock.Parameters)
                 {
                     if (paramAst == null)
@@ -57,19 +57,30 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         {
                             continue;
                         }
-                                               
+
                         foreach (NamedAttributeArgumentAst namedArgument in namedArguments)
                         {
                             if (namedArgument == null || !(namedArgument.ArgumentName.Equals("HelpMessage", StringComparison.OrdinalIgnoreCase)))
                             {
                                 continue;
+
+/* Unmerged change from project 'Rules (net452)'
+Before:
                             }
                             
+                            string errCondition;
+After:
+                            }
+
+                            string errCondition;
+*/
+                            }
+
                             string errCondition;
                             if (namedArgument.ExpressionOmitted || HasEmptyStringInExpression(namedArgument.Argument))
                             {
                                 errCondition = "empty";
-                            }                                                        
+                            }
                             else if (HasNullInExpression(namedArgument.Argument))
                             {
                                 errCondition = "null";
@@ -84,16 +95,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                                                 Strings.AvoidNullOrEmptyHelpMessageAttributeError,
                                                                 paramAst.Name.VariablePath.UserPath);
                                 yield return new DiagnosticRecord(message,
-                                                                    paramAst.Extent, 
-                                                                    GetName(), 
-                                                                    DiagnosticSeverity.Warning, 
-                                                                    fileName, 
+                                                                    paramAst.Extent,
+                                                                    GetName(),
+                                                                    DiagnosticSeverity.Warning,
+                                                                    fileName,
                                                                     paramAst.Name.VariablePath.UserPath);
-                            }                            
-                        }                                                
+                            }
+                        }
                     }
                 }
-                
+
             }
         }
 

--- a/Rules/AvoidPositionalParameters.cs
+++ b/Rules/AvoidPositionalParameters.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidPositionalParameters: Check to make sure that positional parameters are not used.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidPositionalParameters : IScriptRule
     {
@@ -51,7 +51,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // You can also review the remark section in following document,
                 // MSDN: CommandAst.GetCommandName Method
                 if (cmdAst.GetCommandName() == null) continue;
-                
+
                 if ((Helper.Instance.IsKnownCmdletFunctionOrExternalScript(cmdAst) || declaredFunctionNames.Contains(cmdAst.GetCommandName())) &&
                     (Helper.Instance.PositionalParameterUsed(cmdAst, true)))
                 {

--- a/Rules/AvoidReservedCharInCmdlet.cs
+++ b/Rules/AvoidReservedCharInCmdlet.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidReservedCharInCmdlet: Analyzes script to check for reserved characters in cmdlet names.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidReservedCharInCmdlet : IScriptRule
     {
@@ -55,16 +55,17 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     {
                         yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.ReservedCmdletCharError, funcAst.Name),
                             funcAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
-                    }                
+                    }
                 }
-            }            
+            }
         }
 
         /// <summary>
         /// GetName: Retrieves the name of this rule.
         /// </summary>
         /// <returns>The name of this rule</returns>
-        public string GetName() {
+        public string GetName()
+        {
             return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.ReservedCmdletCharName);
         }
 
@@ -81,7 +82,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// GetDescription: Retrieves the description of this rule.
         /// </summary>
         /// <returns>The description of this rule</returns>
-        public string GetDescription() {
+        public string GetDescription()
+        {
             return string.Format(CultureInfo.CurrentCulture, Strings.ReservedCmdletCharDescription);
         }
 

--- a/Rules/AvoidReservedParams.cs
+++ b/Rules/AvoidReservedParams.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidReservedParams: Analyzes the ast to check for reserved parameters in function definitions.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidReservedParams : IScriptRule
     {
@@ -30,7 +30,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <param name="ast">The script's ast</param>
         /// <param name="fileName">The script's file name</param>
         /// <returns>A List of diagnostic results of this rule</returns>
-        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName) {
+        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
             IEnumerable<Ast> funcAsts = ast.FindAll(item => item is FunctionDefinitionAst, true);
@@ -89,7 +90,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// GetDescription: Retrieves the description of this rule.
         /// </summary>
         /// <returns>The description of this rule</returns>
-        public string GetDescription() {
+        public string GetDescription()
+        {
             return string.Format(CultureInfo.CurrentCulture, Strings.ReservedParamsDescription);
         }
 

--- a/Rules/AvoidShouldContinueWithoutForce.cs
+++ b/Rules/AvoidShouldContinueWithoutForce.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// the function should have a boolean force parameter
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidShouldContinueWithoutForce : IScriptRule
     {
@@ -41,7 +41,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 foreach (ParameterAst paramAst in paramAsts)
                 {
                     if (String.Equals(paramAst.Name.VariablePath.ToString(), "force", StringComparison.OrdinalIgnoreCase)
-                        && (String.Equals(paramAst.StaticType.FullName, "System.Boolean", StringComparison.OrdinalIgnoreCase) 
+                        && (String.Equals(paramAst.StaticType.FullName, "System.Boolean", StringComparison.OrdinalIgnoreCase)
                         || String.Equals(paramAst.StaticType.FullName, "System.Management.Automation.SwitchParameter", StringComparison.OrdinalIgnoreCase)))
                     {
                         hasForce = true;

--- a/Rules/AvoidUserNameAndPasswordParams.cs
+++ b/Rules/AvoidUserNameAndPasswordParams.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // Finds all functionAst
             IEnumerable<Ast> functionAsts = ast.FindAll(testAst => testAst is FunctionDefinitionAst, true);
 
-            List<String> passwords = new List<String>() {"Password", "Passphrase"};
-            List<String> usernames = new List<String>() { "Username", "User"};
+            List<String> passwords = new List<String>() { "Password", "Passphrase" };
+            List<String> usernames = new List<String>() { "Username", "User" };
             Type[] typeWhiteList = {typeof(CredentialAttribute),
                                             typeof(PSCredential),
                                             typeof(System.Security.SecureString),
@@ -55,7 +55,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 foreach (ParameterAst paramAst in paramAsts)
                 {
                     var attributes = typeWhiteList.Select(x => GetAttributeOfType(paramAst.Attributes, x));
-                    String paramName = paramAst.Name.VariablePath.ToString();                    
+                    String paramName = paramAst.Name.VariablePath.ToString();
                     foreach (String password in passwords)
                     {
                         if (paramName.IndexOf(password, StringComparison.OrdinalIgnoreCase) != -1)
@@ -116,7 +116,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             var usrExt = usernameAst.Extent;
             var pwdExt = passwordAst.Extent;
             IScriptExtent startExt, endExt;
-            var usrBeforePwd 
+            var usrBeforePwd
                 = (usrExt.StartLineNumber == pwdExt.StartLineNumber
                     && usrExt.StartColumnNumber < pwdExt.StartColumnNumber)
                     || usrExt.StartLineNumber < pwdExt.StartLineNumber;

--- a/Rules/AvoidUsingComputerNameHardcoded.cs
+++ b/Rules/AvoidUsingComputerNameHardcoded.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidUsingComputerNameHardcoded: Check that parameter ComputerName is not hardcoded.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidUsingComputerNameHardcoded : AvoidParameterGeneric
     {

--- a/Rules/AvoidUsingConvertToSecureStringWithPlainText.cs
+++ b/Rules/AvoidUsingConvertToSecureStringWithPlainText.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidUsingConvertToSecureStringWithPlainText: Check that convertto-securestring does not use plaintext.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidUsingConvertToSecureStringWithPlainText : AvoidParameterGeneric
     {

--- a/Rules/AvoidUsingDeprecatedManifestFields.cs
+++ b/Rules/AvoidUsingDeprecatedManifestFields.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         result = ps.Invoke();
                     }
                     catch
-                    {}
+                    { }
 
                     if (result != null)
                     {

--- a/Rules/AvoidUsingInvokeExpression.cs
+++ b/Rules/AvoidUsingInvokeExpression.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// InvokeExpressionRule: Check to make sure that Invoke-Expression is not used.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class InvokeExpressionRule : AvoidCmdletGeneric
     {

--- a/Rules/AvoidUsingPlainTextForPassword.cs
+++ b/Rules/AvoidUsingPlainTextForPassword.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // Finds all ParamAsts.
             IEnumerable<Ast> paramAsts = ast.FindAll(testAst => testAst is ParameterAst, true);
 
-            List<String> passwords = new List<String>() {"Password", "Passphrase", "Cred", "Credential"};
+            List<String> passwords = new List<String>() { "Password", "Passphrase", "Cred", "Credential" };
 
             // Iterates all ParamAsts and check if their names are on the list.
             foreach (ParameterAst paramAst in paramAsts)
@@ -102,7 +102,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             if (paramAst.Attributes != null)
             {
-                foreach(var attr in paramAst.Attributes)
+                foreach (var attr in paramAst.Attributes)
                 {
                     if (attr.GetType() == typeof(TypeConstraintAst))
                     {

--- a/Rules/AvoidUsingWMICmdlet.cs
+++ b/Rules/AvoidUsingWMICmdlet.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidUsingWMICmdlet: Avoid Using Get-WMIObject, Remove-WMIObject, Invoke-WmiMethod, Register-WmiEvent, Set-WmiInstance
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidUsingWMICmdlet : IScriptRule
     {
@@ -37,8 +37,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // Iterate all CommandAsts and check the command name
                 foreach (CommandAst cmdAst in commandAsts)
                 {
-                    if (cmdAst.GetCommandName() != null && 
-                        (String.Equals(cmdAst.GetCommandName(), "get-wmiobject", StringComparison.OrdinalIgnoreCase) 
+                    if (cmdAst.GetCommandName() != null &&
+                        (String.Equals(cmdAst.GetCommandName(), "get-wmiobject", StringComparison.OrdinalIgnoreCase)
                             || String.Equals(cmdAst.GetCommandName(), "remove-wmiobject", StringComparison.OrdinalIgnoreCase)
                             || String.Equals(cmdAst.GetCommandName(), "invoke-wmimethod", StringComparison.OrdinalIgnoreCase)
                             || String.Equals(cmdAst.GetCommandName(), "register-wmievent", StringComparison.OrdinalIgnoreCase)
@@ -69,7 +69,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
             IEnumerable<Ast> scriptBlockAsts = ast.FindAll(testAst => testAst is ScriptBlockAst, true);
-            
+
             foreach (ScriptBlockAst scriptBlockAst in scriptBlockAsts)
             {
                 if (null != scriptBlockAst.ScriptRequirements && null != scriptBlockAst.ScriptRequirements.RequiredPSVersion)

--- a/Rules/AvoidUsingWriteHost.cs
+++ b/Rules/AvoidUsingWriteHost.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidUsingWriteHost: Check that Write-Host or Console.Write are not used
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class AvoidUsingWriteHost : AstVisitor, IScriptRule
     {

--- a/Rules/CompatibilityRules/CompatibilityRule.cs
+++ b/Rules/CompatibilityRules/CompatibilityRule.cs
@@ -1,18 +1,36 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+
+/* Unmerged change from project 'Rules (net452)'
+Before:
+using System;
+After:
+using Microsoft.PowerShell.CrossCompatibility.Query;
+using Microsoft.PowerShell.CrossCompatibility.Retrieval;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+using System;
+*/
+using Microsoft.PowerShell.CrossCompatibility.Query;
+using Microsoft.PowerShell.CrossCompatibility.Retrieval;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Management.Automation.Language;
-using System.Text;
+
+/* Unmerged change from project 'Rules (net452)'
+Before:
 using System.Text.RegularExpressions;
 using Microsoft.PowerShell.CrossCompatibility.Query;
 using Microsoft.PowerShell.CrossCompatibility.Retrieval;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+After:
+using System.Text.RegularExpressions;
+*/
+using System.IO;
+using System.Linq;
+using System.Management.Automation.Language;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
@@ -67,7 +85,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// The profile names or filenames of profiles to load from the profile directory,
         /// as well as absolute paths to other profiles.
         /// </summary>
-        [ConfigurableRuleProperty(defaultValue: new string[] {})]
+        [ConfigurableRuleProperty(defaultValue: new string[] { })]
         public string[] TargetProfiles { get; set; }
 
         /// <summary>

--- a/Rules/CompatibilityRules/UseCompatibleCommands.cs
+++ b/Rules/CompatibilityRules/UseCompatibleCommands.cs
@@ -1,16 +1,42 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
+using Microsoft.PowerShell.
+/* Unmerged change from project 'Rules (net452)'
+Before:
 using System.Globalization;
 using System.Management.Automation.Language;
+After:
+using System.Query;
+using Microsoft.PowerShell.CrossCompatibility.Utility;
+*/
+CrossCompatibility.Query;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+
+/* Unmerged change from project 'Rules (net452)'
+Before:
 using Microsoft.PowerShell.CrossCompatibility.Query;
 using Microsoft.PowerShell.CrossCompatibility.Utility;
+After:
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+*/
+using System.IO;
+
+/* Unmerged change from project 'Rules (net452)'
+Before:
 using System.Text.RegularExpressions;
 using System.IO;
 using System.Runtime.Serialization;
+After:
+using System.Management.Automation.Language;
+using System.Runtime.Serialization;
+using System.Text.RegularExpressions;
+*/
+using System.Collections.Generic;
+using System.Globalization;
+using System.Management.Automation.Language;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
@@ -27,7 +53,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// List of commands to ignore the compatibility of.
         /// </summary>
-        [ConfigurableRuleProperty(new string[] {})]
+        [ConfigurableRuleProperty(new string[] { })]
         public string[] IgnoreCommands { get; set; }
 
         /// <summary>

--- a/Rules/CompatibilityRules/UseCompatibleSyntax.cs
+++ b/Rules/CompatibilityRules/UseCompatibleSyntax.cs
@@ -2,12 +2,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Management.Automation.Language;
 using System.Text;
-using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
@@ -21,15 +21,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 #endif
     public class UseCompatibleSyntax : ConfigurableRule
     {
-        private static readonly Version s_v3 = new Version(3,0);
+        private static readonly Version s_v3 = new Version(3, 0);
 
-        private static readonly Version s_v4 = new Version(4,0);
+        private static readonly Version s_v4 = new Version(4, 0);
 
-        private static readonly Version s_v5 = new Version(5,0);
+        private static readonly Version s_v5 = new Version(5, 0);
 
-        private static readonly Version s_v6 = new Version(6,0);
+        private static readonly Version s_v6 = new Version(6, 0);
 
-        private static readonly IReadOnlyList<Version> s_targetableVersions = new []
+        private static readonly IReadOnlyList<Version> s_targetableVersions = new[]
         {
             s_v3,
             s_v4,
@@ -40,7 +40,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// The versions of PowerShell for the rule to target.
         /// </summary>
-        [ConfigurableRuleProperty(new string[]{})]
+        [ConfigurableRuleProperty(new string[] { })]
         public string[] TargetVersions { get; set; }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             if (versionSettings == null || versionSettings.Length <= 0)
             {
-                return new HashSet<Version>(){ s_v5, s_v6 };
+                return new HashSet<Version>() { s_v5, s_v6 };
             }
 
             var targetVersions = new HashSet<Version>();
@@ -265,7 +265,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         _rule.Severity,
                         _analyzedFilePath,
                         ruleId: null,
-                        suggestedCorrections: new [] { suggestedCorrection }
+                        suggestedCorrections: new[] { suggestedCorrection }
                     ));
 
                     return AstVisitAction.Continue;

--- a/Rules/CompatibilityRules/UseCompatibleTypes.cs
+++ b/Rules/CompatibilityRules/UseCompatibleTypes.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.PowerShell.CrossCompatibility;
+using Microsoft.PowerShell.CrossCompatibility.Query;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Management.Automation.Language;
-using Microsoft.PowerShell.CrossCompatibility;
-using Microsoft.PowerShell.CrossCompatibility.Query;
-using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
@@ -24,7 +24,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// Full names of types or type accelerators to ignore the compatibility of.
         /// </summary>
-        [ConfigurableRuleProperty(new string[] {})]
+        [ConfigurableRuleProperty(new string[] { })]
         public string[] IgnoreTypes { get; set; }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     }
 
                     // We need the PowerShell parser to turn this into something structured now
-                    TypeExpressionAst typeNameAst = (TypeExpressionAst)Parser.ParseInput("["+typeNameStringExp.Value+"]", out Token[] tokens, out ParseError[] errors)
+                    TypeExpressionAst typeNameAst = (TypeExpressionAst)Parser.ParseInput("[" + typeNameStringExp.Value + "]", out Token[] tokens, out ParseError[] errors)
                         .Find(ast => ast is TypeExpressionAst, true);
 
                     if (typeNameAst == null)

--- a/Rules/DscExamplesPresent.cs
+++ b/Rules/DscExamplesPresent.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// Examples folder should contain sample configuration for given resource - file name should contain resource's name.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IDSCResourceRule))]
+    [Export(typeof(IDSCResourceRule))]
 #endif
     public class DscExamplesPresent : IDSCResourceRule
     {
@@ -43,8 +43,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             String fileNameOnly = Path.GetFileName(fileName);
             String resourceName = Path.GetFileNameWithoutExtension(fileNameOnly);
             String examplesQuery = String.Format("*{0}*", resourceName);
-            Boolean examplesPresent = false; 
-            String expectedExamplesPath = Path.Combine(new String[] {fileName, "..", "..", "..", "Examples"});
+            Boolean examplesPresent = false;
+            String expectedExamplesPath = Path.Combine(new String[] { fileName, "..", "..", "..", "Examples" });
 
             // Verify examples are present
             if (Directory.Exists(expectedExamplesPath))
@@ -65,7 +65,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
         }
 
-        #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
 
         /// <summary>
         /// AnalyzeDSCClass: Analyzes given DSC class
@@ -94,7 +94,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 String examplesQuery = String.Format("*{0}*", resourceName);
                 Boolean examplesPresent = false;
-                String expectedExamplesPath = Path.Combine(new String[] {fileName, "..", "Examples"});
+                String expectedExamplesPath = Path.Combine(new String[] { fileName, "..", "Examples" });
 
                 // Verify examples are present
                 if (Directory.Exists(expectedExamplesPath))
@@ -113,10 +113,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.DscExamplesPresentNoExamplesError, resourceName),
                                 dscClass.Extent, GetName(), DiagnosticSeverity.Information, fileName);
                 }
-            }       
+            }
         }
 
-        #endif
+#endif
 
         /// <summary>
         /// GetName: Retrieves the name of this rule.

--- a/Rules/DscTestsPresent.cs
+++ b/Rules/DscTestsPresent.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// Tests folder should contain test script for given resource - file name should contain resource's name.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IDSCResourceRule))]
+    [Export(typeof(IDSCResourceRule))]
 #endif
     public class DscTestsPresent : IDSCResourceRule
     {
@@ -65,7 +65,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
         }
 
-        #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
 
         /// <summary>
         /// AnalyzeDSCClass: Analyzes given DSC class
@@ -116,7 +116,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
         }
 
-        #endif
+#endif
 
         /// <summary>
         /// GetName: Retrieves the name of this rule.

--- a/Rules/MisleadingBacktick.cs
+++ b/Rules/MisleadingBacktick.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// MisleadingBacktick: Checks that lines don't end with a backtick followed by whitespace
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class MisleadingBacktick : IScriptRule
     {
@@ -34,7 +34,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             string[] lines = NewlineRegex.Split(ast.Extent.Text);
 
-            if((ast.Extent.EndLineNumber - ast.Extent.StartLineNumber + 1) != lines.Length)
+            if ((ast.Extent.EndLineNumber - ast.Extent.StartLineNumber + 1) != lines.Length)
             {
                 // Did not match the number of lines that the extent indicated
                 yield break;
@@ -46,7 +46,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 Match match = TrailingEscapedWhitespaceRegex.Match(line);
 
-                if(match.Success)
+                if (match.Success)
                 {
                     int lineNumber = ast.Extent.StartLineNumber + i;
 
@@ -74,7 +74,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             var corrections = new List<CorrectionExtent>();
             string description = "Remove trailing whilespace";
             corrections.Add(new CorrectionExtent(
-                violationExtent.StartLineNumber ,
+                violationExtent.StartLineNumber,
                 violationExtent.EndLineNumber,
                 violationExtent.StartColumnNumber + 1,
                 violationExtent.EndColumnNumber,

--- a/Rules/MissingModuleManifestField.cs
+++ b/Rules/MissingModuleManifestField.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         if (Helper.IsMissingManifestMemberException(errorRecord))
                         {
                             System.Diagnostics.Debug.Assert(
-                                errorRecord.Exception != null && !String.IsNullOrWhiteSpace(errorRecord.Exception.Message), 
+                                errorRecord.Exception != null && !String.IsNullOrWhiteSpace(errorRecord.Exception.Message),
                                 Strings.NullErrorMessage);
                             var hashTableAst = ast.Find(x => x is HashtableAst, false);
                             if (hashTableAst == null)
@@ -56,12 +56,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 yield break;
                             }
                             yield return new DiagnosticRecord(
-                                errorRecord.Exception.Message, 
-                                hashTableAst.Extent, 
-                                GetName(), 
-                                DiagnosticSeverity.Warning, 
+                                errorRecord.Exception.Message,
+                                hashTableAst.Extent,
+                                GetName(),
+                                DiagnosticSeverity.Warning,
                                 fileName,
-                                suggestedCorrections:GetCorrectionExtent(hashTableAst as HashtableAst));
+                                suggestedCorrections: GetCorrectionExtent(hashTableAst as HashtableAst));
                         }
 
                     }
@@ -134,7 +134,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             correctionExtents.Add(correctionExtent);
             return correctionExtents;
         }
-        
+
         /// <summary>
         /// GetName: Retrieves the name of this rule.
         /// </summary>

--- a/Rules/PossibleIncorrectComparisonWithNull.cs
+++ b/Rules/PossibleIncorrectComparisonWithNull.cs
@@ -17,24 +17,27 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// NullComparisonRule: Analyzes the ast to check that $null is on the left side of any equality comparisons.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
-    public class PossibleIncorrectComparisonWithNull : IScriptRule {
+    public class PossibleIncorrectComparisonWithNull : IScriptRule
+    {
         /// <summary>
         /// AnalyzeScript: Analyzes the ast to check that $null is on the left side of any equality comparisons.
         /// <param name="ast">The script's ast</param>
         /// <param name="fileName">The script's file name</param>
         /// <returns>The diagnostic results of this rule</returns>
         /// </summary>
-        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName) {
+        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
             IEnumerable<Ast> binExpressionAsts = ast.FindAll(testAst => testAst is BinaryExpressionAst, false);
 
-            foreach (BinaryExpressionAst binExpressionAst in binExpressionAsts) {
-                if ((binExpressionAst.Operator.Equals(TokenKind.Equals) || binExpressionAst.Operator.Equals(TokenKind.Ceq) 
+            foreach (BinaryExpressionAst binExpressionAst in binExpressionAsts)
+            {
+                if ((binExpressionAst.Operator.Equals(TokenKind.Equals) || binExpressionAst.Operator.Equals(TokenKind.Ceq)
                     || binExpressionAst.Operator.Equals(TokenKind.Cne) || binExpressionAst.Operator.Equals(TokenKind.Ine) || binExpressionAst.Operator.Equals(TokenKind.Ieq))
-                    && binExpressionAst.Right.Extent.Text.Equals("$null", StringComparison.OrdinalIgnoreCase)) 
+                    && binExpressionAst.Right.Extent.Text.Equals("$null", StringComparison.OrdinalIgnoreCase))
                 {
                     if (IncorrectComparisonWithNull(binExpressionAst, ast))
                     {
@@ -44,15 +47,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
             }
 
-            #if PSV3
+#if PSV3
 
             IEnumerable<Ast> funcAsts = ast.FindAll(item => item is FunctionDefinitionAst, true);
 
-            #else
+#else
 
             IEnumerable<Ast> funcAsts = ast.FindAll(item => item is FunctionDefinitionAst, true).Union(ast.FindAll(item => item is FunctionMemberAst, true));
 
-            #endif
+#endif
 
             foreach (Ast funcAst in funcAsts)
             {
@@ -70,9 +73,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         private bool IncorrectComparisonWithNull(BinaryExpressionAst binExpressionAst, Ast ast)
         {
-            if ((binExpressionAst.Operator.Equals(TokenKind.Equals) || binExpressionAst.Operator.Equals(TokenKind.Ceq) 
+            if ((binExpressionAst.Operator.Equals(TokenKind.Equals) || binExpressionAst.Operator.Equals(TokenKind.Ceq)
                 || binExpressionAst.Operator.Equals(TokenKind.Cne) || binExpressionAst.Operator.Equals(TokenKind.Ine) || binExpressionAst.Operator.Equals(TokenKind.Ieq))
-                && binExpressionAst.Right.Extent.Text.Equals("$null", StringComparison.OrdinalIgnoreCase)) 
+                && binExpressionAst.Right.Extent.Text.Equals("$null", StringComparison.OrdinalIgnoreCase))
             {
                 if (binExpressionAst.Left.StaticType.IsArray)
                 {
@@ -122,7 +125,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// GetName: Retrieves the name of this rule.
         /// </summary>
         /// <returns>The name of this rule</returns>
-        public string GetName() {
+        public string GetName()
+        {
             return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.PossibleIncorrectComparisonWithNullName);
         }
 
@@ -139,7 +143,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// GetDescription: Retrieves the description of this rule.
         /// </summary>
         /// <returns>The description of this rule</returns>
-        public string GetDescription() {
+        public string GetDescription()
+        {
             return string.Format(CultureInfo.CurrentCulture, Strings.PossibleIncorrectComparisonWithNullDescription);
         }
 

--- a/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
+++ b/Rules/PossibleIncorrectUsageOfAssignmentOperator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// The origin of this rule is that people often forget that operators change when switching between different languages such as C# and PowerShell.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class PossibleIncorrectUsageOfAssignmentOperator : AstVisitor, IScriptRule
     {

--- a/Rules/PossibleIncorrectUsageOfRedirectionOperator.cs
+++ b/Rules/PossibleIncorrectUsageOfRedirectionOperator.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// The origin of this rule is that people often forget that operators change when switching between different languages such as C# and PowerShell.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class PossibleIncorrectUsageOfRedirectionOperator : AstVisitor, IScriptRule
     {

--- a/Rules/ReturnCorrectTypesForDSCFunctions.cs
+++ b/Rules/ReturnCorrectTypesForDSCFunctions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// ReturnCorrectTypeDSCFunctions: Check that DSC functions return the correct type.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IDSCResourceRule))]
+    [Export(typeof(IDSCResourceRule))]
 #endif
     public class ReturnCorrectTypesForDSCFunctions : IDSCResourceRule
     {
@@ -35,27 +35,40 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             IEnumerable<Ast> functionDefinitionAsts = Helper.Instance.DscResourceFunctions(ast);
 
-            #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
 
             IEnumerable<TypeDefinitionAst> classes = ast.FindAll(item =>
                 item is TypeDefinitionAst
                 && ((item as TypeDefinitionAst).IsClass), true).Cast<TypeDefinitionAst>();
 
-            #endif
+#endif
 
             foreach (FunctionDefinitionAst func in functionDefinitionAsts)
             {
 
-                #if PSV3 || PSV4
+#if PSV3 || PSV4
 
                 List<Tuple<string, StatementAst>> outputTypes = FindPipelineOutput.OutputTypes(func);
 
-                #else
+#else
 
                 List<Tuple<string, StatementAst>> outputTypes = FindPipelineOutput.OutputTypes(func, classes);
 
+
+/* Unmerged change from project 'Rules (net452)'
+Before:
                 #endif
                 
+
+                if (String.Equals(func.Name, "Set-TargetResource", StringComparison.OrdinalIgnoreCase))
+After:
+                #endif
+
+
+                if (String.Equals(func.Name, "Set-TargetResource", StringComparison.OrdinalIgnoreCase))
+*/
+#endif
+
 
                 if (String.Equals(func.Name, "Set-TargetResource", StringComparison.OrdinalIgnoreCase))
                 {
@@ -93,7 +106,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
         }
 
-        #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
 
         /// <summary>
         /// AnalyzeDSCClass: Analyzes given DSC Resource
@@ -184,15 +197,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
         }
 
-        #endif
-        
+#endif
+
 
         /// <summary>
         /// GetName: Retrieves the name of this rule.
         /// </summary>
         /// <returns>The name of this rule</returns>
         public string GetName()
-        {            
+        {
             return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.ReturnCorrectTypeDSCFunctionsName);
         }
 

--- a/Rules/UseApprovedVerbs.cs
+++ b/Rules/UseApprovedVerbs.cs
@@ -19,16 +19,18 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// UseApprovedVerbs: Analyzes scripts to check that all defined functions use approved verbs.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
-    public class UseApprovedVerbs : IScriptRule {
+    public class UseApprovedVerbs : IScriptRule
+    {
         /// <summary>
         /// Analyze script to check that all defined functions use approved verbs
         /// </summary>
         /// <param name="ast"></param>
         /// <param name="fileName"></param>
         /// <returns></returns>
-        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName) {
+        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
             List<string> approvedVerbs = typeof(VerbsCommon).GetFields().Concat<FieldInfo>(
@@ -92,7 +94,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// GetDescription: Retrieves the description of this rule.
         /// </summary>
         /// <returns>The description of this rule</returns>
-        public string GetDescription() {
+        public string GetDescription()
+        {
             return string.Format(CultureInfo.CurrentCulture, Strings.UseApprovedVerbsDescription);
         }
 

--- a/Rules/UseBOMForUnicodeEncodedFile.cs
+++ b/Rules/UseBOMForUnicodeEncodedFile.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// UseBOMForUnicodeEncodedFile: Checks if a file with missing BOM is ASCII encoded.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class UseBOMForUnicodeEncodedFile : IScriptRule
     {
@@ -41,9 +41,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // Did not detect the presence of BOM
                 // Make sure there is no byte > 127 (0x7F) to ensure file is ASCII encoded
                 // Else emit rule violation
-                                
+
                 if (0 != byteStream.Count(o => o > 0x7F))
-                { 
+                {
                     yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.UseBOMForUnicodeEncodedFileError, System.IO.Path.GetFileName(fileName), null),
                                 null, GetName(), DiagnosticSeverity.Warning, fileName);
                 }
@@ -89,7 +89,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             // Did not detect BOM OR Unknown File encoding
             return null;
-            
+
         }
 
         /// <summary>

--- a/Rules/UseCmdletCorrectly.cs
+++ b/Rules/UseCmdletCorrectly.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// Use CmdletCorrectly: Check that cmdlets are invoked with the correct mandatory parameter
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class UseCmdletCorrectly : IScriptRule
     {

--- a/Rules/UseCompatibleCmdlets.cs
+++ b/Rules/UseCompatibleCmdlets.cs
@@ -374,7 +374,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         private void ResetCurCmdletCompatibilityMap()
         {
             // cannot iterate over collection and change the values, hence the conversion to list
-            foreach(var key in curCmdletCompatibilityMap.Keys.ToList())
+            foreach (var key in curCmdletCompatibilityMap.Keys.ToList())
             {
                 curCmdletCompatibilityMap[key] = true;
             }

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -80,7 +80,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         private int indentationLevelMultiplier;
 
         // TODO Enable auto when the rule is able to detect indentation
-        private enum IndentationKind {
+        private enum IndentationKind
+        {
             Space,
             Tab,
             // Auto
@@ -201,7 +202,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 && tokens[tokenIndex - 2].Kind == TokenKind.Comment)
                             {
                                 int searchForPrecedingLineContinuationIndex = tokenIndex - 2;
-                                while (searchForPrecedingLineContinuationIndex  > 0 && tokens[searchForPrecedingLineContinuationIndex].Kind == TokenKind.Comment)
+                                while (searchForPrecedingLineContinuationIndex > 0 && tokens[searchForPrecedingLineContinuationIndex].Kind == TokenKind.Comment)
                                 {
                                     searchForPrecedingLineContinuationIndex--;
                                 }

--- a/Rules/UseCorrectCasing.cs
+++ b/Rules/UseCorrectCasing.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Management.Automation.Language;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System.Management.Automation;
-using System.IO;
-using System.Runtime.InteropServices;
 #if !CORECLR
 using System.ComponentModel.Composition;
 #endif

--- a/Rules/UseDeclaredVarsMoreThanAssignments.cs
+++ b/Rules/UseDeclaredVarsMoreThanAssignments.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// UseDeclaredVarsMoreThanAssignments: Analyzes the ast to check that variables are used in more than just their assignment.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class UseDeclaredVarsMoreThanAssignments : IScriptRule
     {

--- a/Rules/UseIdenticalMandatoryParametersDSC.cs
+++ b/Rules/UseIdenticalMandatoryParametersDSC.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     {
                         return importClassesMethod.Invoke(
                             null,
-                            new object[] { path, moduleInfo, errors}) as List<CimClass>;
+                            new object[] { path, moduleInfo, errors }) as List<CimClass>;
                     };
                 }
             }

--- a/Rules/UseIdenticalParametersDSC.cs
+++ b/Rules/UseIdenticalParametersDSC.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// Set-TargetResource have identical parameters.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IDSCResourceRule))]
+    [Export(typeof(IDSCResourceRule))]
 #endif
     public class UseIdenticalParametersDSC : IDSCResourceRule
     {
@@ -62,7 +62,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         || !CompareParamAsts(paramAst, paramNames[paramAst.Name.VariablePath.UserPath]))
                     {
                         yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.UseIdenticalParametersDSCError),
-                            paramAst.Extent, GetName(), DiagnosticSeverity.Error, fileName);   
+                            paramAst.Extent, GetName(), DiagnosticSeverity.Error, fileName);
                     }
                 }
             }
@@ -117,15 +117,28 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
 
             return true;
+
+/* Unmerged change from project 'Rules (net452)'
+Before:
         }
         
+
+        /// <summary>
+After:
+        }
+
+
+        /// <summary>
+*/
+        }
+
 
         /// <summary>
         /// GetName: Retrieves the name of this rule.
         /// </summary>
         /// <returns>The name of this rule</returns>
         public string GetName()
-        {            
+        {
             return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.UseIdenticalParametersDSCName);
         }
 

--- a/Rules/UseOutputTypeCorrectly.cs
+++ b/Rules/UseOutputTypeCorrectly.cs
@@ -18,15 +18,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// UseOutputTypeCorrectly: Checks that objects returned in a cmdlet have their types declared in OutputType Attribute.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class UseOutputTypeCorrectly : SkipTypeDefinition, IScriptRule
     {
-        #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
 
         private IEnumerable<TypeDefinitionAst> _classes;
 
-        #endif
+#endif
 
         /// <summary>
         /// AnalyzeScript: Checks that objects returned in a cmdlet have their types declared in OutputType Attribute
@@ -41,11 +41,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             DiagnosticRecords.Clear();
             this.fileName = fileName;
 
-            #if !(PSV3||PSV4)
+#if !(PSV3 || PSV4)
 
             _classes = ast.FindAll(item => item is TypeDefinitionAst && ((item as TypeDefinitionAst).IsClass), true).Cast<TypeDefinitionAst>();
 
-            #endif
+#endif
 
             ast.Visit(this);
 
@@ -103,15 +103,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
             }
 
-            #if PSV3
+#if PSV3
 
             List<Tuple<string, StatementAst>> returnTypes = FindPipelineOutput.OutputTypes(funcAst);
 
-            #else
+#else
 
             List<Tuple<string, StatementAst>> returnTypes = FindPipelineOutput.OutputTypes(funcAst, _classes);
 
-            #endif
+#endif
 
             HashSet<string> specialTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             specialTypes.Add(typeof(Unreached).FullName);

--- a/Rules/UsePSCredentialType.cs
+++ b/Rules/UsePSCredentialType.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// UsePSCredentialType: Checks if a parameter named Credential is of type PSCredential. Also checks if there is a credential transformation attribute defined after the PSCredential type attribute. The order between credential transformation attribute and PSCredential type attribute is applicable only to Poweshell 4.0 and earlier.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class UsePSCredentialType : IScriptRule
     {
@@ -50,7 +50,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 && sbAst.ScriptRequirements.RequiredPSVersion.Major == 5
                 && requiresTransformationAttribute)
             {
-                        yield break;
+                yield break;
             }
 
             IEnumerable<Ast> funcDefAsts = ast.FindAll(testAst => testAst is FunctionDefinitionAst, true);
@@ -112,18 +112,18 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             string fileName,
             bool requiresTransformationAttribute)
         {
-                foreach (ParameterAst parameter in parameterAsts)
+            foreach (ParameterAst parameter in parameterAsts)
+            {
+                if (WrongCredentialUsage(parameter, requiresTransformationAttribute))
                 {
-                    if (WrongCredentialUsage(parameter, requiresTransformationAttribute))
-                    {
-                        yield return new DiagnosticRecord(
-                            errorMessage,
-                            parameter.Extent,
-                            GetName(),
-                            DiagnosticSeverity.Warning,
-                            fileName);
-                    }
+                    yield return new DiagnosticRecord(
+                        errorMessage,
+                        parameter.Extent,
+                        GetName(),
+                        DiagnosticSeverity.Warning,
+                        fileName);
                 }
+            }
         }
 
         private bool WrongCredentialUsage(ParameterAst parameter, bool requiresTransformationAttribute)

--- a/Rules/UseShouldProcessCorrectly.cs
+++ b/Rules/UseShouldProcessCorrectly.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// UseShouldProcessCorrectly: Analyzes the ast to check that if the ShouldProcess attribute is present, the function calls ShouldProcess and vice versa.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class UseShouldProcessCorrectly : IScriptRule
     {
@@ -87,7 +87,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <returns>The description of this rule</returns>
         public string GetDescription()
         {
-            return string.Format(CultureInfo.CurrentCulture,Strings.ShouldProcessDescription);
+            return string.Format(CultureInfo.CurrentCulture, Strings.ShouldProcessDescription);
         }
 
         /// <summary>
@@ -366,7 +366,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             if (commandsWithSupportShouldProcess.Count > 0)
             {
                 funcDigraph.AddVertex(implicitShouldProcessVertex);
-                foreach(var v in commandsWithSupportShouldProcess)
+                foreach (var v in commandsWithSupportShouldProcess)
                 {
                     funcDigraph.AddEdge(v, implicitShouldProcessVertex);
                 }
@@ -379,7 +379,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// </summary>
     class Vertex
     {
-        public string Name {get { return name;}}
+        public string Name { get { return name; } }
         public Ast Ast
         {
             get
@@ -392,7 +392,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
         }
 
-        public bool IsNestedFunctionDefinition {get {return isNestedFunctionDefinition;}}
+        public bool IsNestedFunctionDefinition { get { return isNestedFunctionDefinition; } }
 
         private string name;
         private Ast ast;
@@ -403,7 +403,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             name = String.Empty;
         }
 
-        public Vertex (string name, Ast ast)
+        public Vertex(string name, Ast ast)
         {
             if (name == null)
             {
@@ -413,9 +413,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             this.ast = ast;
         }
 
-        public Vertex (String name, Ast ast, bool isNestedFunctionDefinition)
+        public Vertex(String name, Ast ast, bool isNestedFunctionDefinition)
             : this(name, ast)
-            {
+        {
             this.isNestedFunctionDefinition = isNestedFunctionDefinition;
         }
 
@@ -507,7 +507,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // if the graph contains a vertex with name equal to that
             // of the input vertex, then update the vertex's ast if the
             // input vertex's ast is of FunctionDefinitionAst type
-            foreach(Vertex v in digraph.GetVertices())
+            foreach (Vertex v in digraph.GetVertices())
             {
                 if (v.Equals(vertex))
                 {
@@ -574,7 +574,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return AstVisitAction.Continue;
             }
 
-            var vertex = new Vertex (cmdName, ast);
+            var vertex = new Vertex(cmdName, ast);
             AddVertex(vertex);
             if (IsWithinFunctionDefinition())
             {
@@ -612,7 +612,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // necessarily a function, we do it because we are mainly interested in
             // finding connection between a function and ShouldProcess and this approach
             // prevents any unnecessary complexity.
-            var memberVertex = new Vertex (memberExprAst.Value, memberExprAst);
+            var memberVertex = new Vertex(memberExprAst.Value, memberExprAst);
             AddVertex(memberVertex);
             if (IsWithinFunctionDefinition())
             {

--- a/Rules/UseShouldProcessForStateChangingFunctions.cs
+++ b/Rules/UseShouldProcessForStateChangingFunctions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// UseShouldProcessForStateChangingFunctions: Analyzes the ast to check if ShouldProcess is included in Advanced functions if the Verb of the function could change system state.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class UseShouldProcessForStateChangingFunctions : IScriptRule
     {
@@ -32,17 +32,17 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 throw new ArgumentNullException(Strings.NullAstErrorMessage);
             }
-            IEnumerable<Ast> funcDefWithNoShouldProcessAttrAsts = ast.FindAll(IsStateChangingFunctionWithNoShouldProcessAttribute, true);            
+            IEnumerable<Ast> funcDefWithNoShouldProcessAttrAsts = ast.FindAll(IsStateChangingFunctionWithNoShouldProcessAttribute, true);
             foreach (FunctionDefinitionAst funcDefAst in funcDefWithNoShouldProcessAttrAsts)
             {
                 yield return new DiagnosticRecord(
-                    string.Format(CultureInfo.CurrentCulture, Strings.UseShouldProcessForStateChangingFunctionsError, funcDefAst.Name), 
-                    Helper.Instance.GetScriptExtentForFunctionName(funcDefAst),                    
-                    this.GetName(), 
-                    DiagnosticSeverity.Warning, 
+                    string.Format(CultureInfo.CurrentCulture, Strings.UseShouldProcessForStateChangingFunctionsError, funcDefAst.Name),
+                    Helper.Instance.GetScriptExtentForFunctionName(funcDefAst),
+                    this.GetName(),
+                    DiagnosticSeverity.Warning,
                     fileName);
             }
-                            
+
         }
         /// <summary>
         /// Checks if the ast defines a state changing function
@@ -57,7 +57,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 return false;
             }
-            return Helper.Instance.IsStateChangingFunctionName(funcDefAst.Name) 
+            return Helper.Instance.IsStateChangingFunctionName(funcDefAst.Name)
                     && (funcDefAst.Body.ParamBlock == null
                         || funcDefAst.Body.ParamBlock.Attributes == null
                         || !HasShouldProcessTrue(funcDefAst.Body.ParamBlock.Attributes));

--- a/Rules/UseSingularNouns.cs
+++ b/Rules/UseSingularNouns.cs
@@ -10,13 +10,13 @@
 // THE SOFTWARE.
 //
 
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Management.Automation.Language;
-using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System.ComponentModel.Composition;
 using System.Globalization;
+using System.Linq;
+using System.Management.Automation.Language;
 using System.Text.RegularExpressions;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
@@ -26,7 +26,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// 
     /// </summary>
     [Export(typeof(IScriptRule))]
-    public class CmdletSingularNoun : IScriptRule {
+    public class CmdletSingularNoun : IScriptRule
+    {
 
         private readonly string[] nounWhiteList =
         {
@@ -39,7 +40,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <param name="ast"></param>
         /// <param name="fileName"></param>
         /// <returns></returns>
-        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName) {
+        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
             if (ast == null) throw new ArgumentNullException(Strings.NullCommandInfoError);
 
             IEnumerable<Ast> funcAsts = ast.FindAll(item => item is FunctionDefinitionAst, true);
@@ -57,7 +59,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     // Convert the noun part of the function into a series of space delimited words
                     // This helps the PluralizationService to provide an accurate determination about the plurality of the string
                     nounPart = SplitCamelCaseString(nounPart);
-                    var words = nounPart.Split(new char [] { ' ' });
+                    var words = nounPart.Split(new char[] { ' ' });
                     var noun = words.LastOrDefault();
                     if (noun == null)
                     {
@@ -106,7 +108,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// GetDescription: Retrieves the description of this rule.
         /// </summary>
         /// <returns>The description of this rule</returns>
-        public string GetDescription() {
+        public string GetDescription()
+        {
             return string.Format(CultureInfo.CurrentCulture, Strings.UseSingularNounsDescription);
         }
 

--- a/Rules/UseStandardDSCFunctionsInResource.cs
+++ b/Rules/UseStandardDSCFunctionsInResource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// UseStandardDSCFunctionsInResource: Checks if the DSC resource uses standard Get/Set/Test TargetResource functions.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IDSCResourceRule))]
+    [Export(typeof(IDSCResourceRule))]
 #endif
     public class UseStandardDSCFunctionsInResource : IDSCResourceRule
     {
@@ -30,9 +30,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         public IEnumerable<DiagnosticRecord> AnalyzeDSCResource(Ast ast, string fileName)
         {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
-                        
+
             // Expected TargetResource functions in the DSC Resource module
-            List<string> expectedTargetResourceFunctionNames = new List<string>(new string[]  { "Get-TargetResource", "Set-TargetResource", "Test-TargetResource" });
+            List<string> expectedTargetResourceFunctionNames = new List<string>(new string[] { "Get-TargetResource", "Set-TargetResource", "Test-TargetResource" });
 
             // Retrieve a list of Asts where the function name contains TargetResource            
             IEnumerable<Ast> functionDefinitionAsts = (ast.FindAll(dscAst => dscAst is FunctionDefinitionAst && ((dscAst as FunctionDefinitionAst).Name.IndexOf("targetResource", StringComparison.OrdinalIgnoreCase) != -1), true));
@@ -42,17 +42,17 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 targetResourceFunctionNamesInAst.Add(functionDefinitionAst.Name);
             }
-            
+
             foreach (string expectedTargetResourceFunctionName in expectedTargetResourceFunctionNames)
             {
                 // If the Ast does not contain the expected functions, provide a Rule violation message
                 if (!targetResourceFunctionNamesInAst.Contains(expectedTargetResourceFunctionName, StringComparer.OrdinalIgnoreCase))
                 {
                     yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.UseStandardDSCFunctionsInResourceError, expectedTargetResourceFunctionName),
-                        ast.Extent, GetName(), DiagnosticSeverity.Error, fileName);      
+                        ast.Extent, GetName(), DiagnosticSeverity.Error, fileName);
                 }
             }
-        }        
+        }
 
         /// <summary>
         /// AnalyzeDSCClass: Analyzes dsc classes and the file and check that they have get, set and test
@@ -64,13 +64,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
-            #if (PSV3||PSV4)
+#if (PSV3 || PSV4)
 
             return null;
 
-            #else
+#else
 
-            List<string> resourceFunctionNames = new List<string>(new string[] {"Test", "Get", "Set"});
+            List<string> resourceFunctionNames = new List<string>(new string[] { "Test", "Get", "Set" });
 
             IEnumerable<Ast> dscClasses = ast.FindAll(item =>
                 item is TypeDefinitionAst
@@ -91,15 +91,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
             }
 
-            #endif
-        }        
+#endif
+        }
 
         /// <summary>
         /// GetName: Retrieves the name of this rule.
         /// </summary>
         /// <returns>The name of this rule</returns>
         public string GetName()
-        {            
+        {
             return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.UseStandardDSCFunctionsInResourceName);
         }
 
@@ -143,7 +143,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// </summary>
         public string GetSourceName()
         {
-            return string.Format(CultureInfo.CurrentCulture,Strings.DSCSourceName);
+            return string.Format(CultureInfo.CurrentCulture, Strings.DSCSourceName);
         }
     }
 

--- a/Rules/UseToExportFieldsInManifest.cs
+++ b/Rules/UseToExportFieldsInManifest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         private const string functionsToExport = "FunctionsToExport";
         private const string cmdletsToExport = "CmdletsToExport";
         private const string aliasesToExport = "AliasesToExport";
-                   
+
         /// <summary>
         /// AnalyzeScript: Analyzes the AST to check if AliasToExport, CmdletsToExport, FunctionsToExport 
         /// and VariablesToExport fields do not use wildcards and $null in their entries. 
@@ -43,7 +43,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 throw new ArgumentNullException(Strings.NullAstErrorMessage);
             }
-            
+
             if (fileName == null || !Helper.IsModuleManifest(fileName))
             {
                 yield break;
@@ -51,31 +51,31 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             // check if valid module manifest
             IEnumerable<ErrorRecord> errorRecord = null;
-            PSModuleInfo psModuleInfo = Helper.Instance.GetModuleManifest(fileName, out errorRecord);            
+            PSModuleInfo psModuleInfo = Helper.Instance.GetModuleManifest(fileName, out errorRecord);
             if ((errorRecord != null && errorRecord.Count() > 0) || psModuleInfo == null)
-            {                
+            {
                 yield break;
             }
-            
+
             var hashtableAst = ast.Find(x => x is HashtableAst, false) as HashtableAst;
-            
+
             if (hashtableAst == null)
-            {                                
+            {
                 yield break;
             }
 
             string[] manifestFields = { functionsToExport, cmdletsToExport, aliasesToExport };
 
-            foreach(string field in manifestFields)
+            foreach (string field in manifestFields)
             {
                 IScriptExtent extent;
                 if (!HasAcceptableExportField(field, hashtableAst, ast.Extent.Text, out extent) && extent != null)
                 {
                     yield return new DiagnosticRecord(
-                        GetError(field), 
-                        extent, 
-                        GetName(), 
-                        DiagnosticSeverity.Warning, 
+                        GetError(field),
+                        extent,
+                        GetName(),
+                        DiagnosticSeverity.Warning,
                         fileName,
                         suggestedCorrections: GetCorrectionExtent(field, extent, psModuleInfo));
                 }
@@ -83,8 +83,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
 
                 }
-            }                               
-                        
+            }
+
         }
 
         private string GetListLiteral<T>(Dictionary<string, T> exportedItemsDict)
@@ -124,7 +124,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         private List<CorrectionExtent> GetCorrectionExtent(string field, IScriptExtent extent, PSModuleInfo psModuleInfo)
         {
-            Debug.Assert(field != null);            
+            Debug.Assert(field != null);
             Debug.Assert(psModuleInfo != null);
             Debug.Assert(extent != null);
             var corrections = new List<CorrectionExtent>();
@@ -194,7 +194,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     && varExprAst.VariablePath.IsUnqualified
                     && varExprAst.VariablePath.UserPath.Equals("null", StringComparison.OrdinalIgnoreCase);
         }
-                
+
         /// <summary>
         /// Checks if the *ToExport fields are explicitly set to arrays, eg. @(...), and the array entries do not contain any wildcard.
         /// </summary>
@@ -209,7 +209,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             foreach (var pair in hast.KeyValuePairs)
             {
                 var keyStrConstAst = pair.Item1 as StringConstantExpressionAst;
-                if (keyStrConstAst != null && keyStrConstAst.Value.Equals(key, StringComparison.OrdinalIgnoreCase))                    
+                if (keyStrConstAst != null && keyStrConstAst.Value.Equals(key, StringComparison.OrdinalIgnoreCase))
                 {
                     // Checks for wildcard character in the entry.
                     var astWithWildcard = pair.Item2.Find(HasWildcardInExpression, false);
@@ -235,9 +235,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
             }
             return true;
-        }       
+        }
 
-        
+
         /// <summary>
         /// Gets the error string of the rule.
         /// </summary>

--- a/Rules/UseUTF8EncodingForHelpFile.cs
+++ b/Rules/UseUTF8EncodingForHelpFile.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// AvoidAlias: Check if help file uses utf8 encoding
     /// </summary>
 #if !CORECLR
-[Export(typeof(IScriptRule))]
+    [Export(typeof(IScriptRule))]
 #endif
     public class UseUTF8EncodingForHelpFile : IScriptRule
     {

--- a/Rules/UseVerboseMessageInDSCResource.cs
+++ b/Rules/UseVerboseMessageInDSCResource.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// UseVerboseMessageInDSCResource: Analyzes the ast to check that Write-Verbose is called for DSC Resources.
     /// </summary>
 #if !CORECLR
-[Export(typeof(IDSCResourceRule))]
+    [Export(typeof(IDSCResourceRule))]
 #endif
     public class UseVerboseMessageInDSCResource : SkipNamedBlock, IDSCResourceRule
     {
@@ -31,7 +31,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             if (ast == null)
             {
                 throw new ArgumentNullException(Strings.NullAstErrorMessage);
-            }            
+            }
 
             IEnumerable<Ast> functionDefinitionAsts = Helper.Instance.DscResourceFunctions(ast);
 
@@ -56,7 +56,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             }
         }
-        
+
         /// <summary>
         /// AnalyzeDSCClass: This function returns nothing in the case of dsc class.
         /// </summary>


### PR DESCRIPTION
## PR Summary

This will make the diff in future PR's cleaner.
This was done using Visual Studios new code cleanup feature that runs the formatter on all files and removes unused namespaces

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.