### PR TITLE
Pin major version of Pester to 4 and upgrade Pester version for WMF4 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Note: the PSScriptAnalyzer Chocolatey package is provided and supported by the c
 #### Requirements
 
 * [.NET Core 3.1.102 SDK](https://www.microsoft.com/net/download/dotnet-core/3.1#sdk-3.1.102) or newer patch release
+* [Pester v4 PowerShell module, available on PowerShell Gallery](https://github.com/pester/Pester)
 * [PlatyPS PowerShell module, available on PowerShell Gallery](https://github.com/PowerShell/platyPS/releases)
 * Optionally but recommended for development: [Visual Studio 2017/2019](https://www.visualstudio.com/downloads/)
 

--- a/build.psm1
+++ b/build.psm1
@@ -331,13 +331,14 @@ function Test-ScriptAnalyzer
             }
             $savedModulePath = $env:PSModulePath
             $env:PSModulePath = "${testModulePath}{0}${env:PSModulePath}" -f [System.IO.Path]::PathSeparator
+            $importPesterV4 = 'Import-Module -Name Pester -MaximumVersion 4.99'
             if ($ShowAll)
             {
-                $scriptBlock = [scriptblock]::Create("Invoke-Pester -Path $testScripts -OutputFormat NUnitXml -OutputFile $testResultsFile")
+                $scriptBlock = [scriptblock]::Create("$importPesterV4; Invoke-Pester -Path $testScripts -OutputFormat NUnitXml -OutputFile $testResultsFile")
             }
             else
             {
-                $scriptBlock = [scriptblock]::Create("Invoke-Pester -Path $testScripts -OutputFormat NUnitXml -OutputFile $testResultsFile -Show Describe,Summary,Failed")
+                $scriptBlock = [scriptblock]::Create("$importPesterV4; Invoke-Pester -Path $testScripts -OutputFormat NUnitXml -OutputFile $testResultsFile -Show Describe,Summary,Failed")
             }
             if ( $InProcess ) {
                 & $scriptBlock

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -4,7 +4,7 @@
 $ErrorActionPreference = 'Stop'
 
 function Install-Pester {
-    $requiredPesterVersion = '4.10.0'
+    $requiredPesterVersion = '4.10.1'
     $pester = Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq $requiredPesterVersion }
     if ($null -eq $pester) {
         if ($null -eq (Get-Module -ListAvailable PowershellGet)) {
@@ -15,7 +15,7 @@ function Install-Pester {
         else {
             # Visual Studio 2017 build (has already Pester v3, therefore a different installation mechanism is needed to make it also use the new version 4)
             Write-Verbose -Verbose "Installing Pester via Install-Module"
-            Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser -Repository PSGallery
+            Install-Module -Name Pester -MaximumVersion 4.99 -Force -SkipPublisherCheck -Scope CurrentUser -Repository PSGallery
         }
     }
 }


### PR DESCRIPTION
## PR Summary

PSSA is not ready for Pester v5, therefore pinning it to v4 for the moment to avoid the inevitable build failure next week

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.