### PR TITLE
Correct casing of parameters as well in PSUseCorrectCasing formatter rule

### DIFF
--- a/RuleDocumentation/UseCorrectCasing.md
+++ b/RuleDocumentation/UseCorrectCasing.md
@@ -4,24 +4,22 @@
 
 ## Description
 
-This is a style/formatting rule. PowerShell is case insensitive where applicable. The casing of cmdlet names does not matter but this rule ensures that the casing matches for consistency and also because most cmdlets start with an upper case and using that improves readability to the human eye.
+This is a style/formatting rule. PowerShell is case insensitive where applicable. The casing of cmdlet names or parameters does not matter but this rule ensures that the casing matches for consistency and also because most cmdlets/parameters start with an upper case and using that improves readability to the human eye.
 
 ## How
 
-Use exact casing of the cmdlet, e.g. `Invoke-Command`.
+Use exact casing of the cmdlet and its parameters, e.g. `Invoke-Command { 'foo' } -RunAsAdministrator`.
 
 ## Example
 
 ### Wrong
 
 ``` PowerShell
-invoke-command { 'foo' }
-}
+invoke-command { 'foo' } -runasadministrator
 ```
 
 ### Correct
 
 ``` PowerShell
-Invoke-Command { 'foo' }
-}
+Invoke-Command { 'foo' } -RunAsAdministrator
 ```

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -493,6 +493,42 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Avoid overwriting built in cmdlets.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsCommonName {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsCommonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not overwrite the definition of a cmdlet that is included with PowerShell.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsDescription {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a cmdlet that is included with PowerShell (version {1}) whose definition should not be overridden.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsError {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidOverwritingBuiltInCmdlets.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsName {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Avoid Using ShouldContinue Without Boolean Force Parameter.
         /// </summary>
         internal static string AvoidShouldContinueWithoutForceCommonName {
@@ -2084,50 +2120,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
                 return ResourceManager.GetString("UseCompatibleCmdletsName", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Avoid overwriting built in cmdlets.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsCommonName
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsCommonName", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Avoid overwriting built in cmdlets.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsDescription
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsDescription", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a cmdlet that is included with PowerShell whose definition should not be overridden.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsError
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsError", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to AvoidOverwritingBuiltInCmdlets.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsName
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsName", resourceCulture);
-            }
-        }
         
         /// <summary>
         ///   Looks up a localized string similar to The command &apos;{0}&apos; is not available by default in PowerShell version &apos;{1}&apos; on platform &apos;{2}&apos;.
@@ -2427,7 +2419,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use exact casing of cmdlet/function name..
+        ///   Looks up a localized string similar to Use exact casing of cmdlet/function/parameter name..
         /// </summary>
         internal static string UseCorrectCasingCommonName {
             get {
@@ -2436,7 +2428,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to For better readability and consistency, use the exact casing of the cmdlet/function..
+        ///   Looks up a localized string similar to For better readability and consistency, use the exact casing of the cmdlet/function/parameter..
         /// </summary>
         internal static string UseCorrectCasingDescription {
             get {
@@ -2445,7 +2437,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cmdlet/Function does not match its exact casing &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Cmdlet/Function/Parameter does not match its exact casing &apos;{0}&apos;..
         /// </summary>
         internal static string UseCorrectCasingError {
             get {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1081,13 +1081,13 @@
     <value>Use space before pipe.</value>
   </data>
   <data name="UseCorrectCasingCommonName" xml:space="preserve">
-    <value>Use exact casing of cmdlet/function name.</value>
+    <value>Use exact casing of cmdlet/function/parameter name.</value>
   </data>
   <data name="UseCorrectCasingDescription" xml:space="preserve">
-    <value>For better readability and consistency, use the exact casing of the cmdlet/function.</value>
+    <value>For better readability and consistency, use the exact casing of the cmdlet/function/parameter.</value>
   </data>
   <data name="UseCorrectCasingError" xml:space="preserve">
-    <value>Cmdlet/Function does not match its exact casing '{0}'.</value>
+    <value>Cmdlet/Function/Parameter does not match its exact casing '{0}'.</value>
   </data>
   <data name="UseCorrectCasingName" xml:space="preserve">
     <value>UseCorrectCasing</value>

--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -54,4 +54,15 @@ Describe "UseCorrectCasing" {
         $scriptDefinition = ". $uncPath"
         Invoke-Formatter $scriptDefinition | Should -Be $scriptDefinition
     }
+
+    It "Corrects parameter casing" {
+        function Invoke-DummyFunction ($ParameterName) { }
+
+        Invoke-Formatter 'Invoke-DummyFunction -parametername $parameterValue' |
+            Should -Be 'Invoke-DummyFunction -ParameterName $parameterValue'
+        Invoke-Formatter 'Invoke-DummyFunction -parametername:$parameterValue' |
+            Should -Be 'Invoke-DummyFunction -ParameterName:$parameterValue'
+        Invoke-Formatter 'Invoke-DummyFunction -parametername: $parameterValue' |
+            Should -Be 'Invoke-DummyFunction -ParameterName: $parameterValue'
+    }
 }


### PR DESCRIPTION
## PR Summary

Correct casing of parameters as well in PSUseCorrectCasing formatter rule.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.