### PR TITLE
Increase macOS CI coverage to include both 10.14 and 10.15

### DIFF
--- a/.azure-pipelines-ci/ci.yaml
+++ b/.azure-pipelines-ci/ci.yaml
@@ -29,8 +29,10 @@ stages:
               vmImage: ubuntu-16.04
             Ubuntu_18_04:
               vmImage: ubuntu-18.04
-            macOS:
-              vmImage: macos-latest
+            macOS_10_14_Mojave:
+              vmImage: macOS-10.14
+            macOS_10_15_Catalina:
+              vmImage: macOS-10.15
             Windows_Server2016_PowerShell_Core:
               vmImage: vs2017-win2016
             Windows_Server2019_PowerShell_Core:


### PR DESCRIPTION
## PR Summary

10.15 has recently been added to Azure DevOps hosted agents

https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.