### PR TITLE
Use AST to determine if SupportsShouldProcess has been set if an error is thrown

### DIFF
--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -82,6 +82,21 @@ Write-Output $flag
             $diagnostics[0].Extent.Text | Should -BeExactly '$flag'
         }
 
+        It "Understands when variables are not used in child scopes" {
+$script = @'
+$duck = $true
+& {
+    $duck = $false
+    Write-Output $duck
+}
+'@
+
+            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script
+            $diagnostics | Should -HaveCount 1
+            $diagnostics[0].Extent.StartLineNumber | Should -Be 1
+            $diagnostics[0].Extent.Text | Should -BeExactly '$duck'
+        }
+
     }
 
     Context "When there are no violations" {

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -67,6 +67,18 @@ function MyFunc2() {
             $results[0].Extent | Should -Be '$mySecondvar'
         }
 
+        It "Flags when variables are assigned after use" {
+            $script = @'
+Write-Output $moo
+$moo = "Hi"
+'@
+
+            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script
+            $diagnostics | Should -HaveCount 1
+            $diagnostics[0].Extent.StartLineNumber | Should -Be 2
+            $diagnostics[0].Extent.Text | Should -BeExactly '$moo'
+        }
+
         It "Understands that variables set in a child scope are not the same" {
             $script = @'
 $flag = $true


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/PowerShell/PSScriptAnalyzer/issues/1217.

When PowerShell throws an error due to not being able to resolve an attribute type, we sift through the AST to determine whether `SupportsShouldProcess` has been set on a function.

Also cleans up some of the logic so it's not all nested `as`s.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.