### PR TITLE
Fix configuration for PS v5 and v6 builds to be Debug/Release and not PSV6Debug, etc. as it used to be able to produce actual debug builds

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -239,7 +239,10 @@ function Start-ScriptAnalyzerBuild
             }
         }
 
-        $config = "PSV${PSVersion}${Configuration}"
+        $buildConfiguration = $Configuration
+        if ((3, 4) -contains $PSVersion) {
+            $buildConfiguration = "PSV${PSVersion}${Configuration}"
+        }
 
         # Build ScriptAnalyzer
         # The Rules project has a dependency on the Engine therefore just building the Rules project is enough
@@ -249,7 +252,7 @@ function Start-ScriptAnalyzerBuild
             if ( -not $script:DotnetExe ) {
                 $script:DotnetExe = Get-DotnetExe
             }
-            $buildOutput = & $script:DotnetExe build --framework $framework --configuration "$config" 2>&1
+            $buildOutput = & $script:DotnetExe build --framework $framework --configuration "$buildConfiguration" 2>&1
             if ( $LASTEXITCODE -ne 0 ) { throw "$buildOutput" }
         }
         catch {
@@ -264,9 +267,9 @@ function Start-ScriptAnalyzerBuild
         Publish-File $itemsToCopyCommon $script:destinationDir
 
         $itemsToCopyBinaries = @(
-            "$projectRoot\Engine\bin\${config}\${Framework}\Microsoft.Windows.PowerShell.ScriptAnalyzer.dll",
-            "$projectRoot\Rules\bin\${config}\${Framework}\Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll"
-            "$projectRoot\Rules\bin\${config}\${framework}\Microsoft.PowerShell.CrossCompatibility.dll"
+            "$projectRoot\Engine\bin\${buildConfiguration}\${Framework}\Microsoft.Windows.PowerShell.ScriptAnalyzer.dll",
+            "$projectRoot\Rules\bin\${buildConfiguration}\${Framework}\Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll"
+            "$projectRoot\Rules\bin\${buildConfiguration}\${framework}\Microsoft.PowerShell.CrossCompatibility.dll"
             )
         Publish-File $itemsToCopyBinaries $destinationDirBinaries
 
@@ -274,7 +277,7 @@ function Start-ScriptAnalyzerBuild
         Publish-File $settingsFiles (Join-Path -Path $script:destinationDir -ChildPath Settings)
 
         if ($framework -eq 'net452') {
-            Copy-Item -path "$projectRoot\Rules\bin\${config}\${framework}\Newtonsoft.Json.dll" -Destination $destinationDirBinaries
+            Copy-Item -path "$projectRoot\Rules\bin\${buildConfiguration}\${framework}\Newtonsoft.Json.dll" -Destination $destinationDirBinaries
         }
 
         Pop-Location


### PR DESCRIPTION
## PR Summary

The special `PSV4Debug` and `PSV3Debug` configurations apply only to builds of v3 and v4. The other builds do not need that and should just be `Debug`/`Release` as a config. At the moment this makes Debug build actually be Release builds, which this PR fixes. cc @thomasrayner 
This minor regression was introduced in the build module refactoring of PR #1139

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.