### PR TITLE
Remove obsolete GetCommandInfoLegacy method and use GetCommandInfo instead

### DIFF
--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -70,21 +70,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             return _commandInfoCache.GetOrAdd(key, new Lazy<CommandInfo>(() => GetCommandInfoInternal(commandName, commandTypes))).Value;
         }
 
-        /// <summary>
-        /// Retrieve a command info object about a command.
-        /// </summary>
-        /// <param name="commandName">Name of the command to get a commandinfo object for.</param>
-        /// <param name="commandTypes">What types of command are needed. If omitted, all types are retrieved.</param>
-        /// <returns></returns>
-        [Obsolete("Alias lookup is expensive and should not be relied upon for command lookup")]
-        public CommandInfo GetCommandInfoLegacy(string commandOrAliasName, CommandTypes? commandTypes = null)
-        {
-            string commandName = _helperInstance.GetCmdletNameFromAlias(commandOrAliasName);
-
-            return string.IsNullOrEmpty(commandName)
-                ? GetCommandInfo(commandOrAliasName, commandTypes: commandTypes)
-                : GetCommandInfo(commandName, commandTypes: commandTypes);
-        }
 
         /// <summary>
         /// Get a CommandInfo object of the given command name

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -667,20 +667,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             return moreThanTwoPositional ? argumentsWithoutProcedingParameters > 2 : argumentsWithoutProcedingParameters > 0;
         }
 
-        /// <summary>
-        ///  Legacy method, new callers should use <see cref="GetCommandInfo"/> instead.
-        ///  Given a command's name, checks whether it exists. It does not use the passed in CommandTypes parameter, which is a bug.
-        ///  But existing method callers are already depending on this behaviour and therefore this could not be simply fixed.
-        ///  It also populates the commandInfoCache which can have side effects in some cases.
-        /// </summary>
-        /// <param name="name">Command Name.</param>
-        /// <param name="commandType">Not being used.</param>
-        /// <returns></returns>
-        [Obsolete]
-        public CommandInfo GetCommandInfoLegacy(string name, CommandTypes? commandType = null)
-        {
-            return CommandInfoCache.GetCommandInfoLegacy(commandOrAliasName: name, commandTypes: commandType);
-        }
 
         /// <summary>
         /// Given a command's name, checks whether it exists.

--- a/Rules/UseCmdletCorrectly.cs
+++ b/Rules/UseCmdletCorrectly.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             #region Compares parameter list and mandatory parameter list.
 
-            CommandInfo cmdInfo = Helper.Instance.GetCommandInfoLegacy(cmdAst.GetCommandName());
+            CommandInfo cmdInfo = Helper.Instance.GetCommandInfo(cmdAst.GetCommandName());
 
             // If we can't resolve the command or it's not a cmdlet, we are done
             if (cmdInfo == null || (cmdInfo.CommandType != System.Management.Automation.CommandTypes.Cmdlet))

--- a/Rules/UseShouldProcessCorrectly.cs
+++ b/Rules/UseShouldProcessCorrectly.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return false;
             }
 
-            var cmdInfo = Helper.Instance.GetCommandInfoLegacy(cmdName);
+            var cmdInfo = Helper.Instance.GetCommandInfo(cmdName);
             if (cmdInfo == null)
             {
                 return false;


### PR DESCRIPTION
## PR Summary

In the past we could not remove them because it broke tests but now it seems that tests are OK.
There is a risk for a regression that is not covered by tests but especially with the new way of PSSA being hosted, it feels more worth of a try now.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.