### PR TITLE
Invoke-Formatter: Skip VariableAnalysis, which is not used by Formatter rules - this yields a 25% performance improvement

### DIFF
--- a/Engine/Formatter.cs
+++ b/Engine/Formatter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                 Range updatedRange;
                 bool fixesWereApplied;
-                text = ScriptAnalyzer.Instance.Fix(text, range, out updatedRange, out fixesWereApplied);
+                text = ScriptAnalyzer.Instance.Fix(text, range, out updatedRange, out fixesWereApplied, skipVariableAnalysis: true);
                 range = updatedRange;
             }
 


### PR DESCRIPTION
## PR Summary

Formatter rules do not call APIs from VariableAnalysis, therefore skipping its initialization makes formatting much faster.
For PowerShell's 3000 line [build.psm1](https://github.com/PowerShell/PowerShell/blob/master/build.psm1) file, this changes execution time from 2 seconds to 1.5 seconds.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.