### PR TITLE
Add more automatic variables to PSAvoidAssignmentToAutomaticVariables that are not read-only but should still not be assigned to in most cases

### DIFF
--- a/Rules/AvoidAssignmentToAutomaticVariable.cs
+++ b/Rules/AvoidAssignmentToAutomaticVariable.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             "IsCoreCLR", "IsLinux", "IsMacOS", "IsWindows"
         };
 
-        private static readonly IList<string> _automaticVariablesThatCouldBeProblematicToAssignTo = new List<string>()
+        private static readonly IReadOnlyList<string> _automaticVariablesThatCouldBeProblematicToAssignTo = new List<string>()
         {
             // Attempting to assign to any of those could cause issues, only in some special cases could assignment be by design
             "_", "AllNodes", "Args", "ConsoleFilename", "Event", "EventArgs", "EventSubscriber", "ForEach", "Input", "Matches", "MyInvocation",

--- a/Rules/AvoidAssignmentToAutomaticVariable.cs
+++ b/Rules/AvoidAssignmentToAutomaticVariable.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             "IsCoreCLR", "IsLinux", "IsMacOS", "IsWindows"
         };
 
-        private static readonly IReadOnlyList<string> _automaticVariablesThatCouldBeProblematicToAssignTo = new List<string>()
+        private static readonly IReadOnlyList<string> _writableAutomaticVariables = new List<string>()
         {
             // Attempting to assign to any of those could cause issues, only in some special cases could assignment be by design
             "_", "AllNodes", "Args", "ConsoleFilename", "Event", "EventArgs", "EventSubscriber", "ForEach", "Input", "Matches", "MyInvocation",
@@ -72,7 +72,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                                       variableExpressionAst.Extent, GetName(), severity, fileName);
                 }
 
-                if (_automaticVariablesThatCouldBeProblematicToAssignTo.Contains(variableName, StringComparer.OrdinalIgnoreCase))
+                if (_writableAutomaticVariables.Contains(variableName, StringComparer.OrdinalIgnoreCase))
                 {
                     yield return new DiagnosticRecord(DiagnosticRecordHelper.FormatError(Strings.AvoidAssignmentToWritableAutomaticVariableError, variableName),
                                                       variableExpressionAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
@@ -103,7 +103,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                                       variableExpressionAst.Extent, GetName(), severity, fileName);
                 }
 
-                if (_automaticVariablesThatCouldBeProblematicToAssignTo.Contains(variableName, StringComparer.OrdinalIgnoreCase))
+                if (_writableAutomaticVariables.Contains(variableName, StringComparer.OrdinalIgnoreCase))
                 {
                     yield return new DiagnosticRecord(DiagnosticRecordHelper.FormatError(Strings.AvoidAssignmentToWritableAutomaticVariableError, variableName),
                                                       variableExpressionAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -151,6 +151,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The Variable &apos;{0}&apos; is an automatic variable that is built into PowerShell, assigning to it might have undesired side effects. If assignment is not by design, please use a different name..
+        /// </summary>
+        internal static string AvoidAssignmentToWritableAutomaticVariableError {
+            get {
+                return ResourceManager.GetString("AvoidAssignmentToWritableAutomaticVariableError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Avoid Using ComputerName Hardcoded.
         /// </summary>
         internal static string AvoidComputerNameHardcodedCommonName {
@@ -489,6 +498,42 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         internal static string AvoidNullOrEmptyHelpMessageAttributeName {
             get {
                 return ResourceManager.GetString("AvoidNullOrEmptyHelpMessageAttributeName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Avoid overwriting built in cmdlets.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsCommonName {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsCommonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Do not overwrite the definition of a cmdlet that is included with PowerShell.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsDescription {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is a cmdlet that is included with PowerShell (version {1}) whose definition should not be overridden.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsError {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidOverwritingBuiltInCmdlets.
+        /// </summary>
+        internal static string AvoidOverwritingBuiltInCmdletsName {
+            get {
+                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsName", resourceCulture);
             }
         }
         
@@ -2082,50 +2127,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         internal static string UseCompatibleCmdletsName {
             get {
                 return ResourceManager.GetString("UseCompatibleCmdletsName", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Avoid overwriting built in cmdlets.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsCommonName
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsCommonName", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to Avoid overwriting built in cmdlets.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsDescription
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsDescription", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is a cmdlet that is included with PowerShell whose definition should not be overridden.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsError
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsError", resourceCulture);
-            }
-        }
-
-        /// <summary>
-        ///   Looks up a localized string similar to AvoidOverwritingBuiltInCmdlets.
-        /// </summary>
-        internal static string AvoidOverwritingBuiltInCmdletsName
-        {
-            get
-            {
-                return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsName", resourceCulture);
             }
         }
         

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1104,4 +1104,7 @@
   <data name="UseProcessBlockForPipelineCommandName" xml:space="preserve">
     <value>UseProcessBlockForPipelineCommand</value>
   </data>
+  <data name="AvoidAssignmentToWritableAutomaticVariableError" xml:space="preserve">
+    <value>The Variable '{0}' is an automatic variable that is built into PowerShell, assigning to it might have undesired side effects. If assignment is not by design, please use a different name.</value>
+  </data>
 </root>

--- a/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
+++ b/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
@@ -9,29 +9,54 @@ Describe "AvoidAssignmentToAutomaticVariables" {
             $excpectedSeverityForAutomaticVariablesInPowerShell6 = 'Error'
         }
 
-        $testCases_ReadOnlyVariables = @(
-            @{ VariableName = '?'; ExpectedSeverity = 'Error'; }
-            @{ VariableName = 'Error' ; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'ExecutionContext'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'false'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'Home'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'Host'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'PID'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'PSCulture'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'PSEdition'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'PSHome'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'PSUICulture'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'PSVersionTable'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'ShellId'; ExpectedSeverity = 'Error' }
-            @{ VariableName = 'true'; ExpectedSeverity = 'Error' }
-            # Variables introuced only in PowerShell 6.0 have a Severity of Warning only
+        $testCases_AutomaticVariables = @(
+            @{ VariableName = '?'; ExpectedSeverity = 'Error'; IsReadOnly = $true }
+            @{ VariableName = 'Error' ; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'ExecutionContext'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'false'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'Home'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'Host'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'PID'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'PSCulture'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'PSEdition'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'PSHome'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'PSUICulture'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'PSVersionTable'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'ShellId'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            @{ VariableName = 'true'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+            # Variables introduced only in PowerShell 6+ have a Severity of Warning only
             @{ VariableName = 'IsCoreCLR'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
             @{ VariableName = 'IsLinux'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
             @{ VariableName = 'IsMacOS'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
             @{ VariableName = 'IsWindows'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
+            @{ VariableName = '_'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'AllNodes'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'Args'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'ConsoleFilename'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'Event'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'EventArgs'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'EventSubscriber'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'ForEach'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'Input'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'Matches'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'MyInvocation'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'NestedPromptLevel'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'Profile'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'PSBoundParameters'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'PsCmdlet'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'PSCommandPath'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'ReportErrorShowExceptionClass'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'ReportErrorShowInnerException'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'ReportErrorShowSource'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'ReportErrorShowStackTrace'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'Sender'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'StackTrace'; ExpectedSeverity = 'Warning' }
+            @{ VariableName = 'This'; ExpectedSeverity = 'Warning' }
         )
 
-        It "Variable <VariableName> produces warning of Severity <ExpectedSeverity>" -TestCases $testCases_ReadOnlyVariables {
+        $testCases_ReadOnlyAutomaticVariables = $testCases_AutomaticVariables | Where-Object { $_.IsReadonly }
+
+        It "Variable <VariableName> produces warning of Severity <ExpectedSeverity>" -TestCases $testCases_AutomaticVariables {
             param ($VariableName, $ExpectedSeverity)
 
             $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "`$${VariableName} = 'foo'" -ExcludeRule PSUseDeclaredVarsMoreThanAssignments
@@ -40,7 +65,7 @@ Describe "AvoidAssignmentToAutomaticVariables" {
             $warnings.RuleName | Should -Be $ruleName
         }
 
-        It "Using Variable <VariableName> as parameter name produces warning of Severity error" -TestCases $testCases_ReadOnlyVariables {
+        It "Using Variable <VariableName> as parameter name produces warning of Severity error" -TestCases $testCases_AutomaticVariables {
             param ($VariableName, $ExpectedSeverity)
 
             [System.Array] $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "function foo{Param(`$$VariableName)}"
@@ -49,7 +74,7 @@ Describe "AvoidAssignmentToAutomaticVariables" {
             $warnings.RuleName | Should -Be $ruleName
         }
 
-        It "Using Variable <VariableName> as parameter name in param block produces warning of Severity error" -TestCases $testCases_ReadOnlyVariables {
+        It "Using Variable <VariableName> as parameter name in param block produces warning of Severity error" -TestCases $testCases_AutomaticVariables {
             param ($VariableName, $ExpectedSeverity)
 
             [System.Array] $warnings = Invoke-ScriptAnalyzer -ScriptDefinition "function foo(`$$VariableName){}"
@@ -77,8 +102,8 @@ Describe "AvoidAssignmentToAutomaticVariables" {
             $warnings.Count | Should -Be 0
         }
 
-        It "Setting Variable <VariableName> throws exception in applicable PowerShell version to verify the variables is read-only" -TestCases $testCases_ReadOnlyVariables {
-            param ($VariableName, $ExpectedSeverity, $OnlyPresentInCoreClr)
+        It "Setting Variable <VariableName> throws exception in applicable PowerShell version to verify the variables is read-only" -TestCases $testCases_ReadOnlyAutomaticVariables {
+            param ($VariableName, $ExpectedSeverity, $OnlyPresentInCoreClr, [bool] $IsReadOnly)
 
             if ($OnlyPresentInCoreClr -and !$IsCoreCLR)
             {
@@ -86,7 +111,7 @@ Describe "AvoidAssignmentToAutomaticVariables" {
                 Set-Variable -Name $VariableName -Value 'foo'
                 continue
             }
-            
+
             # Setting the $Error variable has the side effect of the ErrorVariable to contain only the exception message string, therefore exclude this case.
             # For the library test in WMF 4, assigning a value $PSEdition does not seem to throw an error, therefore this special case is excluded as well.
             if ($VariableName -ne 'Error' -and ($VariableName -ne 'PSEdition' -and $PSVersionTable.PSVersion.Major -ne 4))


### PR DESCRIPTION
## PR Summary

Closes #712
Closes #1183 

The list of variables was extracted from #712 and it i s the union of non-readonly automatic variables in Windows PowerShell and PowerShell Core. Some of those variables can be assigned to in very special cases but the point of this rule is to rather warn that assignment to automatic variables happens and if the author knows what he/she/they are doing then they can/should suppress the rule

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.