### PR TITLE
Improve performance of UseConsistentIndentation -> 35% speedup for formatter

### DIFF
--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -256,12 +256,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         private static bool LineHasPipelineBeforeToken(Token[] tokens, int tokenIndex, Token token)
         {
-            var searchIndex = tokenIndex;
-            var searchLine = token.Extent.StartLineNumber;
+            int searchIndex = tokenIndex;
+            int searchLine = token.Extent.StartLineNumber;
             do
             {
                 searchLine = tokens[searchIndex].Extent.StartLineNumber;
-                var searchcolumn = tokens[searchIndex].Extent.StartColumnNumber;
+                int searchcolumn = tokens[searchIndex].Extent.StartColumnNumber;
                 if (tokens[searchIndex].Kind == TokenKind.Pipe && searchcolumn < token.Extent.StartColumnNumber)
                 {
                     return true;

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -219,22 +219,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 }
                             }
 
-                            bool lineHasPipelineBeforeToken = false;
-                            var searchIndex = tokenIndex;
-                            var searchToken = tokens[searchIndex];
-                            var searchLine = token.Extent.StartLineNumber;
-                            do
-                            {
-                                searchToken = tokens[searchIndex];
-                                searchLine = searchToken.Extent.StartLineNumber;
-                                var searchcolumn = searchToken.Extent.StartColumnNumber;
-                                if (searchToken.Kind == TokenKind.Pipe && searchcolumn < token.Extent.StartColumnNumber)
-                                {
-                                    lineHasPipelineBeforeToken = true;
-                                    break;
-                                }
-                                searchIndex--;
-                            } while (searchLine == token.Extent.StartLineNumber && searchIndex >= 0);
+                            bool lineHasPipelineBeforeToken = LineHasPipelineBeforeToken(tokens, tokenIndex, token);
 
                             AddViolation(token, tempIndentationLevel, diagnosticRecords, ref onNewLine, lineHasPipelineBeforeToken);
                         }
@@ -267,6 +252,25 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
 
             return diagnosticRecords;
+        }
+
+        private static bool LineHasPipelineBeforeToken(Token[] tokens, int tokenIndex, Token token)
+        {
+            bool lineHasPipelineBeforeToken = false;
+            var searchIndex = tokenIndex;
+            var searchLine = token.Extent.StartLineNumber;
+            do
+            {
+                searchLine = tokens[searchIndex].Extent.StartLineNumber;
+                var searchcolumn = tokens[searchIndex].Extent.StartColumnNumber;
+                if (tokens[searchIndex].Kind == TokenKind.Pipe && searchcolumn < token.Extent.StartColumnNumber)
+                {
+                    lineHasPipelineBeforeToken = true;
+                    break;
+                }
+                searchIndex--;
+            } while (searchLine == token.Extent.StartLineNumber && searchIndex >= 0);
+            return lineHasPipelineBeforeToken;
         }
 
         private static CommandBaseAst LastPipeOnFirstLineWithPipeUsage(PipelineAst pipelineAst)

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -219,10 +219,22 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 }
                             }
 
-                            var lineHasPipelineBeforeToken = tokens.Any(oneToken =>
-                                oneToken.Kind == TokenKind.Pipe &&
-                                oneToken.Extent.StartLineNumber == token.Extent.StartLineNumber &&
-                                oneToken.Extent.StartColumnNumber < token.Extent.StartColumnNumber);
+                            bool lineHasPipelineBeforeToken = false;
+                            var searchIndex = tokenIndex;
+                            var searchToken = tokens[searchIndex];
+                            var searchLine = token.Extent.StartLineNumber;
+                            do
+                            {
+                                searchToken = tokens[searchIndex];
+                                searchLine = searchToken.Extent.StartLineNumber;
+                                var searchcolumn = searchToken.Extent.StartColumnNumber;
+                                if (searchToken.Kind == TokenKind.Pipe && searchcolumn < token.Extent.StartColumnNumber)
+                                {
+                                    lineHasPipelineBeforeToken = true;
+                                    break;
+                                }
+                                searchIndex--;
+                            } while (searchLine == token.Extent.StartLineNumber && searchIndex >= 0);
 
                             AddViolation(token, tempIndentationLevel, diagnosticRecords, ref onNewLine, lineHasPipelineBeforeToken);
                         }

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -256,7 +256,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         private static bool LineHasPipelineBeforeToken(Token[] tokens, int tokenIndex, Token token)
         {
-            bool lineHasPipelineBeforeToken = false;
             var searchIndex = tokenIndex;
             var searchLine = token.Extent.StartLineNumber;
             do
@@ -265,12 +264,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 var searchcolumn = tokens[searchIndex].Extent.StartColumnNumber;
                 if (tokens[searchIndex].Kind == TokenKind.Pipe && searchcolumn < token.Extent.StartColumnNumber)
                 {
-                    lineHasPipelineBeforeToken = true;
-                    break;
+                    return true;
                 }
                 searchIndex--;
             } while (searchLine == token.Extent.StartLineNumber && searchIndex >= 0);
-            return lineHasPipelineBeforeToken;
+            return false;
         }
 
         private static CommandBaseAst LastPipeOnFirstLineWithPipeUsage(PipelineAst pipelineAst)


### PR DESCRIPTION
## PR Summary

Speedup is relative to the speed BEFORE my recent 2 PRs so that one sees the impact relative to those improvments (therefore the actual speedup relative to master would actually be higher). Speed is for a call of Invoke-Formatter with the default settings of the VS-Code extension.
Because the rule already loops through all tokens, there was a line that did a search through all tokens and the list of tokens can be quite long for big scripts.
First improvement would've been to create a list just consisting of pipeline tokens but even then I still saw some overhead just because it had to loop the whole list again. Therefore I optimized it further to just walk back on the current line, which is the only line of interest.
If we take this improvement and the previous 2 PRs together, then the formatter is nearly 3 times faster in total.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.