### PR TITLE
Formatter: Recycle parsed AST and tokens in between rule invocations when no correction was applied to improve performance

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -422,7 +422,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             }
             else if (String.Equals(this.ParameterSetName, "ScriptDefinition", StringComparison.OrdinalIgnoreCase))
             {
-                diagnosticsList = ScriptAnalyzer.Instance.AnalyzeScriptDefinition(scriptDefinition);
+                diagnosticsList = ScriptAnalyzer.Instance.AnalyzeScriptDefinition(scriptDefinition, out _, out _);
                 WriteToOutput(diagnosticsList);
             }
         }

--- a/Engine/Formatter.cs
+++ b/Engine/Formatter.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Management.Automation;
+using System.Management.Automation.Language;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 {
@@ -46,6 +47,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             };
 
             var text = new EditableText(scriptDefinition);
+            ScriptBlockAst scriptAst = null;
+            Token[] scriptTokens = null;
+            bool skipParsing = false;
             foreach (var rule in ruleOrder)
             {
                 if (!settings.RuleArguments.ContainsKey(rule))
@@ -57,9 +61,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 ScriptAnalyzer.Instance.UpdateSettings(currentSettings);
                 ScriptAnalyzer.Instance.Initialize(cmdlet, null, null, null, null, true, false);
 
-                Range updatedRange;
-                bool fixesWereApplied;
-                text = ScriptAnalyzer.Instance.Fix(text, range, out updatedRange, out fixesWereApplied, skipVariableAnalysis: true);
+                text = ScriptAnalyzer.Instance.Fix(text, range, skipParsing, out Range updatedRange, out bool fixesWereApplied, ref scriptAst, ref scriptTokens, skipVariableAnalysis: true);
+                skipParsing = !fixesWereApplied;
                 range = updatedRange;
             }
 

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1698,22 +1698,21 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         }
 
         private static IEnumerable<CorrectionExtent> GetCorrectionExtentsForFix(
-            IEnumerable<CorrectionExtent> correctionExtents)
+            List<CorrectionExtent> correctionExtents)
         {
-            var ceList = correctionExtents.ToList();
-            ceList.Sort((x, y) =>
+            correctionExtents.Sort((x, y) =>
             {
                 return x.StartLineNumber < y.StartLineNumber ?
                             1 :
                             (x.StartLineNumber == y.StartLineNumber ? 0 : -1);
             });
 
-            return ceList.GroupBy(ce => ce.StartLineNumber).Select(g => g.First());
+            return correctionExtents.GroupBy(ce => ce.StartLineNumber).Select(g => g.First());
         }
 
         private static EditableText Fix(
             EditableText text,
-            IEnumerable<CorrectionExtent> correctionExtents,
+            List<CorrectionExtent> correctionExtents,
             out int unusedCorrections)
         {
             var correctionsToUse = GetCorrectionExtentsForFix(correctionExtents);
@@ -1724,7 +1723,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 text.ApplyEdit(correction);
             }
 
-            unusedCorrections = correctionExtents.Count() - count;
+            unusedCorrections = correctionExtents.Count - count;
             return text;
         }
 

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1597,7 +1597,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             do
             {
                 IEnumerable<DiagnosticRecord> records;
-                if (skipParsing)
+                if (skipParsing && previousUnusedCorrections == 0)
                 {
                     records = AnalyzeSyntaxTree(scriptAst, scriptTokens, String.Empty, skipVariableAnalysis);
                 }

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -94,7 +94,7 @@ function Invoke-ScriptAnalyzer {
     }
     else
     {
-        $results = $scriptAnalyzer.AnalyzeScriptDefinition($ScriptDefinition);
+        $results = $scriptAnalyzer.AnalyzeScriptDefinition($ScriptDefinition, [ref] $null, [ref] $null)
 	}
 
 	$results


### PR DESCRIPTION
## PR Summary

This saves on the expensive calls to the Parser and the rule itself, which are called at the moment for every rule invocation AND after every applied `DiagnosticRecord`. With this PR, parsing is skipped and the previous result is used if a rule did not return a `DiagnosticRecord` that changed the analysed script definition string. If there is not `DiagnosticRecord` returned from a rule during formatting, this simple change can dramatically speed up the formatting time: In the case of a pre-formatted file (always using PowerShell's `build.psm1` for reference), formatting is 3 times faster. In reality, I guess it's only around 50%-100% depending on how well formatter the script already is. Because I had to change publicly exposed methods, it is technically speaking a breaking change but I think we can live with that.

Since I haven't written this core logic, I can only guess it was written like this because applying a change invalidates the previous analysis and this explains why one cannot simply run the rules in parallel. However, I imagine, one could write code to not re-parse at all between applying a list of `DiagnosticRecord`s by adapting the line and column numbers (which would also allow for parallelisation of the rules). At the moment one could probably even improve performance further by stopping rule analysis once the first object comes back due to this re-analysis pattern. I've actually tried that locally but it would've broken a few tests so maybe not as easy as it seems to be therefore let's leave that for later now though.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.