### PR TITLE
Harden handling when getting the installed dotnet cli version

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -534,7 +534,6 @@ function Get-InstalledCLIVersion {
         # earlier versions of dotnet do not support --list-sdks, so we'll check the output
         # and use dotnet --version as a fallback
         $sdkList = & $script:DotnetExe --list-sdks 2>&1
-        $sdkList = "Unknown option"
         if ( $sdkList -match "Unknown option" ) {
             $installedVersions = & $script:DotnetExe --version 2>$null
         }
@@ -618,9 +617,15 @@ function Get-DotnetExe
         # it's possible that there are multiples. Take the highest version we find
         # the problem is that invoking dotnet on a version which is lower than the specified
         # version in global.json will produce an error, so we can only take the dotnet which executes
+        #
+        # dotnet --version has changed its output, so we have to work much harder to determine what's installed.
+        # dotnet --version can now emit a list of installed sdks as output *and* an error if the global.json
+        # file points to a version of the sdk which is *not* installed. However, the format of the new list
+        # with --version has a couple of spaces at the beginning of the line, so we need to be resilient
+        # against that.
         $latestDotnet = $discoveredDotNet |
             Where-Object { try { & $_ --version 2>$null } catch { } } |
-            Sort-Object { $pv = ConvertTo-PortableVersion (& $_ --version 2>$null); "$pv" } |
+            Sort-Object { $pv = ConvertTo-PortableVersion (& $_ --version 2>$null| %{$_.Trim().Split()[0]}); "$pv" } |
             Select-Object -Last 1
         if ( $latestDotnet ) {
             $script:DotnetExe = $latestDotnet


### PR DESCRIPTION
## PR Summary

`dotnet --version` can now emit a list of installed sdks as output *and* an error if the global.json
file points to a version of the sdk which is *not* installed. However, the format of the new list
with --version has a couple of spaces at the beginning of the line, so we need to be resilient
against that.

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.