### PR TITLE
Add PipelineIndentationStyle.None option for scenarios where indentation is custom, inconsistent or the user does not like any of the 3 pipeline indentation styles

### DIFF
--- a/RuleDocumentation/UseConsistentIndentation.md
+++ b/RuleDocumentation/UseConsistentIndentation.md
@@ -53,6 +53,7 @@ foo |
 bar |
 baz
 ```
+- None: Do not change any existing pipeline indentation.
 
 #### Kind: string (Default value is `space`)
 

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -90,7 +90,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             IncreaseIndentationForFirstPipeline,
             IncreaseIndentationAfterEveryPipeline,
-            NoIndentation
+            NoIndentation,
+            None
         }
 
         // TODO make this configurable
@@ -152,6 +153,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         break;
 
                     case TokenKind.Pipe:
+                        if (pipelineIndentationStyle == PipelineIndentationStyle.None) { break; }
                         bool pipelineIsFollowedByNewlineOrLineContinuation = tokenIndex < tokens.Length - 1 && tokenIndex > 0 &&
                               (tokens[tokenIndex + 1].Kind == TokenKind.NewLine || tokens[tokenIndex + 1].Kind == TokenKind.LineContinuation);
                         if (!pipelineIsFollowedByNewlineOrLineContinuation)
@@ -225,6 +227,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         break;
                 }
 
+                if (pipelineIndentationStyle == PipelineIndentationStyle.None) { break; }
                 // Check if the current token matches the end of a PipelineAst
                 var matchingPipeLineAstEnd = pipelineAsts.FirstOrDefault(pipelineAst =>
                         PositionIsEqual(pipelineAst.Extent.EndScriptPosition, token.Extent.EndScriptPosition)) as PipelineAst;

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -225,10 +225,29 @@ baz
             Test-CorrectionExtentFromContent @params
         }
 
+        It 'Should preserve script when using PipelineIndentation None' -TestCases @(
+            @{ IdempotentScriptDefinition = @'
+foo |
+bar
+'@
+            }
+            @{ IdempotentScriptDefinition = @'
+foo |
+    bar
+'@
+            }
+            ) {
+        param ($IdempotentScriptDefinition)
+
+        $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = 'None'
+        Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
+    }
+
         It "Should preserve script when using PipelineIndentation <PipelineIndentation>" -TestCases @(
                 @{ PipelineIndentation = 'IncreaseIndentationForFirstPipeline' }
                 @{ PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline' }
                 @{ PipelineIndentation = 'NoIndentation' }
+                @{ PipelineIndentation = 'None' }
                 ) {
             param ($PipelineIndentation)
             $idempotentScriptDefinition = @'
@@ -246,6 +265,7 @@ function hello {
             @{ PipelineIndentation = 'IncreaseIndentationForFirstPipeline' }
             @{ PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline' }
             @{ PipelineIndentation = 'NoIndentation' }
+            @{ PipelineIndentation = 'None' }
             ) {
         param ($PipelineIndentation)
         $idempotentScriptDefinition = @'
@@ -264,6 +284,7 @@ function foo {
         @{ PipelineIndentation = 'IncreaseIndentationForFirstPipeline' }
         @{ PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline' }
         @{ PipelineIndentation = 'NoIndentation' }
+        @{ PipelineIndentation = 'None' }
         ) {
     param ($PipelineIndentation)
     $idempotentScriptDefinition = @'
@@ -281,6 +302,7 @@ Describe 'describe' {
             @{ PipelineIndentation = 'IncreaseIndentationForFirstPipeline' }
             @{ PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline' }
             @{ PipelineIndentation = 'NoIndentation' }
+            @{ PipelineIndentation = 'None' }
         ) {
             param ($PipelineIndentation)
             $idempotentScriptDefinition = @'


### PR DESCRIPTION
#1330  PR Summary

Add PipelineIndentationStyle.None option for scenarios where indentation is custom, inconsistent or the user does not like any of the 3 pipeline indentation styles.

Originally suggested by @vexx32 at the time when the rule was a bit buggy.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.