### PR TITLE
Performance: Eliminate Regex overhead in AvoidTrailingWhitespace -> Speedup of 5% (PowerShell 5.1) or 2.5 % (PowerShell 7.1-preview.2)

### DIFF
--- a/Rules/AvoidTrailingWhitespace.cs
+++ b/Rules/AvoidTrailingWhitespace.cs
@@ -36,11 +36,21 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             var diagnosticRecords = new List<DiagnosticRecord>();
 
-            string[] lines = Regex.Split(ast.Extent.Text, @"\r?\n");
+            //string[] lines = Regex.Split(ast.Extent.Text, @"\r?\n");
+            string[] lines = ast.Extent.Text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
 
             for (int lineNumber = 0; lineNumber < lines.Length; lineNumber++)
             {
                 var line = lines[lineNumber];
+
+                if (line.Length == 0)
+                {
+                    continue;
+                }
+                if (line[line.Length - 1] != ' ' && line[line.Length - 1] != '\t')
+                {
+                    continue;
+                }
 
                 var match = Regex.Match(line, @"\s+$");
                 if (match.Success)

--- a/Rules/AvoidTrailingWhitespace.cs
+++ b/Rules/AvoidTrailingWhitespace.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             var diagnosticRecords = new List<DiagnosticRecord>();
 
-            //string[] lines = Regex.Split(ast.Extent.Text, @"\r?\n");
             string[] lines = ast.Extent.Text.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
 
             for (int lineNumber = 0; lineNumber < lines.Length; lineNumber++)

--- a/Rules/AvoidTrailingWhitespace.cs
+++ b/Rules/AvoidTrailingWhitespace.cs
@@ -46,11 +46,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     continue;
                 }
+
                 if (line[line.Length - 1] != ' ' &&
                     line[line.Length - 1] != '\t')
                 {
                     continue;
                 }
+
                 int startColumnOfTrailingWhitespace = 1;
                 for (int i = line.Length - 2; i > 0; i--)
                 {
@@ -61,10 +63,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     }
                 }
 
-                var startLine = lineNumber + 1;
-                var endLine = startLine;
-                var startColumn = startColumnOfTrailingWhitespace;
-                var endColumn = line.Length + 1;
+                int startLine = lineNumber + 1;
+                int endLine = startLine;
+                int startColumn = startColumnOfTrailingWhitespace;
+                int endColumn = line.Length + 1;
 
                 var violationExtent = new ScriptExtent(
                     new ScriptPosition(

--- a/Rules/AvoidTrailingWhitespace.cs
+++ b/Rules/AvoidTrailingWhitespace.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     continue;
                 }
 
-                if (line[line.Length - 1] != ' ' &&
+                if (!char.IsWhiteSpace(line[line.Length - 1]) &&
                     line[line.Length - 1] != '\t')
                 {
                     continue;

--- a/Rules/AvoidTrailingWhitespace.cs
+++ b/Rules/AvoidTrailingWhitespace.cs
@@ -47,51 +47,57 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     continue;
                 }
-                if (line[line.Length - 1] != ' ' && line[line.Length - 1] != '\t')
+                if (line[line.Length - 1] != ' ' &&
+                    line[line.Length - 1] != '\t')
                 {
                     continue;
                 }
-
-                var match = Regex.Match(line, @"\s+$");
-                if (match.Success)
+                int startColumnOfTrailingWhitespace = 0;
+                for (int i = line.Length - 2; i > 0; i--)
                 {
-                    var startLine = lineNumber + 1;
-                    var endLine = startLine;
-                    var startColumn = match.Index + 1;
-                    var endColumn = startColumn + match.Length;
-
-                    var violationExtent = new ScriptExtent(
-                        new ScriptPosition(
-                            ast.Extent.File,
-                            startLine,
-                            startColumn,
-                            line
-                        ),
-                        new ScriptPosition(
-                            ast.Extent.File,
-                            endLine,
-                            endColumn,
-                            line
-                        ));
-
-                    var suggestedCorrections = new List<CorrectionExtent>();
-                    suggestedCorrections.Add(new CorrectionExtent(
-                                violationExtent,
-                                string.Empty,
-                                ast.Extent.File
-                            ));
-
-                    diagnosticRecords.Add(
-                        new DiagnosticRecord(
-                            String.Format(CultureInfo.CurrentCulture, Strings.AvoidTrailingWhitespaceError),
-                            violationExtent,
-                            GetName(),
-                            GetDiagnosticSeverity(),
-                            ast.Extent.File,
-                            null,
-                            suggestedCorrections
-                        ));
+                    if (line[i] != ' ' && line[i] != '\t')
+                    {
+                        startColumnOfTrailingWhitespace = i + 2;
+                        break;
+                    }
                 }
+
+                var startLine = lineNumber + 1;
+                var endLine = startLine;
+                var startColumn = startColumnOfTrailingWhitespace;
+                var endColumn = line.Length + 1;
+
+                var violationExtent = new ScriptExtent(
+                    new ScriptPosition(
+                        ast.Extent.File,
+                        startLine,
+                        startColumn,
+                        line
+                    ),
+                    new ScriptPosition(
+                        ast.Extent.File,
+                        endLine,
+                        endColumn,
+                        line
+                    ));
+
+                var suggestedCorrections = new List<CorrectionExtent>();
+                suggestedCorrections.Add(new CorrectionExtent(
+                            violationExtent,
+                            string.Empty,
+                            ast.Extent.File
+                        ));
+
+                diagnosticRecords.Add(
+                    new DiagnosticRecord(
+                        String.Format(CultureInfo.CurrentCulture, Strings.AvoidTrailingWhitespaceError),
+                        violationExtent,
+                        GetName(),
+                        GetDiagnosticSeverity(),
+                        ast.Extent.File,
+                        null,
+                        suggestedCorrections
+                    ));
             }
 
             return diagnosticRecords;

--- a/Rules/AvoidTrailingWhitespace.cs
+++ b/Rules/AvoidTrailingWhitespace.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     continue;
                 }
-                int startColumnOfTrailingWhitespace = 0;
+                int startColumnOfTrailingWhitespace = 1;
                 for (int i = line.Length - 2; i > 0; i--)
                 {
                     if (line[i] != ' ' && line[i] != '\t')


### PR DESCRIPTION
## PR Summary

Whitespace ignoring diff makes it clearer. This was the most expensive script analysis rule when being run in warm mode and also easy to fix :-)
It also shows the performance improvements in .Net Core 5

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.