### PR TITLE
Remove redundant whitespace between parameters with new option (disabled by default) in UseConsistentWhitespace

### DIFF
--- a/Engine/Settings/CodeFormatting.psd1
+++ b/Engine/Settings/CodeFormatting.psd1
@@ -38,6 +38,7 @@
             CheckOperator   = $true
             CheckPipe       = $true
             CheckSeparator  = $true
+            CheckParameter  = $false
         }
 
         PSAlignAssignmentStatement = @{

--- a/Engine/Settings/CodeFormattingAllman.psd1
+++ b/Engine/Settings/CodeFormattingAllman.psd1
@@ -38,6 +38,7 @@
             CheckOperator   = $true
             CheckPipe       = $true
             CheckSeparator  = $true
+            CheckParameter  = $false
         }
 
         PSAlignAssignmentStatement = @{

--- a/Engine/Settings/CodeFormattingOTBS.psd1
+++ b/Engine/Settings/CodeFormattingOTBS.psd1
@@ -38,6 +38,7 @@
             CheckOperator  = $true
             CheckPipe       = $true
             CheckSeparator = $true
+            CheckParameter = $false
         }
 
         PSAlignAssignmentStatement = @{

--- a/Engine/Settings/CodeFormattingStroustrup.psd1
+++ b/Engine/Settings/CodeFormattingStroustrup.psd1
@@ -39,6 +39,7 @@
             CheckOperator   = $true
             CheckPipe       = $true
             CheckSeparator  = $true
+            CheckParameter  = $false
         }
 
         PSAlignAssignmentStatement = @{

--- a/RuleDocumentation/UseConsistentWhitespace.md
+++ b/RuleDocumentation/UseConsistentWhitespace.md
@@ -20,6 +20,7 @@
             CheckOperator   = $true
             CheckPipe       = $true
             CheckSeparator  = $true
+            CheckParameter  = $false
         }
     }
 ```
@@ -53,3 +54,8 @@ Checks if a comma or a semicolon is followed by a space. E.g. `@(1, 2, 3)` or `@
 #### CheckPipe: bool (Default value is `$true`)
 
 Checks if a pipe is surrounded on both sides by a space. E.g. `foo | bar` instead of `foo|bar`.
+
+#### CheckParameter: bool (Default value is `$false` at the moment due to the setting being new)
+
+Checks if there is more than one space between parameters and values. E.g. `foo -bar $baz -bat` instead of `foo   -bar   $baz   -bat`. This eliminates redundant whitespace that was probably added unintentionally.
+The rule does not check for whitespace between parameter and value when the colon syntax `-ParameterName:$ParameterValue` is used as some users prefer either 0 or 1 whitespace in this case.

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -493,6 +493,42 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Avoid overwriting built in cmdlets.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsCommonName {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsCommonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not overwrite the definition of a cmdlet that is included with PowerShell.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsDescription {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a cmdlet that is included with PowerShell (version {1}) whose definition should not be overridden.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsError {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidOverwritingBuiltInCmdlets.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsName {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Avoid Using ShouldContinue Without Boolean Force Parameter.
         /// </summary>
         internal static string AvoidShouldContinueWithoutForceCommonName {
@@ -2084,50 +2120,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
                 return ResourceManager.GetString("UseCompatibleCmdletsName", resourceCulture);
             }
         }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Avoid overwriting built in cmdlets.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsCommonName
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsCommonName", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Avoid overwriting built in cmdlets.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsDescription
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsDescription", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a cmdlet that is included with PowerShell whose definition should not be overridden.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsError
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsError", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to AvoidOverwritingBuiltInCmdlets.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsName
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsName", resourceCulture);
-            }
-        }
         
         /// <summary>
         ///   Looks up a localized string similar to The command &apos;{0}&apos; is not available by default in PowerShell version &apos;{1}&apos; on platform &apos;{2}&apos;.
@@ -2414,6 +2406,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         internal static string UseConsistentWhitespaceErrorSpaceBeforePipe {
             get {
                 return ResourceManager.GetString("UseConsistentWhitespaceErrorSpaceBeforePipe", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use only 1 whitespace between parameter names or values..
+        /// </summary>
+        internal static string UseConsistentWhitespaceErrorSpaceBetweenParameter {
+            get {
+                return ResourceManager.GetString("UseConsistentWhitespaceErrorSpaceBetweenParameter", resourceCulture);
             }
         }
         

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1104,4 +1104,7 @@
   <data name="UseProcessBlockForPipelineCommandName" xml:space="preserve">
     <value>UseProcessBlockForPipelineCommand</value>
   </data>
+  <data name="UseConsistentWhitespaceErrorSpaceBetweenParameter" xml:space="preserve">
+    <value>Use only 1 whitespace between parameter names or values.</value>
+  </data>
 </root>

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -396,12 +396,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     {
                         int numberOfRedundantWhiteSpaces = rightExtent.StartColumnNumber - expectedStartColumnNumberOfRightExtent;
                         var correction = new CorrectionExtent(
-                            leftExtent.StartLineNumber,
-                            leftExtent.EndLineNumber,
-                            leftExtent.EndColumnNumber + 1,
-                            leftExtent.EndColumnNumber + 1 + numberOfRedundantWhiteSpaces,
-                            string.Empty,
-                            leftExtent.File);
+                            startLineNumber: leftExtent.StartLineNumber,
+                            endLineNumber: leftExtent.EndLineNumber,
+                            startColumnNumber: leftExtent.EndColumnNumber + 1,
+                            endColumnNumber: leftExtent.EndColumnNumber + 1 + numberOfRedundantWhiteSpaces,
+                            text: string.Empty,
+                            file: leftExtent.File);
 
                         yield return new DiagnosticRecord(
                             GetError(ErrorKind.BetweenParameter),

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -377,22 +377,21 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         private IEnumerable<DiagnosticRecord> FindParameterViolations(Ast ast)
         {
-            var commandAsts = ast.FindAll(
+            IEnumerable<Ast> commandAsts = ast.FindAll(
                     testAst => testAst is CommandAst, true);
             foreach (CommandAst commandAst in commandAsts)
             {
-                var commandParameterAstElements = commandAst.FindAll(testAst => true, searchNestedScriptBlocks: false).ToList();
+                List<Ast> commandParameterAstElements = commandAst.FindAll(testAst => true, searchNestedScriptBlocks: false).ToList();
                 for (int i = 0; i < commandParameterAstElements.Count - 1; i++)
                 {
-                    var leftExtent = commandParameterAstElements[i].Extent;
-                    var rightExtent = commandParameterAstElements[i + 1].Extent;
-                    var extentsAreOnSameLine = leftExtent.EndLineNumber == rightExtent.StartLineNumber;
-                    if (!extentsAreOnSameLine)
+                    IScriptExtent leftExtent = commandParameterAstElements[i].Extent;
+                    IScriptExtent rightExtent = commandParameterAstElements[i + 1].Extent;
+                    if (leftExtent.EndLineNumber != rightExtent.StartLineNumber)
                     {
                         continue;
                     }
-                    var expectedStartColumnNumberOfRightExtent = leftExtent.EndColumnNumber + 1;
-                    if (rightExtent.StartColumnNumber > expectedStartColumnNumberOfRightExtent)
+
+                    if (rightExtent.StartColumnNumber > leftExtent.EndColumnNumber + 1)
                     {
                         int numberOfRedundantWhiteSpaces = rightExtent.StartColumnNumber - expectedStartColumnNumberOfRightExtent;
                         var correction = new CorrectionExtent(

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 #endif
     public class UseConsistentWhitespace : ConfigurableRule
     {
-        private enum ErrorKind { BeforeOpeningBrace, Paren, Operator, SeparatorComma, SeparatorSemi, AfterOpeningBrace, BeforeClosingBrace, BeforePipe, AfterPipe };
+        private enum ErrorKind { BeforeOpeningBrace, Paren, Operator, SeparatorComma, SeparatorSemi,
+            AfterOpeningBrace, BeforeClosingBrace, BeforePipe, AfterPipe, BetweenParameter };
         private const int whiteSpaceSize = 1;
         private const string whiteSpace = " ";
         private readonly SortedSet<TokenKind> openParenKeywordWhitelist = new SortedSet<TokenKind>()
@@ -211,6 +212,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     return string.Format(CultureInfo.CurrentCulture, Strings.UseConsistentWhitespaceErrorSeparatorComma);
                 case ErrorKind.SeparatorSemi:
                     return string.Format(CultureInfo.CurrentCulture, Strings.UseConsistentWhitespaceErrorSeparatorSemi);
+                case ErrorKind.BetweenParameter:
+                    return string.Format(CultureInfo.CurrentCulture, Strings.UseConsistentWhitespaceErrorSpaceBetweenParameter);
                 default:
                     return string.Format(CultureInfo.CurrentCulture, Strings.UseConsistentWhitespaceErrorBeforeParen);
             }
@@ -398,11 +401,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                             leftExtent.EndColumnNumber + 1,
                             leftExtent.EndColumnNumber + 1 + numberOfRedundantWhiteSpaces,
                             string.Empty,
-                            leftExtent.File,
-                            "description TODO");
+                            leftExtent.File);
 
                         yield return new DiagnosticRecord(
-                            GetError(ErrorKind.BeforeOpeningBrace),
+                            GetError(ErrorKind.BetweenParameter),
                             leftExtent,
                             GetName(),
                             GetDiagnosticSeverity(),

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -110,6 +110,23 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 diagnosticRecords = diagnosticRecords.Concat(violationFinder(tokenOperations));
             }
 
+            var commandParameterAsts = ast.FindAll(
+                    testAst => testAst is CommandParameterAst, true);
+            foreach (CommandParameterAst commandParameterAst in commandParameterAsts)
+            {
+                var commandParameterAstElements = commandParameterAst.FindAll(testAst => true, false).ToList(); // no recursive option to avoid getting children from the colon syntax
+                for (int i = 1; i < commandParameterAstElements.Count - 1; i++)
+                {
+                    var leftExtent = commandParameterAstElements[i].Extent;
+                    var rightExtent = commandParameterAstElements[i + 1].Extent;
+                    var extentsAreOnSameLine = leftExtent.EndLineNumber == rightExtent.StartLineNumber;
+                    if (!extentsAreOnSameLine)
+                    {
+                        continue;
+                    }
+                }
+            }
+
             return diagnosticRecords.ToArray(); // force evaluation here
         }
 

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         private IEnumerable<DiagnosticRecord> FindParameterViolations(Ast ast)
         {
             var commandAsts = ast.FindAll(
-                    testAst => testAst is CommandAst, true).ToArray();
+                    testAst => testAst is CommandAst, true);
             foreach (CommandAst commandAst in commandAsts)
             {
                 var commandParameterAstElements = commandAst.FindAll(testAst => true, searchNestedScriptBlocks: false).ToList();

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -409,8 +409,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                             GetName(),
                             GetDiagnosticSeverity(),
                             leftExtent.File,
-                            null,
-                            Enumerable.Repeat<CorrectionExtent>(correction, 1));
+                            suggestedCorrections: new CorrectionExtent[] { correction });
                     }
                 }
             }

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -391,7 +391,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         continue;
                     }
 
-                    if (rightExtent.StartColumnNumber > leftExtent.EndColumnNumber + 1)
+                    var expectedStartColumnNumberOfRightExtent = leftExtent.EndColumnNumber + 1;
+                    if (rightExtent.StartColumnNumber > expectedStartColumnNumberOfRightExtent)
                     {
                         int numberOfRedundantWhiteSpaces = rightExtent.StartColumnNumber - expectedStartColumnNumberOfRightExtent;
                         var correction = new CorrectionExtent(

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -401,8 +401,17 @@ if ($true) { Get-Item `
             $ruleConfiguration.CheckParameter = $true
         }
 
+        It "Should not find no violation when newlines are involved" {
+            $def = {foo -a $b `
+-c d -d $e -f g `
+-h i |
+bar -h i `
+-switch}
+            Invoke-ScriptAnalyzer -ScriptDefinition "$def" -Settings $settings | Should -Be $null
+        }
+
         It "Should not find no violation if there is always 1 space between parameters except when using colon syntax" {
-            $def = 'foo -bar $baz -bat -parameterName:$parameterValue'
+            $def = 'foo -bar $baz @splattedVariable -bat -parameterName:$parameterValue'
             Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
@@ -430,5 +439,19 @@ if ($true) { Get-Item `
                 Should -BeExactly 'foo -bar $baz -ParameterName:  $ParameterValue'
         }
 
+        It "Should fix script when newlines are involved" {
+            $def = {foo  -a  $b `
+-c  d -d  $e  -f  g `
+-h  i |
+bar  -h  i `
+-switch}
+            $expected = {foo -a $b `
+-c d -d $e -f g `
+-h i |
+bar -h i `
+-switch}
+            Invoke-Formatter -ScriptDefinition "$def" -Settings $settings |
+                Should -Be "$expected"
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

Disabled by default because it is new. The plan is to later add an option to the vs code extension and pending positive feedback we can then later enable it by default.
The only case that was excluded by design is when the user uses the `-ParameterName:$ParameterValue` syntax as some people might prefer 0 or 1 whitespace here, the rule leaves those cases completely untouched.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.