### PR TITLE
Fix recently introduced bug (PR #1391) for UseCorrectCasing

### DIFF
--- a/Rules/UseCorrectCasing.cs
+++ b/Rules/UseCorrectCasing.cs
@@ -73,8 +73,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 foreach (var commandParameterAst in commandParameterAsts)
                 {
                     var parameterName = commandParameterAst.ParameterName;
-                    var parameterMetaData = availableParameters[parameterName];
-                    if (parameterMetaData != null)
+                    if (availableParameters.TryGetValue(parameterName, out ParameterMetadata parameterMetaData))
                     {
                         var correctlyCasedParameterName = parameterMetaData.Name;
                         if (!parameterName.Equals(correctlyCasedParameterName, StringComparison.Ordinal))

--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -65,4 +65,9 @@ Describe "UseCorrectCasing" {
         Invoke-Formatter 'Invoke-DummyFunction -parametername: $parameterValue' |
             Should -Be 'Invoke-DummyFunction -ParameterName: $parameterValue'
     }
+
+    It "Should not throw when using parameter name that does not exist" {
+        Invoke-Formatter 'Get-Process -NonExistingParameterName' -ErrorAction Stop
+    }
+
 }


### PR DESCRIPTION
## PR Summary

The bug was caused by accessing an index that can not be present in special cases. The test case shows an example where this could happen.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.