### PR TITLE
Cleanup csproj files: Remove code duplication for Configuration and entries in Rules project, since it depends on Engine project

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -16,7 +16,7 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 
@@ -61,29 +61,16 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' AND '$(Configuration)' == 'PSV7Debug'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="System.Management.Automation" Version="7.0.0" />
   </ItemGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' AND '$(Configuration)' == 'PSV7Debug'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);PSV7;CORECLR</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)' == 'PSV6Debug'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);PSV6;CORECLR</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)' == 'PSV6Debug'">
-    <PackageReference Include="System.Management.Automation" Version="6.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' AND '$(Configuration)' == 'PSV7Release'">
-    <PackageReference Include="System.Management.Automation" Version="7.0.0" />
-  </ItemGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' AND '$(Configuration)' == 'PSV7Release'">
-    <DefineConstants>$(DefineConstants);PSV7;CORECLR</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)' == 'PSV6Release'">
-    <DefineConstants>$(DefineConstants);PSV6;CORECLR</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)' == 'PSV6Release'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Management.Automation" Version="6.1.0" />
   </ItemGroup>
 

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -52,52 +52,20 @@
     <Compile Remove="UseSingularNouns.cs" />
   </ItemGroup>
   
-  <PropertyGroup Condition=" '$(Configuration)' == 'PSV3Release' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'PSV3Release' OR '$(Configuration)' == 'PSV3Debug'">
     <DefineConstants>$(DefineConstants);PSV3</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'PSV4Release' ">
+  <PropertyGroup Condition=" '$(Configuration)' == 'PSV4Debug' OR '$(Configuration)' == 'PSV4Release'">
     <DefineConstants>$(DefineConstants);PSV3;PSV4</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(Configuration)' == 'PSV3Debug' ">
-    <DefineConstants>$(DefineConstants);PSV3</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'PSV4Debug' ">
-    <DefineConstants>$(DefineConstants);PSV3;PSV4</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' AND '$(Configuration)' == 'PSV7Release'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);PSV7;CORECLR</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' AND '$(Configuration)' == 'PSV7Release'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)' == 'PSV6Release'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <DefineConstants>$(DefineConstants);PSV6;CORECLR</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)' == 'PSV6Release'">
-    <PackageReference Include="System.Management.Automation" Version="6.1.0" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' AND '$(Configuration)' == 'PSV7Debug'">
-    <DefineConstants>$(DefineConstants);PSV7;CORECLR</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' AND '$(Configuration)' == 'PSV7Debug'">
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)' == 'PSV6Debug'">
-    <DefineConstants>$(DefineConstants);PSV6;CORECLR</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' AND '$(Configuration)' == 'PSV6Debug'">
-    <PackageReference Include="System.Management.Automation" Version="6.1.0" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## PR Summary

This is a cleanup of PR #1425:
After that PR, building locally via Visual Studio or `dotnet build` was not working any more because it did not cater for the `Configuration` being either `Debug` or `Release`. Since the code for Configuration `PSV6Debug and `PSV6Release` were the same the condition fore the configuration was removed, thereby removing unnecessary code duplication and making the case of `Debug` or `Release` work again, whilst not changing existing behaviour.
Also: Since the `Rules` project depends on the `Engine` project, there is no need to duplicate the reference to SMA (which was actually forgotten to be switched from the SDK to SMA in one project).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.