### PR TITLE
Split CheckPipe feature of trimming redundant whitespace out into option CheckPipeForRedundantWhiteSpace

### DIFF
--- a/Engine/Settings/CodeFormatting.psd1
+++ b/Engine/Settings/CodeFormatting.psd1
@@ -37,7 +37,7 @@
             CheckOpenParen                  = $true
             CheckOperator                   = $true
             CheckPipe                       = $true
-            CheckPipeForRedundantWhiteSpace = $false
+            CheckPipeForRedundantWhitespace  = $false
             CheckSeparator                  = $true
             CheckParameter                  = $false
         }

--- a/Engine/Settings/CodeFormatting.psd1
+++ b/Engine/Settings/CodeFormatting.psd1
@@ -31,14 +31,15 @@
         }
 
         PSUseConsistentWhitespace  = @{
-            Enable          = $true
-            CheckInnerBrace = $true
-            CheckOpenBrace  = $true
-            CheckOpenParen  = $true
-            CheckOperator   = $true
-            CheckPipe       = $true
-            CheckSeparator  = $true
-            CheckParameter  = $false
+            Enable                          = $true
+            CheckInnerBrace                 = $true
+            CheckOpenBrace                  = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $true
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhiteSpace = $false
+            CheckSeparator                  = $true
+            CheckParameter                  = $false
         }
 
         PSAlignAssignmentStatement = @{

--- a/Engine/Settings/CodeFormatting.psd1
+++ b/Engine/Settings/CodeFormatting.psd1
@@ -37,7 +37,7 @@
             CheckOpenParen                  = $true
             CheckOperator                   = $true
             CheckPipe                       = $true
-            CheckPipeForRedundantWhitespace  = $false
+            CheckPipeForRedundantWhitespace = $false
             CheckSeparator                  = $true
             CheckParameter                  = $false
         }

--- a/Engine/Settings/CodeFormattingAllman.psd1
+++ b/Engine/Settings/CodeFormattingAllman.psd1
@@ -37,7 +37,7 @@
             CheckOpenParen                  = $true
             CheckOperator                   = $true
             CheckPipe                       = $true
-            CheckPipeForRedundantWhiteSpace = $false
+            CheckPipeForRedundantWhitespace  = $false
             CheckSeparator                  = $true
             CheckParameter                  = $false
         }

--- a/Engine/Settings/CodeFormattingAllman.psd1
+++ b/Engine/Settings/CodeFormattingAllman.psd1
@@ -31,14 +31,15 @@
         }
 
         PSUseConsistentWhitespace  = @{
-            Enable          = $true
-            CheckInnerBrace = $true
-            CheckOpenBrace  = $true
-            CheckOpenParen  = $true
-            CheckOperator   = $true
-            CheckPipe       = $true
-            CheckSeparator  = $true
-            CheckParameter  = $false
+            Enable                          = $true
+            CheckInnerBrace                 = $true
+            CheckOpenBrace                  = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $true
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhiteSpace = $false
+            CheckSeparator                  = $true
+            CheckParameter                  = $false
         }
 
         PSAlignAssignmentStatement = @{

--- a/Engine/Settings/CodeFormattingAllman.psd1
+++ b/Engine/Settings/CodeFormattingAllman.psd1
@@ -37,7 +37,7 @@
             CheckOpenParen                  = $true
             CheckOperator                   = $true
             CheckPipe                       = $true
-            CheckPipeForRedundantWhitespace  = $false
+            CheckPipeForRedundantWhitespace = $false
             CheckSeparator                  = $true
             CheckParameter                  = $false
         }

--- a/Engine/Settings/CodeFormattingOTBS.psd1
+++ b/Engine/Settings/CodeFormattingOTBS.psd1
@@ -37,7 +37,7 @@
             CheckOpenParen                  = $true
             CheckOperator                   = $true
             CheckPipe                       = $true
-            CheckPipeForRedundantWhiteSpace = $false
+            CheckPipeForRedundantWhitespace  = $false
             CheckSeparator                  = $true
             CheckParameter                  = $false
         }

--- a/Engine/Settings/CodeFormattingOTBS.psd1
+++ b/Engine/Settings/CodeFormattingOTBS.psd1
@@ -37,7 +37,7 @@
             CheckOpenParen                  = $true
             CheckOperator                   = $true
             CheckPipe                       = $true
-            CheckPipeForRedundantWhitespace  = $false
+            CheckPipeForRedundantWhitespace = $false
             CheckSeparator                  = $true
             CheckParameter                  = $false
         }

--- a/Engine/Settings/CodeFormattingOTBS.psd1
+++ b/Engine/Settings/CodeFormattingOTBS.psd1
@@ -31,14 +31,15 @@
         }
 
         PSUseConsistentWhitespace  = @{
-            Enable         = $true
-            CheckInnerBrace = $true
-            CheckOpenBrace = $true
-            CheckOpenParen = $true
-            CheckOperator  = $true
-            CheckPipe       = $true
-            CheckSeparator = $true
-            CheckParameter = $false
+            Enable                          = $true
+            CheckInnerBrace                 = $true
+            CheckOpenBrace                  = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $true
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhiteSpace = $false
+            CheckSeparator                  = $true
+            CheckParameter                  = $false
         }
 
         PSAlignAssignmentStatement = @{

--- a/Engine/Settings/CodeFormattingStroustrup.psd1
+++ b/Engine/Settings/CodeFormattingStroustrup.psd1
@@ -38,7 +38,7 @@
             CheckOpenParen                  = $true
             CheckOperator                   = $true
             CheckPipe                       = $true
-            CheckPipeForRedundantWhitespace  = $false
+            CheckPipeForRedundantWhitespace = $false
             CheckSeparator                  = $true
             CheckParameter                  = $false
         }

--- a/Engine/Settings/CodeFormattingStroustrup.psd1
+++ b/Engine/Settings/CodeFormattingStroustrup.psd1
@@ -31,15 +31,16 @@
             IndentationSize = 4
         }
 
-        PSUseConsistentWhitespace = @{
-            Enable          = $true
-            CheckInnerBrace = $true
-            CheckOpenBrace  = $true
-            CheckOpenParen  = $true
-            CheckOperator   = $true
-            CheckPipe       = $true
-            CheckSeparator  = $true
-            CheckParameter  = $false
+        PSUseConsistentWhitespace  = @{
+            Enable                          = $true
+            CheckInnerBrace                 = $true
+            CheckOpenBrace                  = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $true
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhiteSpace = $false
+            CheckSeparator                  = $true
+            CheckParameter                  = $false
         }
 
         PSAlignAssignmentStatement = @{

--- a/Engine/Settings/CodeFormattingStroustrup.psd1
+++ b/Engine/Settings/CodeFormattingStroustrup.psd1
@@ -38,7 +38,7 @@
             CheckOpenParen                  = $true
             CheckOperator                   = $true
             CheckPipe                       = $true
-            CheckPipeForRedundantWhiteSpace = $false
+            CheckPipeForRedundantWhitespace  = $false
             CheckSeparator                  = $true
             CheckParameter                  = $false
         }

--- a/RuleDocumentation/UseConsistentWhitespace.md
+++ b/RuleDocumentation/UseConsistentWhitespace.md
@@ -19,7 +19,7 @@
             CheckOpenParen                  = $true
             CheckOperator                   = $true
             CheckPipe                       = $true
-            CheckPipeForRedundantWhiteSpace = $false
+            CheckPipeForRedundantWhitespace  = $false
             CheckSeparator                  = $true
             CheckParameter                  = $false
         }
@@ -56,7 +56,7 @@ Checks if a comma or a semicolon is followed by a space. E.g. `@(1, 2, 3)` or `@
 
 Checks if a pipe is surrounded on both sides by a space but ignores redundant whitespace. E.g. `foo | bar` instead of `foo|bar`.
 
-#### CheckPipeForRedundantWhiteSpace: bool (Default value is `$false`)
+#### CheckPipeForRedundantWhitespace : bool (Default value is `$false`)
 
 Checks if a pipe is surrounded by redundant whitespace (i.e. more than 1 whitespace). E.g. `foo | bar` instead of `foo|bar`.
 

--- a/RuleDocumentation/UseConsistentWhitespace.md
+++ b/RuleDocumentation/UseConsistentWhitespace.md
@@ -58,7 +58,8 @@ Checks if a pipe is surrounded on both sides by a space but ignores redundant wh
 
 #### CheckPipeForRedundantWhitespace : bool (Default value is `$false`)
 
-Checks if a pipe is surrounded by redundant whitespace (i.e. more than 1 whitespace). E.g. `foo | bar` instead of `foo|bar`.
+Checks if a pipe is surrounded by redundant whitespace (i.e. more than 1 whitespace). E.g. `foo | bar` instead of `foo     |    
+ bar`.
 
 #### CheckParameter: bool (Default value is `$false` at the moment due to the setting being new)
 

--- a/RuleDocumentation/UseConsistentWhitespace.md
+++ b/RuleDocumentation/UseConsistentWhitespace.md
@@ -19,7 +19,7 @@
             CheckOpenParen                  = $true
             CheckOperator                   = $true
             CheckPipe                       = $true
-            CheckPipeForRedundantWhitespace  = $false
+            CheckPipeForRedundantWhitespace = $false
             CheckSeparator                  = $true
             CheckParameter                  = $false
         }

--- a/RuleDocumentation/UseConsistentWhitespace.md
+++ b/RuleDocumentation/UseConsistentWhitespace.md
@@ -54,7 +54,11 @@ Checks if a comma or a semicolon is followed by a space. E.g. `@(1, 2, 3)` or `@
 
 #### CheckPipe: bool (Default value is `$true`)
 
-Checks if a pipe is surrounded on both sides by a space. E.g. `foo | bar` instead of `foo|bar`.
+Checks if a pipe is surrounded on both sides by a space but ignores redundant whitespace. E.g. `foo | bar` instead of `foo|bar`.
+
+#### CheckPipeForRedundantWhiteSpace: bool (Default value is `$false`)
+
+Checks if a pipe is surrounded by redundant whitespace (i.e. more than 1 whitespace). E.g. `foo | bar` instead of `foo|bar`.
 
 #### CheckParameter: bool (Default value is `$false` at the moment due to the setting being new)
 

--- a/RuleDocumentation/UseConsistentWhitespace.md
+++ b/RuleDocumentation/UseConsistentWhitespace.md
@@ -13,14 +13,15 @@
 ```powershell
     Rules = @{
         PSUseConsistentWhitespace  = @{
-            Enable          = $true
-            CheckInnerBrace = $true
-            CheckOpenBrace  = $true
-            CheckOpenParen  = $true
-            CheckOperator   = $true
-            CheckPipe       = $true
-            CheckSeparator  = $true
-            CheckParameter  = $false
+            Enable                          = $true
+            CheckInnerBrace                 = $true
+            CheckOpenBrace                  = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $true
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhiteSpace = $false
+            CheckSeparator                  = $true
+            CheckParameter                  = $false
         }
     }
 ```

--- a/RuleDocumentation/UseConsistentWhitespace.md
+++ b/RuleDocumentation/UseConsistentWhitespace.md
@@ -58,8 +58,7 @@ Checks if a pipe is surrounded on both sides by a space but ignores redundant wh
 
 #### CheckPipeForRedundantWhitespace : bool (Default value is `$false`)
 
-Checks if a pipe is surrounded by redundant whitespace (i.e. more than 1 whitespace). E.g. `foo | bar` instead of `foo     |    
- bar`.
+Checks if a pipe is surrounded by redundant whitespace (i.e. more than 1 whitespace). E.g. `foo | bar` instead of `foo    |    bar`.
 
 #### CheckParameter: bool (Default value is `$false` at the moment due to the setting being new)
 

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         public bool CheckPipe { get; protected set; }
 
         [ConfigurableRuleProperty(defaultValue: false)]
-        public bool CheckPipeForRedundantWhitespace  { get; protected set; }
+        public bool CheckPipeForRedundantWhitespace { get; protected set; }
 
         [ConfigurableRuleProperty(defaultValue: true)]
         public bool CheckOpenParen { get; protected set; }
@@ -76,7 +76,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 violationFinders.Add(FindInnerBraceViolations);
             }
 
-            if (CheckPipe || CheckPipeForRedundantWhitespace )
+            if (CheckPipe || CheckPipeForRedundantWhitespace)
             {
                 violationFinders.Add(FindPipeViolations);
             }
@@ -319,7 +319,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 if (!IsNextTokenApartByWhitespace(pipe, out bool hasRedundantWhitespace))
                 {
-                    if (CheckPipeForRedundantWhitespace  && hasRedundantWhitespace || CheckPipe && !hasRedundantWhitespace)
+                    if (CheckPipeForRedundantWhitespace && hasRedundantWhitespace || CheckPipe && !hasRedundantWhitespace)
                     {
                         yield return new DiagnosticRecord(
                             GetError(ErrorKind.AfterPipe),
@@ -347,7 +347,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 if (!IsPreviousTokenApartByWhitespace(pipe, out bool hasRedundantWhitespace))
                 {
-                    if (CheckPipeForRedundantWhitespace  && hasRedundantWhitespace || CheckPipe && !hasRedundantWhitespace)
+                    if (CheckPipeForRedundantWhitespace && hasRedundantWhitespace || CheckPipe && !hasRedundantWhitespace)
                     {
                         yield return new DiagnosticRecord(
                         GetError(ErrorKind.BeforePipe),

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     continue;
                 }
 
-                if (!IsNextTokenApartByWhitespace(lCurly, out bool redundantWhitespace))
+                if (!IsNextTokenApartByWhitespace(lCurly))
                 {
                     yield return new DiagnosticRecord(
                         GetError(ErrorKind.AfterOpeningBrace),
@@ -317,9 +317,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     continue;
                 }
 
-                if (!IsNextTokenApartByWhitespace(pipe, out bool redundantWhitespace))
+                if (!IsNextTokenApartByWhitespace(pipe, out bool hasRedundantWhitespace))
                 {
-                    if (CheckPipeForRedundantWhiteSpace && redundantWhitespace || CheckPipe && !redundantWhitespace)
+                    if (CheckPipeForRedundantWhiteSpace && hasRedundantWhitespace || CheckPipe && !hasRedundantWhitespace)
                     {
                         yield return new DiagnosticRecord(
                             GetError(ErrorKind.AfterPipe),
@@ -345,9 +345,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     continue;
                 }
 
-                if (!IsPreviousTokenApartByWhitespace(pipe, out bool redundantWhitespace))
+                if (!IsPreviousTokenApartByWhitespace(pipe, out bool hasRedundantWhitespace))
                 {
-                    if (CheckPipeForRedundantWhiteSpace && redundantWhitespace || CheckPipe && !redundantWhitespace)
+                    if (CheckPipeForRedundantWhiteSpace && hasRedundantWhitespace || CheckPipe && !hasRedundantWhitespace)
                     {
                         yield return new DiagnosticRecord(
                         GetError(ErrorKind.BeforePipe),
@@ -486,6 +486,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             var actualWhitespaceSize = tokenNode.Value.Extent.StartColumnNumber - tokenNode.Previous.Value.Extent.EndColumnNumber;
             hasRedundantWhitespace = actualWhitespaceSize - whiteSpaceSize > 0;
             return whiteSpaceSize == actualWhitespaceSize;
+        }
+
+        private static bool IsNextTokenApartByWhitespace(LinkedListNode<Token> tokenNode)
+        {
+            return IsNextTokenApartByWhitespace(tokenNode, out _);
         }
 
         private static bool IsNextTokenApartByWhitespace(LinkedListNode<Token> tokenNode, out bool hasRedundantWhitespace)

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         public bool CheckPipe { get; protected set; }
 
         [ConfigurableRuleProperty(defaultValue: false)]
-        public bool CheckPipeForRedundantWhiteSpace { get; protected set; }
+        public bool CheckPipeForRedundantWhitespace  { get; protected set; }
 
         [ConfigurableRuleProperty(defaultValue: true)]
         public bool CheckOpenParen { get; protected set; }
@@ -76,7 +76,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 violationFinders.Add(FindInnerBraceViolations);
             }
 
-            if (CheckPipe || CheckPipeForRedundantWhiteSpace)
+            if (CheckPipe || CheckPipeForRedundantWhitespace )
             {
                 violationFinders.Add(FindPipeViolations);
             }
@@ -319,7 +319,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 if (!IsNextTokenApartByWhitespace(pipe, out bool hasRedundantWhitespace))
                 {
-                    if (CheckPipeForRedundantWhiteSpace && hasRedundantWhitespace || CheckPipe && !hasRedundantWhitespace)
+                    if (CheckPipeForRedundantWhitespace  && hasRedundantWhitespace || CheckPipe && !hasRedundantWhitespace)
                     {
                         yield return new DiagnosticRecord(
                             GetError(ErrorKind.AfterPipe),
@@ -347,7 +347,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 if (!IsPreviousTokenApartByWhitespace(pipe, out bool hasRedundantWhitespace))
                 {
-                    if (CheckPipeForRedundantWhiteSpace && hasRedundantWhitespace || CheckPipe && !hasRedundantWhitespace)
+                    if (CheckPipeForRedundantWhitespace  && hasRedundantWhitespace || CheckPipe && !hasRedundantWhitespace)
                     {
                         yield return new DiagnosticRecord(
                         GetError(ErrorKind.BeforePipe),

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -237,7 +237,7 @@ $x = "abc";
             $ruleConfiguration.CheckOpenParen = $false
             $ruleConfiguration.CheckOperator = $false
             $ruleConfiguration.CheckPipe = $true
-            $ruleConfiguration.CheckPipeForRedundantWhiteSpace = $false
+            $ruleConfiguration.CheckPipeForRedundantWhitespace  = $false
             $ruleConfiguration.CheckSeparator = $false
         }
 
@@ -293,14 +293,14 @@ foo
         }
     }
 
-    Context "CheckPipeForRedundantWhiteSpace" {
+    Context "CheckPipeForRedundantWhitespace " {
         BeforeAll {
             $ruleConfiguration.CheckInnerBrace = $false
             $ruleConfiguration.CheckOpenBrace = $false
             $ruleConfiguration.CheckOpenParen = $false
             $ruleConfiguration.CheckOperator = $false
             $ruleConfiguration.CheckPipe = $false
-            $ruleConfiguration.CheckPipeForRedundantWhiteSpace = $true
+            $ruleConfiguration.CheckPipeForRedundantWhitespace  = $true
             $ruleConfiguration.CheckSeparator = $false
         }
 

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -237,6 +237,7 @@ $x = "abc";
             $ruleConfiguration.CheckOpenParen = $false
             $ruleConfiguration.CheckOperator = $false
             $ruleConfiguration.CheckPipe = $true
+            $ruleConfiguration.CheckPipeForRedundantWhiteSpace = $false
             $ruleConfiguration.CheckSeparator = $false
         }
 
@@ -246,22 +247,20 @@ $x = "abc";
             Test-CorrectionExtentFromContent $def $violations 1 '' ' '
         }
 
-        It "Should find a violation if there is no space before pipe" {
+        It "Should not find a violation if there is no space before pipe" {
             $def = 'Get-Item| foo'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             Test-CorrectionExtentFromContent $def $violations 1 '' ' '
         }
 
-        It "Should find a violation if there is one space too much before pipe" {
+        It "Should not find a violation if there is one space too much before pipe" {
             $def = 'Get-Item  | foo'
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            Test-CorrectionExtentFromContent $def $violations 1 '  ' ' '
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -BeNullOrEmpty
         }
 
         It "Should find a violation if there is one space too much after pipe" {
             $def = 'Get-Item |  foo'
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            Test-CorrectionExtentFromContent $def $violations 1 '  ' ' '
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -BeNullOrEmpty
         }
 
         It "Should not find a violation if there is 1 space before and after a pipe" {
@@ -294,6 +293,51 @@ foo
         }
     }
 
+    Context "CheckPipeForRedundantWhiteSpace" {
+        BeforeAll {
+            $ruleConfiguration.CheckInnerBrace = $false
+            $ruleConfiguration.CheckOpenBrace = $false
+            $ruleConfiguration.CheckOpenParen = $false
+            $ruleConfiguration.CheckOperator = $false
+            $ruleConfiguration.CheckPipe = $false
+            $ruleConfiguration.CheckPipeForRedundantWhiteSpace = $true
+            $ruleConfiguration.CheckSeparator = $false
+        }
+
+        It "Should not find a violation if there is no space around pipe" {
+            $def = 'foo|bar'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -BeNullOrEmpty
+        }
+
+        It "Should not find a violation if there is exactly one space around pipe" {
+            $def = 'foo | bar'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -BeNullOrEmpty
+        }
+
+        It "Should find a violation if there is one space too much before pipe" {
+            $def = 'foo  | bar'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            Test-CorrectionExtentFromContent $def $violations 1 '  ' ' '
+        }
+
+        It "Should find a violation if there is two spaces too much before pipe" {
+            $def = 'foo   | bar'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            Test-CorrectionExtentFromContent $def $violations 1 '   ' ' '
+        }
+
+        It "Should find a violation if there is one space too much after pipe" {
+            $def = 'foo |  bar'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            Test-CorrectionExtentFromContent $def $violations 1 '  ' ' '
+        }
+
+        It "Should find a violation if there is two spaces too much after pipe" {
+            $def = 'foo |   bar'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            Test-CorrectionExtentFromContent $def $violations 1 '   ' ' '
+        }
+    }
 
     Context "CheckInnerBrace" {
         BeforeAll {

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -237,7 +237,7 @@ $x = "abc";
             $ruleConfiguration.CheckOpenParen = $false
             $ruleConfiguration.CheckOperator = $false
             $ruleConfiguration.CheckPipe = $true
-            $ruleConfiguration.CheckPipeForRedundantWhitespace  = $false
+            $ruleConfiguration.CheckPipeForRedundantWhitespace = $false
             $ruleConfiguration.CheckSeparator = $false
         }
 
@@ -293,14 +293,14 @@ foo
         }
     }
 
-    Context "CheckPipeForRedundantWhitespace " {
+    Context "CheckPipeForRedundantWhitespace" {
         BeforeAll {
             $ruleConfiguration.CheckInnerBrace = $false
             $ruleConfiguration.CheckOpenBrace = $false
             $ruleConfiguration.CheckOpenParen = $false
             $ruleConfiguration.CheckOperator = $false
             $ruleConfiguration.CheckPipe = $false
-            $ruleConfiguration.CheckPipeForRedundantWhitespace  = $true
+            $ruleConfiguration.CheckPipeForRedundantWhitespace = $true
             $ruleConfiguration.CheckSeparator = $false
         }
 


### PR DESCRIPTION
## PR Summary

This is because some people align their pipes (e.g. in Pester tests) and don't want redundant white-space to be trimmed.
Therefore the concern of the rule options is split into 2 areas:
- `Checkpipe` still corrects when there is no whitespace around the pipe operator
- The new `CheckPipeForRedundantWhiteSpace` option is for cases where redundant whitespace needs to be trimmed. Disabled by default.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.