### PR TITLE
Fix false positive of AvoidAlias rule for implicit aliasing of Get- commands for the CommandType ExternalScript

### DIFF
--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -136,7 +136,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
 
                 var commdNameWithGetPrefix = $"Get-{commandName}";
-                var cmdletNameIfCommandWasMissingGetPrefix = Helper.Instance.GetCommandInfo(commdNameWithGetPrefix);
+                var cmdletNameIfCommandWasMissingGetPrefix = Helper.Instance.GetCommandInfo(name: commdNameWithGetPrefix,
+                    commandType: CommandTypes.Cmdlet | CommandTypes.Function | CommandTypes.Script);
                 if (cmdletNameIfCommandWasMissingGetPrefix != null)
                 {
                     yield return new DiagnosticRecord(


### PR DESCRIPTION

## PR Summary

Fixes #1369
Unfortunately this issue could only be reproduced when PSSA is hosted within PSES where the root of the workspace becomes the working directory of the runspace pool, which causes `Get-Command ..\PathToScript.ps1` to return a command type of ExternalScript, which then makes it into the command cache and causes the false positve.
The fix is to search only for cmdlets/functions where the implicit `Get-` aliasing applies.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.