### PR TITLE
ms-vscode.csharp to ms-dotnettools.csharp

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 	},
 	"postCreateCommand": "dotnet restore",
 	"extensions": [
-		"ms-vscode.csharp",
+		"ms-dotnettools.csharp",
 		"ms-vscode.powershell"
 	]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "ms-vscode.PowerShell",
-        "ms-vscode.csharp",
+        "ms-dotnettools.csharp",
         "ms-vscode-remote.remote-containers"
     ]
 }


### PR DESCRIPTION
C# extension has changed its name from "ms-vscode.csharp" to "ms-dotnettools.csharp", this means all extensions depending on it needs to be updated and i.e. all repositories with extension.json containing
```json
"recommendations": [
    "ms-vscode.csharp"
 ]
```
or you get errors like

![image](https://user-images.githubusercontent.com/1647294/76144809-2c18e500-6084-11ea-80ab-f365de742c99.png)