### PR TITLE
Lazy initialisation of LinkedList in TokenOperations constructor -> 7% performance gain for formatter

### DIFF
--- a/Engine/TokenOperations.cs
+++ b/Engine/TokenOperations.cs
@@ -150,58 +150,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
         }
 
-        // TODO Fix code duplication in the following method and GetBraceInCommandElement
-        private IEnumerable<Token> GetBraceInOneLineIfStatment(TokenKind tokenKind)
-        {
-            var ifStatementAsts = ast.FindAll(ast =>
-            {
-                var ifAst = ast as IfStatementAst;
-                if (ifAst == null)
-                {
-                    return false;
-                }
-
-                return ifAst.Extent.StartLineNumber == ifAst.Extent.EndLineNumber;
-            },
-            true);
-
-            if (ifStatementAsts == null)
-            {
-                yield break;
-            }
-
-            var braceTokens = new List<Token>();
-            foreach (var ast in ifStatementAsts)
-            {
-                var ifStatementAst = ast as IfStatementAst;
-                foreach (var clause in ifStatementAst.Clauses)
-                {
-                    var tokenIf
-                        = tokenKind == TokenKind.LCurly
-                            ? GetTokens(clause.Item2).FirstOrDefault()
-                            : GetTokens(clause.Item2).LastOrDefault();
-                    if (tokenIf != null)
-                    {
-                        yield return tokenIf;
-                    }
-                }
-
-                if (ifStatementAst.ElseClause == null)
-                {
-                    continue;
-                }
-
-                var tokenElse
-                    = tokenKind == TokenKind.LCurly
-                            ? GetTokens(ifStatementAst.ElseClause).FirstOrDefault()
-                            : GetTokens(ifStatementAst.ElseClause).LastOrDefault();
-                if (tokenElse != null)
-                {
-                    yield return tokenElse;
-                }
-            }
-        }
-
         public static IEnumerable<Token> GetTokens(Ast outerAst, Ast innerAst, Token[] outerTokens)
         {
             ThrowIfNull(outerAst, nameof(outerAst));

--- a/Engine/TokenOperations.cs
+++ b/Engine/TokenOperations.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
     public class TokenOperations
     {
         private readonly Token[] tokens;
-        private LinkedList<Token> tokensLL;
+        private readonly Lazy<LinkedList<Token>> tokensLL;
         private readonly Ast ast;
 
         public Ast Ast { get { return ast; } }
@@ -39,7 +39,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             this.tokens = tokens;
             this.ast = ast;
-            this.tokensLL = new LinkedList<Token>(this.tokens);
+            this.tokensLL = new Lazy<LinkedList<Token>>(() => new LinkedList<Token>(this.tokens));
         }
 
         /// <summary>
@@ -150,16 +150,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
         }
 
-        public IEnumerable<Token> GetCloseBraceInOneLineIfStatement()
-        {
-            return GetBraceInOneLineIfStatment(TokenKind.RCurly);
-        }
-
-        public IEnumerable<Token> GetOpenBraceInOneLineIfStatement()
-        {
-            return GetBraceInOneLineIfStatment(TokenKind.LCurly);
-        }
-
         // TODO Fix code duplication in the following method and GetBraceInCommandElement
         private IEnumerable<Token> GetBraceInOneLineIfStatment(TokenKind tokenKind)
         {
@@ -262,7 +252,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
         public IEnumerable<LinkedListNode<Token>> GetTokenNodes(Func<Token, bool> predicate)
         {
-            var token = tokensLL.First;
+            var token = tokensLL.Value.First;
             while (token != null)
             {
                 if (predicate(token.Value))
@@ -288,21 +278,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     item.Value,
                     item.Value.Extent.StartColumnNumber - item.Previous.Value.Extent.EndColumnNumber);
             }
-        }
-
-        public IEnumerable<Tuple<Token, int>> GetOpenBracesWithWhiteSpacesBefore()
-        {
-            return GetTokenAndPrecedingWhitespace(TokenKind.LCurly);
-        }
-
-        public IEnumerable<Tuple<Token, int>> GetOpenParensWithWhiteSpacesBefore()
-        {
-            return GetTokenAndPrecedingWhitespace(TokenKind.LParen);
-        }
-
-        public static int GetExtentWidth(IScriptExtent extent)
-        {
-            return extent.EndOffset - extent.StartOffset;
         }
 
         private bool OnSameLine(Token token1, Token token2)


### PR DESCRIPTION
## PR Summary

This is a simple optimizaton as many consumers that construct the `TokenOperations` class do not call APIs that use the LinkedList. This changes the CPU consumption of this class constructor during a format run from 8% to 1%. Of course one could optimize further but I suggest to do the quick wins first with little risk of code regression.
Performance gains are mainly  in formatter rules but also in relatively expensive `UseSupportsShouldProcess` rule.

Also remove unused method. Technically this is a breaking change due to them being publicly exposed but I don't think people use them, the only usage that I can imagine is in custom rules. I did a global GitHub search and it confirmed that no one is probably using those APIs.

This class is quite disgusting overall, littered with TODOs and private/public methods spread across the file. Idea is to keep changes minimal and safe.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.