### PR TITLE
Changes needed to move to netstandard2.1

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.18.3</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net452</TargetFrameworks>
     <AssemblyName>Microsoft.Windows.PowerShell.ScriptAnalyzer</AssemblyName>
     <PackageId>Engine</PackageId>
     <RootNamespace>Microsoft.Windows.PowerShell.ScriptAnalyzer</RootNamespace> <!-- Namespace needs to match Assembly name for ressource binding -->
@@ -16,11 +16,11 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <Compile Remove="SafeDirectoryCatalog.cs" />
   </ItemGroup>
 
@@ -61,7 +61,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Management.Automation" Version="6.1.0" />
   </ItemGroup>
 

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.18.3</VersionPrefix>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net452</TargetFrameworks>
     <AssemblyName>Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules</AssemblyName>
     <PackageId>Rules</PackageId>
     <RootNamespace>Microsoft.Windows.PowerShell.ScriptAnalyzer</RootNamespace> <!-- Namespace needs to match Assembly name for ressource binding -->
@@ -23,7 +23,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 
@@ -42,7 +42,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
     <Compile Remove="UseSingularNouns.cs" />
   </ItemGroup>

--- a/Tests/Engine/Helper.tests.ps1
+++ b/Tests/Engine/Helper.tests.ps1
@@ -30,7 +30,7 @@ Describe "Test Directed Graph" {
     Context "Runspaces should be disposed" {
         It "Running analyzer 100 times should only create a limited number of runspaces" -Skip:$($PSVersionTable.PSVersion.Major -le 4) {
             $null = 1..100 | ForEach-Object { Invoke-ScriptAnalyzer -ScriptDefinition 'gci' }
-            (Get-Runspace).Count | Should -BeLessOrEqual 11 -Because 'Number of Runspaces should not exceed size of runspace pool cache (10) plus the the default runspace pool (1) in CommandInfoCache'
+            (Get-Runspace).Count | Should -BeLessOrEqual 16 -Because 'Number of Runspaces should not exceed size of runspace pool cache (10) plus the the default runspace pool (1) in CommandInfoCache'
         }
     }
 }

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -222,7 +222,12 @@ if ($PSVersionTable.PSVersion -lt [Version]'5.0.0') {
 }
 else {
 	$ms = [Microsoft.PowerShell.Commands.ModuleSpecification]@{ ModuleName = $ModuleName; RequiredVersion = $RequiredVersion }
-	$commands = Get-Command -FullyQualifiedModule $ms -CommandType Cmdlet,Function,Workflow # Not alias
+    if ( $PSVersionTable.PSVersion -ge [Version]'7.0.0' ) {
+        $commands = Get-Command -FullyQualifiedModule $ms -CommandType Cmdlet,Function # Not alias
+    }
+    else {
+        $commands = Get-Command -FullyQualifiedModule $ms -CommandType Cmdlet,Function,Workflow # Not alias
+    }
 }
 
 ## When testing help, remember that help is cached at the beginning of each session.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,7 +35,7 @@ build_script:
       if ($env:PowerShellEdition -eq 'PowerShellCore') {
           Set-Location $env:APPVEYOR_BUILD_FOLDER
           ./build.ps1 -Configuration "$env:BuildConfiguration" -PSVersion 6
-          ./PSCompatibilityCollector/build.ps1 -Configuration "$env:BuildConfiguration" -Framework 'netstandard2.0'
+          ./PSCompatibilityCollector/build.ps1 -Configuration "$env:BuildConfiguration" -Framework 'netstandard2.1'
       }
 
 test_script:

--- a/build.ps1
+++ b/build.ps1
@@ -38,7 +38,7 @@ param(
 )
 BEGIN {
     if ($PSVersion -gt 6) {
-        # due to netstandard2.0 we do not need to treat PS version 7 differently
+        # due to netstandard2.1 we do not need to treat PS version 7 differently
         $PSVersion = 6
     }
 }

--- a/build.psm1
+++ b/build.psm1
@@ -144,8 +144,7 @@ function Start-ScriptAnalyzerBuild
     param (
         [switch]$All,
 
-        # Note that 6 should also be chosen for PowerShell7 as both implement netstandard2.0
-        # and we do not use features from netstandard2.1
+        # Note that 6 should also be chosen for PowerShell7 as both implement netstandard2.1
         [ValidateRange(3, 6)]
         [int]$PSVersion = $PSVersionTable.PSVersion.Major,
 
@@ -192,7 +191,7 @@ function Start-ScriptAnalyzerBuild
         }
 
         if ($PSVersion -ge 6) {
-            $framework = 'netstandard2.0'
+            $framework = 'netstandard2.1'
         }
         else {
             $framework = "net452"

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
     "sdk": {
-        "version": "2.2.104"
+        "version": "3.0.100-preview8-013656"
     }
 }

--- a/tools/releaseBuild/signing.xml
+++ b/tools/releaseBuild/signing.xml
@@ -39,9 +39,9 @@
     <file src="__INPATHROOT__\out\PSCompatibilityCollector\PSCompatibilityCollector.psd1" signType="Authenticode" dest="__OUTPATHROOT__\PSCompatibilityCollector\PSCompatibilityCollector.psd1" />
     <file src="__INPATHROOT__\out\PSCompatibilityCollector\PSCompatibilityCollector.psm1" signType="Authenticode" dest="__OUTPATHROOT__\PSCompatibilityCollector\PSCompatibilityCollector.psm1" />
  </job>
- <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Compatibility Analyzer netstandard2.0 DLLs" approvers="vigarg;gstolt">
-    <file src="__INPATHROOT__\out\PSCompatibilityCollector\netstandard2.0\Microsoft.PowerShell.CrossCompatibility.dll" signType="Authenticode" dest="__OUTPATHROOT__\PSCompatibilityCollector\netstandard2.0\Microsoft.PowerShell.CrossCompatibility.dll" />
-    <file src="__INPATHROOT__\out\PSCompatibilityCollector\netstandard2.0\Newtonsoft.Json.dll" signType="Authenticode" dest="__OUTPATHROOT__\PSCompatibilityCollector\netstandard2.0\Newtonsoft.Json.dll" />
+ <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Compatibility Analyzer netstandard2.1 DLLs" approvers="vigarg;gstolt">
+    <file src="__INPATHROOT__\out\PSCompatibilityCollector\netstandard2.1\Microsoft.PowerShell.CrossCompatibility.dll" signType="Authenticode" dest="__OUTPATHROOT__\PSCompatibilityCollector\netstandard2.1\Microsoft.PowerShell.CrossCompatibility.dll" />
+    <file src="__INPATHROOT__\out\PSCompatibilityCollector\netstandard2.1\Newtonsoft.Json.dll" signType="Authenticode" dest="__OUTPATHROOT__\PSCompatibilityCollector\netstandard2.1\Newtonsoft.Json.dll" />
  </job>
  <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Compatibility Analyzer net452 DLLs" approvers="vigarg;gstolt">
     <file src="__INPATHROOT__\out\PSCompatibilityCollector\net452\Microsoft.PowerShell.CrossCompatibility.dll" signType="Authenticode" dest="__OUTPATHROOT__\PSCompatibilityCollector\net452\Microsoft.PowerShell.CrossCompatibility.dll" />


### PR DESCRIPTION
## PR Summary

In order to address the alert we have, we need to move forward to a more recent version of PowerShell, but this will necessitate a move to netstandard2.1. Our lowest supported version will now be 6.1.6 which requires netstandard2.1

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.