### PR TITLE
Use Where-Object instead of alias in buildmodule.tests.ps1

### DIFF
--- a/BuildModule.tests.ps1
+++ b/BuildModule.tests.ps1
@@ -141,10 +141,10 @@ Describe "Build Module Tests" {
             $results.Count | Should -Be 2
         }
         It "Get-TestResults finds 1 pass" {
-            @($results | Where-Object -FilterScript { $_.result -eq "Success" }).Count |Should -Be 1
+            @($results | Where-Object -FilterScript { $_.result -eq "Success" }).Count | Should -Be 1
         }
         It "Get-TestResults finds 1 failure" {
-            @($results | Where-Object -FilterScript { $_.result -eq "Failure" }).Count |Should -Be 1
+            @($results | Where-Object -FilterScript { $_.result -eq "Failure" }).Count | Should -Be 1
         }
         It "Get-TestFailures finds 1 failure" {
             $failures.Count | Should -Be 1

--- a/BuildModule.tests.ps1
+++ b/BuildModule.tests.ps1
@@ -141,10 +141,10 @@ Describe "Build Module Tests" {
             $results.Count | Should -Be 2
         }
         It "Get-TestResults finds 1 pass" {
-            @($results | ?{ $_.result -eq "Success" }).Count |Should -Be 1
+            @($results | Where-Object -FilterScript { $_.result -eq "Success" }).Count |Should -Be 1
         }
         It "Get-TestResults finds 1 failure" {
-            @($results | ?{ $_.result -eq "Failure" }).Count |Should -Be 1
+            @($results | Where-Object -FilterScript { $_.result -eq "Failure" }).Count |Should -Be 1
         }
         It "Get-TestFailures finds 1 failure" {
             $failures.Count | Should -Be 1


### PR DESCRIPTION
## PR Summary

Use `Where-Object` instead of `?` in `BuildModule.tests.ps1`

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.