### PR TITLE
Compatibility tests: Use correct test cases object and remove invalid test case

### DIFF
--- a/PSCompatibilityCollector/Tests/UtilityApi.Tests.ps1
+++ b/PSCompatibilityCollector/Tests/UtilityApi.Tests.ps1
@@ -101,7 +101,6 @@ Describe "PowerShell version object" {
     Context "Version parsing" {
         BeforeAll {
             $genericVerCases = @(
-                @{ VerStr = '6'; Major = 6; Minor = -1; Patch = -1 }
                 @{ VerStr = '6.1'; Major = 6; Minor = 1; Patch = -1 }
                 @{ VerStr = '5.2.7'; Major = 5; Minor = 2; Patch = 7 }
                 @{ VerStr = '512.2124.71'; Major = 512; Minor = 2124; Patch = 71 }
@@ -134,7 +133,7 @@ Describe "PowerShell version object" {
             )
         }
 
-        It "Parses version string '<VerStr>' as <Major>.<Minor>.<Patch>" -TestCases $semVerCases {
+        It "Parses version string '<VerStr>' as <Major>.<Minor>.<Patch>" -TestCases $genericVerCases {
             param([string]$VerStr, [int]$Major, [int]$Minor, [int]$Patch)
 
             $v = [Microsoft.PowerShell.CrossCompatibility.PowerShellVersion]$VerStr


### PR DESCRIPTION
## PR Summary

The `$genericVerCases` test case object was not being used due to what seems to have been a copy-paste error.
One test case actually did not work because having a version string with not dot would throw [here](https://github.com/PowerShell/PSScriptAnalyzer/blob/b1a81874fbe61ebaf1a0b9631f337b4f06296625/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/PowerShellVersion.cs#L91)

I could add the following negative test for it but was wondering why we cannot make it accept single character versions?
```pwsh
        It "Does not parse version string '7' due to missing dot" {
            { [Microsoft.PowerShell.CrossCompatibility.PowerShellVersion] '7' } | Should -Throw
        }
```
In the case of PowerShell Core we wouldn't even need our own implementation and just use `System.Management.Automation.SemanticVersion`, which can actually parse versions without a dot.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.