### PR TITLE
Improve performance of UseConsistentIndentation even more > another 10% speedup for formatter

### DIFF
--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -295,6 +295,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     break;
                 }
+
                 if (PositionIsEqual(pipelineAsts[i].Extent.EndScriptPosition, token.Extent.EndScriptPosition))
                 {
                     matchingPipeLineAstEnd = pipelineAsts[i] as PipelineAst;


### PR DESCRIPTION
## PR Summary

This now reduced the total CPU time of this rule to only from 12% to 2% on a run of a warm run Invoke-Formatter (compared to current master with the 3 recent speed improvements). Improvements will be smaller for smaller scripts as this was tested against PowerShell's build.psm1 3000+ line module (same as with previous PRs), therefore it rather ensures performance scales much better.
Basically, because the rule goes over every token, any looping, inside it, even when it is only performed for each line as in this case, it has a measurable impact (both in the profiler but also actual timings). Therfore making sure we iterate over fewer items in the `pipelineAsts` list, by having a minimum index, which increases with each line and breaking the loop early if the line number is bigger than the current line. This is possible because the queried function `PositionIsEqual` only returns pipeline asts on the same line.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.