### PR TITLE
fix #1417 modulehelp false positives 

### DIFF
--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -205,10 +205,6 @@ function Get-CommandVersion {
 
 if (!$RequiredVersion) {
 	$RequiredVersion = (Get-Module $ModuleName -ListAvailable | Sort-Object -Property Version -Descending | Select-Object -First 1).Version
-	if ($null -eq $RequiredVersion) {
-		# Look for loaded modules instead of installed modules, if we don't find any installed modules.
-		$RequiredVersion = (Get-Module $ModuleName | Sort-Object -Property Version -Descending | Select-Object -First 1).Version
-	}
 }
 
 # Remove all versions of the module from the session. Pester can't handle multiple versions.

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -224,9 +224,7 @@ if ($PSVersionTable.PSVersion -lt [Version]'5.0.0') {
 }
 else {
 	$ms = [Microsoft.PowerShell.Commands.ModuleSpecification]@{ ModuleName = $ModuleName; RequiredVersion = $RequiredVersion }
-	# Because on Windows Powershell we have workflow, we need to include it there, but in pwsh, we can't. This makes sure this works on both.
-	$commandTypes = ([System.Enum]::GetNames("System.Management.Automation.CommandTypes") -match "^Cmdlet$|^Function$|^Workflow$")
-	$commands = Get-Command -FullyQualifiedModule $ms -CommandType $commandTypes
+	$commands = Get-Command -FullyQualifiedModule $ms
 }
 
 ## When testing help, remember that help is cached at the beginning of each session.


### PR DESCRIPTION
## PR Summary

Fixes #1417

When looking up module version, if the module is not installed, also check if it is loaded and get module version from loaded module
Add 'AttachAndDebug' to paramBlackList, so it does not throw false positives for DEBUG builds.
Small bugfix for the actual blacklist check, the property 'name' of the $parameter variable needs to be used to check against the blacklist.

I have tested this by running:

```powershell
# in pwsh.exe
.\PSScriptAnalyzer\build.ps1 -clean
.\PSScriptAnalyzer\build.ps1
.\PSScriptAnalyzer\build.ps1 -test
# no errors
``` 

```powershell
# in powershell.exe
.\PSScriptAnalyzer\build.ps1 -clean
.\PSScriptAnalyzer\build.ps1
.\PSScriptAnalyzer\build.ps1 -test
# no errors
``` 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.