### PR TITLE
New rule (disabled by default): AvoidUsingDoubleQuotesForConstantString

### DIFF
--- a/Engine/Formatter.cs
+++ b/Engine/Formatter.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 "PSAlignAssignmentStatement",
                 "PSUseCorrectCasing",
                 "PSAvoidUsingCmdletAliases",
+                "PSAvoidUsingDoubleQuotesForConstantString",
             };
 
             var text = new EditableText(scriptDefinition);

--- a/RuleDocumentation/AvoidUsingDoubleQuotesForConstantString.md
+++ b/RuleDocumentation/AvoidUsingDoubleQuotesForConstantString.md
@@ -1,0 +1,21 @@
+# AvoidUsingDoubleQuotesForConstantString
+
+**Severity Level: Information**
+
+## Description
+
+When the value of a string is constant (i.e. not being interpolated by injecting variables or expression into such as e.g. `"$PID-$(hostname)"`), then single quotes should be used to express the constant nature of the string. This is not only to make the intent clearer that the string is a constant and makes it easier to use some special characters such as e.g. `$` within that string expression without the need to escape them. There are exceptions to that when double quoted strings are more readable though, e.g. when the string value itself has to contain a single quote (which would require a double single quotes to escape the character itself) or certain very special characters such as e.g. `"\n"` are already being escaped, the rule would not warn in this case as it is up to the author to decide on what is more readable in those cases.
+
+## Example
+
+### Wrong
+
+``` PowerShell
+$constantValue = "I Love PowerShell"
+```
+
+### Correct
+
+``` PowerShell
+$constantValue = 'I Love PowerShell'
+```

--- a/RuleDocumentation/README.md
+++ b/RuleDocumentation/README.md
@@ -17,6 +17,7 @@
 |[AvoidNullOrEmptyHelpMessageAttribute](./AvoidNullOrEmptyHelpMessageAttribute.md) | Warning | |
 |[AvoidShouldContinueWithoutForce](./AvoidShouldContinueWithoutForce.md) | Warning | |
 |[UseUsingScopeModifierInNewRunspaces](./UseUsingScopeModifierInNewRunspaces.md) | Warning | |
+|[AvoidUsingDoubleQuotesForConstantString](./AvoidUsingDoubleQuotesForConstantString.md) | Warning | Yes |
 |[AvoidUsingCmdletAliases](./AvoidUsingCmdletAliases.md) | Warning | Yes |
 |[AvoidUsingComputerNameHardcoded](./AvoidUsingComputerNameHardcoded.md) | Error | |
 |[AvoidUsingConvertToSecureStringWithPlainText](./AvoidUsingConvertToSecureStringWithPlainText.md) | Error | |

--- a/Rules/AvoidUsingDoubleQuotesForConstantString.cs
+++ b/Rules/AvoidUsingDoubleQuotesForConstantString.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 switch (stringConstantExpressionAst.StringConstantType)
                 {
                     case StringConstantType.DoubleQuoted:
-                        // Note that .ToString() has to be called in the 2nd case because the Value property already trimmed the ` escape character
                         if (stringConstantExpressionAst.Value.Contains("'") || stringConstantExpressionAst.Extent.Text.Contains("`"))
                         {
                             break;

--- a/Rules/AvoidUsingDoubleQuotesForConstantString.cs
+++ b/Rules/AvoidUsingDoubleQuotesForConstantString.cs
@@ -7,8 +7,6 @@ using System.Collections.Generic;
 using System.ComponentModel.Composition;
 #endif
 using System.Globalization;
-using System.Linq;
-using System.Management;
 using System.Management.Automation.Language;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 
@@ -57,42 +55,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         yield return GetDiagnosticRecord(stringConstantExpressionAst,
                             $"@'{Environment.NewLine}{stringConstantExpressionAst.Value}{Environment.NewLine}'@");
                         break;
-                    // yield return new DiagnosticRecord(
-                    //     Strings.AvoidOverwritingBuiltInCmdletsError,
-                    //     stringConstantExpressionAst.Extent,
-                    //     GetName(),
-                    //     GetDiagnosticSeverity(),
-                    //     stringConstantExpressionAst.Extent.File,
-                    //     suggestedCorrections: new[] {
-                    //         new CorrectionExtent(
-                    //             stringConstantExpressionAst.Extent,
-                    //             $"@'{Environment.NewLine}{stringConstantExpressionAst.Value}{Environment.NewLine}'@",
-                    //             stringConstantExpressionAst.Extent.File
-                    //         )
-                    //     }
-                    // );
 
                     default:
                         break;
                 }
-
-                // if (stringConstantExpressionAst.StringConstantType == StringConstantType.DoubleQuoted)
-                // {
-                //     yield return new DiagnosticRecord(
-                //         Strings.AvoidOverwritingBuiltInCmdletsError,
-                //         stringConstantExpressionAst.Extent,
-                //         GetName(),
-                //         GetDiagnosticSeverity(),
-                //         stringConstantExpressionAst.Extent.File,
-                //         suggestedCorrections: new[] {
-                //             new CorrectionExtent(
-                //                 stringConstantExpressionAst.Extent,
-                //                 $"'{stringConstantExpressionAst.Value}'",
-                //                 stringConstantExpressionAst.Extent.File
-                //             )
-                //         }
-                //     );
-                // }
             }
         }
 

--- a/Rules/AvoidUsingDoubleQuotesForConstantString.cs
+++ b/Rules/AvoidUsingDoubleQuotesForConstantString.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// </summary>
         public AvoidUsingDoubleQuotesForConstantString()
         {
-            Enable = false;  // Disabled by default
+            Enable = false;
         }
 
         /// <summary>
@@ -47,11 +47,19 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 switch (stringConstantExpressionAst.StringConstantType)
                 {
                     case StringConstantType.DoubleQuoted:
+                        if (stringConstantExpressionAst.Value.Contains("'"))
+                        {
+                            break;
+                        }
                         yield return GetDiagnosticRecord(stringConstantExpressionAst,
                             $"'{stringConstantExpressionAst.Value}'");
                         break;
 
                     case StringConstantType.DoubleQuotedHereString:
+                        if (stringConstantExpressionAst.Value.Contains("@'"))
+                        {
+                            break;
+                        }
                         yield return GetDiagnosticRecord(stringConstantExpressionAst,
                             $"@'{Environment.NewLine}{stringConstantExpressionAst.Value}{Environment.NewLine}'@");
                         break;
@@ -66,7 +74,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             string suggestedCorrection)
         {
             return new DiagnosticRecord(
-                Strings.AvoidOverwritingBuiltInCmdletsError,
+                Strings.AvoidUsingDoubleQuotesForConstantStringError,
                 stringConstantExpressionAst.Extent,
                 GetName(),
                 GetDiagnosticSeverity(),

--- a/Rules/AvoidUsingDoubleQuotesForConstantString.cs
+++ b/Rules/AvoidUsingDoubleQuotesForConstantString.cs
@@ -1,0 +1,179 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+#if !CORECLR
+using System.ComponentModel.Composition;
+#endif
+using System.Globalization;
+using System.Linq;
+using System.Management;
+using System.Management.Automation.Language;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
+{
+    /// <summary>
+    /// AvoidUsingDoubleQuotesForConstantStrings: Checks if a string that uses double quotes contains a constant string, which could be simplified to a single quote.
+    /// </summary>
+#if !CORECLR
+    [Export(typeof(IScriptRule))]
+#endif
+    public class AvoidUsingDoubleQuotesForConstantString : ConfigurableRule
+    {
+        /// <summary>
+        /// Construct an object of type <seealso cref="AvoidUsingDoubleQuotesForConstantStrings"/>.
+        /// </summary>
+        public AvoidUsingDoubleQuotesForConstantString()
+        {
+            Enable = false;  // Disabled by default
+        }
+
+        /// <summary>
+        /// Analyzes the given ast to find the [violation]
+        /// </summary>
+        /// <param name="ast">AST to be analyzed. This should be non-null</param>
+        /// <param name="fileName">Name of file that corresponds to the input AST.</param>
+        /// <returns>A an enumerable type containing the violations</returns>
+        public override IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
+            if (ast == null)
+            {
+                throw new ArgumentNullException(nameof(ast));
+            }
+
+            var stringConstantExpressionAsts = ast.FindAll(testAst => testAst is StringConstantExpressionAst, searchNestedScriptBlocks: true);
+            foreach (StringConstantExpressionAst stringConstantExpressionAst in stringConstantExpressionAsts)
+            {
+                switch (stringConstantExpressionAst.StringConstantType)
+                {
+                    case StringConstantType.DoubleQuoted:
+                        yield return GetDiagnosticRecord(stringConstantExpressionAst,
+                            $"'{stringConstantExpressionAst.Value}'");
+                        break;
+
+                    case StringConstantType.DoubleQuotedHereString:
+                        yield return GetDiagnosticRecord(stringConstantExpressionAst,
+                            $"@'{Environment.NewLine}{stringConstantExpressionAst.Value}{Environment.NewLine}'@");
+                        break;
+                    // yield return new DiagnosticRecord(
+                    //     Strings.AvoidOverwritingBuiltInCmdletsError,
+                    //     stringConstantExpressionAst.Extent,
+                    //     GetName(),
+                    //     GetDiagnosticSeverity(),
+                    //     stringConstantExpressionAst.Extent.File,
+                    //     suggestedCorrections: new[] {
+                    //         new CorrectionExtent(
+                    //             stringConstantExpressionAst.Extent,
+                    //             $"@'{Environment.NewLine}{stringConstantExpressionAst.Value}{Environment.NewLine}'@",
+                    //             stringConstantExpressionAst.Extent.File
+                    //         )
+                    //     }
+                    // );
+
+                    default:
+                        break;
+                }
+
+                // if (stringConstantExpressionAst.StringConstantType == StringConstantType.DoubleQuoted)
+                // {
+                //     yield return new DiagnosticRecord(
+                //         Strings.AvoidOverwritingBuiltInCmdletsError,
+                //         stringConstantExpressionAst.Extent,
+                //         GetName(),
+                //         GetDiagnosticSeverity(),
+                //         stringConstantExpressionAst.Extent.File,
+                //         suggestedCorrections: new[] {
+                //             new CorrectionExtent(
+                //                 stringConstantExpressionAst.Extent,
+                //                 $"'{stringConstantExpressionAst.Value}'",
+                //                 stringConstantExpressionAst.Extent.File
+                //             )
+                //         }
+                //     );
+                // }
+            }
+        }
+
+        private DiagnosticRecord GetDiagnosticRecord(StringConstantExpressionAst stringConstantExpressionAst,
+            string suggestedCorrection)
+        {
+            return new DiagnosticRecord(
+                Strings.AvoidOverwritingBuiltInCmdletsError,
+                stringConstantExpressionAst.Extent,
+                GetName(),
+                GetDiagnosticSeverity(),
+                stringConstantExpressionAst.Extent.File,
+                suggestedCorrections: new[] {
+                    new CorrectionExtent(
+                        stringConstantExpressionAst.Extent,
+                        suggestedCorrection,
+                        stringConstantExpressionAst.Extent.File
+                    )
+                }
+            );
+        }
+
+        /// <summary>
+        /// Retrieves the common name of this rule.
+        /// </summary>
+        public override string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingDoubleQuotesForConstantStringCommonName);
+        }
+
+        /// <summary>
+        /// Retrieves the description of this rule.
+        /// </summary>
+        public override string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingDoubleQuotesForConstantStringDescription);
+        }
+
+        /// <summary>
+        /// Retrieves the name of this rule.
+        /// </summary>
+        public override string GetName()
+        {
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.NameSpaceFormat,
+                GetSourceName(),
+                Strings.AvoidUsingDoubleQuotesForConstantStringName);
+        }
+
+        /// <summary>
+        /// Retrieves the severity of the rule: error, warning or information.
+        /// </summary>
+        public override RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Information;
+        }
+
+        /// <summary>
+        /// Gets the severity of the returned diagnostic record: error, warning, or information.
+        /// </summary>
+        /// <returns></returns>
+        public DiagnosticSeverity GetDiagnosticSeverity()
+        {
+            return DiagnosticSeverity.Information;
+        }
+
+        /// <summary>
+        /// Retrieves the name of the module/assembly the rule is from.
+        /// </summary>
+        public override string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+
+        /// <summary>
+        /// Retrieves the type of the rule, Builtin, Managed or Module.
+        /// </summary>
+        public override SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
+        }
+    }
+}

--- a/Rules/AvoidUsingDoubleQuotesForConstantString.cs
+++ b/Rules/AvoidUsingDoubleQuotesForConstantString.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         }
 
         /// <summary>
-        /// Analyzes the given ast to find the [violation]
+        /// Analyzes the given ast to find occurences of StringConstantExpressionAst where double quotes are used
+        /// and could be replaced with single quotes.
         /// </summary>
         /// <param name="ast">AST to be analyzed. This should be non-null</param>
         /// <param name="fileName">Name of file that corresponds to the input AST.</param>

--- a/Rules/AvoidUsingDoubleQuotesForConstantString.cs
+++ b/Rules/AvoidUsingDoubleQuotesForConstantString.cs
@@ -47,6 +47,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 switch (stringConstantExpressionAst.StringConstantType)
                 {
+                    /*
+                        If an interpolated string (i.e. using double quotes) uses single quotes (or @' in case of a here-string), then do not warn.
+                        This because one would then have to escape this single quote, which would make the string less readable.
+                        If an interpolated string contains a backtick character, then do not warn as well.
+                        This is because we'd have to replace the backtick in some cases like `$ and in others like `a it would not be possible at all.
+                        Therefore to keep it simple, all interpolated strings with a backtick are being excluded. 
+                    */
                     case StringConstantType.DoubleQuoted:
                         if (stringConstantExpressionAst.Value.Contains("'") || stringConstantExpressionAst.Extent.Text.Contains("`"))
                         {

--- a/Rules/AvoidUsingDoubleQuotesForConstantString.cs
+++ b/Rules/AvoidUsingDoubleQuotesForConstantString.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 switch (stringConstantExpressionAst.StringConstantType)
                 {
                     case StringConstantType.DoubleQuoted:
-                        if (stringConstantExpressionAst.Value.Contains("'"))
+                        if (stringConstantExpressionAst.Value.Contains("'") || stringConstantExpressionAst.Value.Contains("`"))
                         {
                             break;
                         }
@@ -56,7 +56,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         break;
 
                     case StringConstantType.DoubleQuotedHereString:
-                        if (stringConstantExpressionAst.Value.Contains("@'"))
+                        if (stringConstantExpressionAst.Value.Contains("@'") || stringConstantExpressionAst.Value.Contains("`"))
                         {
                             break;
                         }

--- a/Rules/AvoidUsingDoubleQuotesForConstantString.cs
+++ b/Rules/AvoidUsingDoubleQuotesForConstantString.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     case StringConstantType.DoubleQuoted:
                         // Note that .ToString() has to be called in the 2nd case because the Value property already trimmed the ` escape character
-                        if (stringConstantExpressionAst.Value.Contains("'") || stringConstantExpressionAst.ToString().Contains("`"))
+                        if (stringConstantExpressionAst.Value.Contains("'") || stringConstantExpressionAst.Extent.Text.Contains("`"))
                         {
                             break;
                         }
@@ -57,7 +57,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         break;
 
                     case StringConstantType.DoubleQuotedHereString:
-                        if (stringConstantExpressionAst.Value.Contains("@'") || stringConstantExpressionAst.ToString().Contains("`"))
+                        if (stringConstantExpressionAst.Value.Contains("@'") || stringConstantExpressionAst.Extent.Text.Contains("`"))
                         {
                             break;
                         }

--- a/Rules/AvoidUsingDoubleQuotesForConstantString.cs
+++ b/Rules/AvoidUsingDoubleQuotesForConstantString.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 switch (stringConstantExpressionAst.StringConstantType)
                 {
                     case StringConstantType.DoubleQuoted:
-                        if (stringConstantExpressionAst.Value.Contains("'") || stringConstantExpressionAst.Value.Contains("`"))
+                        // Note that .ToString() has to be called in the 2nd case because the Value property already trimmed the ` escape character
+                        if (stringConstantExpressionAst.Value.Contains("'") || stringConstantExpressionAst.ToString().Contains("`"))
                         {
                             break;
                         }
@@ -56,7 +57,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         break;
 
                     case StringConstantType.DoubleQuotedHereString:
-                        if (stringConstantExpressionAst.Value.Contains("@'") || stringConstantExpressionAst.Value.Contains("`"))
+                        if (stringConstantExpressionAst.Value.Contains("@'") || stringConstantExpressionAst.ToString().Contains("`"))
                         {
                             break;
                         }

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -862,6 +862,33 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Avoid using double quotes if the string is constant..
+        /// </summary>
+        internal static string AvoidUsingDoubleQuotesForConstantStringCommonName {
+            get {
+                return ResourceManager.GetString("AvoidUsingDoubleQuotesForConstantStringCommonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use single quotes if the string is constant..
+        /// </summary>
+        internal static string AvoidUsingDoubleQuotesForConstantStringDescription {
+            get {
+                return ResourceManager.GetString("AvoidUsingDoubleQuotesForConstantStringDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidUsingDoubleQuotesForConstantString.
+        /// </summary>
+        internal static string AvoidUsingDoubleQuotesForConstantStringName {
+            get {
+                return ResourceManager.GetString("AvoidUsingDoubleQuotesForConstantStringName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Avoid Using Empty Catch Block.
         /// </summary>
         internal static string AvoidUsingEmptyCatchBlockCommonName {

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -880,6 +880,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use single quotes when a string is constant..
+        /// </summary>
+        internal static string AvoidUsingDoubleQuotesForConstantStringError {
+            get {
+                return ResourceManager.GetString("AvoidUsingDoubleQuotesForConstantStringError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to AvoidUsingDoubleQuotesForConstantString.
         /// </summary>
         internal static string AvoidUsingDoubleQuotesForConstantStringName {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1146,4 +1146,7 @@
   <data name="AvoidUsingDoubleQuotesForConstantStringName" xml:space="preserve">
     <value>AvoidUsingDoubleQuotesForConstantString</value>
   </data>
+  <data name="AvoidUsingDoubleQuotesForConstantStringError" xml:space="preserve">
+    <value>Use single quotes when a string is constant.</value>
+  </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1137,4 +1137,13 @@
   <data name="UseUsingScopeModifierInNewRunspacesCorrectionDescription" xml:space="preserve">
     <value>Replace {0} with {1}</value>
   </data>
+  <data name="AvoidUsingDoubleQuotesForConstantStringCommonName" xml:space="preserve">
+    <value>Avoid using double quotes if the string is constant.</value>
+  </data>
+  <data name="AvoidUsingDoubleQuotesForConstantStringDescription" xml:space="preserve">
+    <value>Use single quotes if the string is constant.</value>
+  </data>
+  <data name="AvoidUsingDoubleQuotesForConstantStringName" xml:space="preserve">
+    <value>AvoidUsingDoubleQuotesForConstantString</value>
+  </data>
 </root>

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -58,7 +58,7 @@ Describe "Test Name parameters" {
 
         It "get Rules with no parameters supplied" {
             $defaultRules = Get-ScriptAnalyzerRule
-            $expectedNumRules = 64
+            $expectedNumRules = 65
             if ((Test-PSEditionCoreClr) -or (Test-PSVersionV3) -or (Test-PSVersionV4))
             {
                 # for PSv3 PSAvoidGlobalAliases is not shipped because
@@ -156,7 +156,7 @@ Describe "TestSeverity" {
 
     It "filters rules based on multiple severity inputs"{
         $rules = Get-ScriptAnalyzerRule -Severity Error,Information
-        $rules.Count | Should -Be 17
+        $rules.Count | Should -Be 18
     }
 
         It "takes lower case inputs" {

--- a/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
+++ b/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
@@ -13,12 +13,16 @@ Describe 'AvoidUsingDoubleQuotesForConstantString' {
             (Invoke-ScriptAnalyzer -ScriptDefinition '$item = "value"' -Settings $settings).Count | Should -Be 1
         }
 
+        It 'Should not warn if string is interpolated and double quotes are used but single quotes are in value' {
+            Invoke-ScriptAnalyzer -ScriptDefinition '$item = "''value''"' -Settings $settings | Should -BeNullOrEmpty
+        }
+
         It 'Should not warn if string is constant and signle quotes are used' {
             Invoke-ScriptAnalyzer -ScriptDefinition '$item = ''value''' -Settings $settings | Should -BeNullOrEmpty
         }
 
         It 'Should not warn if string is interpolated and double quotes are used' {
-            Invoke-ScriptAnalyzer -ScriptDefinition '$item = $(Get-Item)' -Settings $settings | Should -BeNullOrEmpty
+            Invoke-ScriptAnalyzer -ScriptDefinition '$item = "$(Get-Item)"' -Settings $settings | Should -BeNullOrEmpty
         }
     }
 

--- a/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
+++ b/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
@@ -17,6 +17,10 @@ Describe 'AvoidUsingDoubleQuotesForConstantString' {
             Invoke-ScriptAnalyzer -ScriptDefinition '$item = "''value''"' -Settings $settings | Should -BeNullOrEmpty
         }
 
+        It 'Should not warn if string is interpolated and double quotes are used but backtick character is in value' {
+            Invoke-ScriptAnalyzer -ScriptDefinition '$item = ''foo-`$-bar''' -Settings $settings | Should -BeNullOrEmpty
+        }
+
         It 'Should not warn if string is constant and signle quotes are used' {
             Invoke-ScriptAnalyzer -ScriptDefinition '$item = ''value''' -Settings $settings | Should -BeNullOrEmpty
         }
@@ -24,7 +28,13 @@ Describe 'AvoidUsingDoubleQuotesForConstantString' {
         It 'Should not warn if string is interpolated and double quotes are used' {
             Invoke-ScriptAnalyzer -ScriptDefinition '$item = "$(Get-Item)"' -Settings $settings | Should -BeNullOrEmpty
         }
+
+        It 'Should not warn if string is interpolated and double quotes are used' {
+            Invoke-ScriptAnalyzer -ScriptDefinition '$item = "$(Get-Item)"' -Settings $settings | Should -BeNullOrEmpty
+        }
     }
+
+    # TODO: check escape strings
 
     Context 'Here string' {
         It 'Should warn if string is constant and double quotes are used' {
@@ -34,6 +44,23 @@ value
 "@
 '@
             (Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings).Count | Should -Be 1
+        }
+
+        It 'Should not warn if string is constant and double quotes are used but @'' is used in value' {
+            $scriptDefinition = @'
+$item=@"
+value1@'value2
+"@
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings | Should -BeNullOrEmpty
+        }
+        It 'Should not warn if string is constant and double quotes are used but backtick is used in value' {
+            $scriptDefinition = @'
+$item=@"
+foo-`$-bar
+"@
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings | Should -BeNullOrEmpty
         }
 
         It 'Should not warn if string is constant and single quotes are used' {

--- a/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
+++ b/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
@@ -18,7 +18,7 @@ Describe 'AvoidUsingDoubleQuotesForConstantString' {
         }
 
         It 'Should not warn if string is interpolated and double quotes are used but backtick character is in value' {
-            Invoke-ScriptAnalyzer -ScriptDefinition '$item = ''foo-`$-bar''' -Settings $settings | Should -BeNullOrEmpty
+            Invoke-ScriptAnalyzer -ScriptDefinition '$item = "foo-`$-bar"' -Settings $settings | Should -BeNullOrEmpty
         }
 
         It 'Should not warn if string is constant and signle quotes are used' {

--- a/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
+++ b/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
@@ -13,16 +13,20 @@ Describe 'AvoidUsingDoubleQuotesForConstantString' {
             (Invoke-ScriptAnalyzer -ScriptDefinition '$item = "value"' -Settings $settings).Count | Should -Be 1
         }
 
+        It 'Should correctly format if string is constant and double quotes are used' {
+            Invoke-Formatter -ScriptDefinition '$item = "value"' -Settings $settings | Should -Be "`$item = 'value'"
+        }
+
         It 'Should not warn if string is interpolated and double quotes are used but single quotes are in value' {
-            Invoke-ScriptAnalyzer -ScriptDefinition '$item = "''value''"' -Settings $settings | Should -BeNullOrEmpty
+            Invoke-ScriptAnalyzer -ScriptDefinition "`$item = 'value'" -Settings $settings | Should -BeNullOrEmpty
         }
 
         It 'Should not warn if string is interpolated and double quotes are used but backtick character is in value' {
             Invoke-ScriptAnalyzer -ScriptDefinition '$item = "foo-`$-bar"' -Settings $settings | Should -BeNullOrEmpty
         }
 
-        It 'Should not warn if string is constant and signle quotes are used' {
-            Invoke-ScriptAnalyzer -ScriptDefinition '$item = ''value''' -Settings $settings | Should -BeNullOrEmpty
+        It 'Should not warn if string is constant and single quotes are used' {
+            Invoke-ScriptAnalyzer -ScriptDefinition "`$item = 'value'" -Settings $settings | Should -BeNullOrEmpty
         }
 
         It 'Should not warn if string is interpolated and double quotes are used' {
@@ -44,6 +48,19 @@ value
 "@
 '@
             (Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings).Count | Should -Be 1
+        }
+
+        It 'Should correctly format if string is constant and double quotes are used' {
+            $scriptDefinition = @'
+$item=@"
+value
+"@
+'@
+            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be @"
+`$item=@'
+value
+'@
+"@
         }
 
         It 'Should not warn if string is constant and double quotes are used but @'' is used in value' {

--- a/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
+++ b/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
@@ -1,0 +1,54 @@
+﻿$settings = @{
+    IncludeRules = @('PSAvoidUsingDoubleQuotesForConstantString')
+    Rules        = @{
+        PSAvoidUsingDoubleQuotesForConstantString = @{
+            Enable = $true
+        }
+    }
+}
+
+Describe 'AvoidUsingDoubleQuotesForConstantString' {
+    Context 'One line string' {
+        It 'Should warn if string is constant and double quotes are used' {
+            (Invoke-ScriptAnalyzer -ScriptDefinition '$item = "value"' -Settings $settings).Count | Should -Be 1
+        }
+
+        It 'Should not warn if string is constant and signle quotes are used' {
+            Invoke-ScriptAnalyzer -ScriptDefinition '$item = ''value''' -Settings $settings | Should -BeNullOrEmpty
+        }
+
+        It 'Should not warn if string is interpolated and double quotes are used' {
+            Invoke-ScriptAnalyzer -ScriptDefinition '$item = $(Get-Item)' -Settings $settings | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'Here string' {
+        It 'Should warn if string is constant and double quotes are used' {
+            $scriptDefinition = @'
+$item=@"
+value
+"@
+'@
+            (Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings).Count | Should -Be 1
+        }
+
+        It 'Should not warn if string is constant and single quotes are used' {
+            $scriptDefinition = @"
+`$item=@'
+value
+'@
+"@
+            Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings | Should -BeNullOrEmpty
+        }
+
+        It 'Should not warn if string is interpolated' {
+            $scriptDefinition = @'
+$item=@"
+$(Get-Process)
+"@
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings | Should -BeNullOrEmpty
+        }
+    }
+
+}


### PR DESCRIPTION
## PR Summary

Closes #292
The rule is disabled by default to avoid breaking lots of people's CI pipeline and its main purpose is to be used in the formatter. The rule was kept quite simple to not touch constant strings that use single quotes (because then one would have to escape them, which would make the code uglier and therefore is a general exception) or have escape sequences, here it is up to the user.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.