### PR TITLE
CI: Use runtime expression syntax for passing pwsh parameter

### DIFF
--- a/.azure-pipelines-ci/templates/test.yaml
+++ b/.azure-pipelines-ci/templates/test.yaml
@@ -13,7 +13,7 @@ steps:
   displayName: 'Test'
   inputs:
     targetType: inline
-    pwsh: ${{ parameters.pwsh }}
+    pwsh: $[ parameters.pwsh ]
     script: |
       Import-Module .\tools\appveyor.psm1
       Invoke-AppveyorTest -CheckoutPath $env:BUILD_SOURCESDIRECTORY


### PR DESCRIPTION
## PR Summary

This is due to a regression in Azure Pipelines expressions, which used to work the way they were but a few weeks ago they somehow changed their behaviour and now don't pass the parameter any more, meaning that the tests that were supposed to run on Windows PowerShell in the test matrix were actually run on PowerShell Core.
Changing to a run-time expression instead of a runtime expression for the moment to fix this
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#variables

I submitted this bug report: https://developercommunity.visualstudio.com/content/problem/996647/boolean-compile-time-yaml-expression-not-correctly.html

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.