### PR TITLE
Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,9 +355,9 @@ The next example selects a few rules to execute instead of all the default rules
 }
 ```
 
-Then invoke that settings file when using:
+Then invoke that settings file:
 ``` PowerShell
-Invoke-ScriptAnalyzer -Path MyScript.ps1 -Setting ScriptAnalyzerSettings.psd1
+Invoke-ScriptAnalyzer -Path MyScript.ps1 -Setting PSScriptAnalyzerSettings.psd1
 ```
 
 ## Implicit

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ that does not output an Error or Warning diagnostic record.
 Then invoke that settings file when using `Invoke-ScriptAnalyzer`:
 
 ``` PowerShell
-Invoke-ScriptAnalyzer -Path MyScript.ps1 -Setting PSScriptAnalyzerSettings.psd1
+Invoke-ScriptAnalyzer -Path MyScript.ps1 -Settings PSScriptAnalyzerSettings.psd1
 ```
 
 The next example selects a few rules to execute instead of all the default rules.
@@ -357,7 +357,7 @@ The next example selects a few rules to execute instead of all the default rules
 
 Then invoke that settings file:
 ``` PowerShell
-Invoke-ScriptAnalyzer -Path MyScript.ps1 -Setting PSScriptAnalyzerSettings.psd1
+Invoke-ScriptAnalyzer -Path MyScript.ps1 -Settings PSScriptAnalyzerSettings.psd1
 ```
 
 ## Implicit


### PR DESCRIPTION
Correct the script name to match the name in the example.

Removed the `when using`. It belonged with the `when using Invoke-ScriptAnalyzer` used in the previous example and repeating that seems unnecessary.
