### PR TITLE
Make CompatibilityCollector able to parse a single version String

### DIFF
--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/PowerShellVersion.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Common/PowerShellVersion.cs
@@ -88,7 +88,8 @@ namespace Microsoft.PowerShell.CrossCompatibility
 
             if (dotCount == 0)
             {
-                throw new ArgumentException($"Version string '{versionStr}' must contain at least one dot separator");
+                var majorVersion = int.Parse(versionStr);
+                return new PowerShellVersion(majorVersion, -1, -1, label: null);
             }
 
             versionParts[dotCount] = int.Parse(versionStr.Substring(sectionStartOffset, i - sectionStartOffset));

--- a/PSCompatibilityCollector/Tests/UtilityApi.Tests.ps1
+++ b/PSCompatibilityCollector/Tests/UtilityApi.Tests.ps1
@@ -101,6 +101,8 @@ Describe "PowerShell version object" {
     Context "Version parsing" {
         BeforeAll {
             $genericVerCases = @(
+                @{ VerStr = '42'; Major = 42; Minor = -1; Patch = -1 }
+                @{ VerStr = '7'; Major = 7; Minor = -1; Patch = -1 }
                 @{ VerStr = '6.1'; Major = 6; Minor = 1; Patch = -1 }
                 @{ VerStr = '5.2.7'; Major = 5; Minor = 2; Patch = 7 }
                 @{ VerStr = '512.2124.71'; Major = 512; Minor = 2124; Patch = 71 }


### PR DESCRIPTION
## PR Summary

Make CompatibilityCollector able to parse a single version String.
I found it odd that the version number is `-1` when not being specified (`System.Management.Automation.SemanticVersion` uses a `0` in that case) but I tried to be at least consistent with the current implementation...

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.