### PR TITLE
ReviewunusedParameter: Search through child scope

### DIFF
--- a/Rules/ReviewUnusedParameter.cs
+++ b/Rules/ReviewUnusedParameter.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 IEnumerable<Ast> parameterAsts = scriptBlockAst.FindAll(oneAst => oneAst is ParameterAst, false);
 
                 // list all variables
-                IDictionary<string, int> variableCount = scriptBlockAst.FindAll(oneAst => oneAst is VariableExpressionAst, false)
+                IDictionary<string, int> variableCount = scriptBlockAst.FindAll(oneAst => oneAst is VariableExpressionAst, true)
                     .Select(variableExpressionAst => ((VariableExpressionAst)variableExpressionAst).VariablePath.UserPath)
                     .GroupBy(variableName => variableName, StringComparer.OrdinalIgnoreCase)
                     .ToDictionary(variableName => variableName.Key, variableName => variableName.Count(), StringComparer.OrdinalIgnoreCase);

--- a/Tests/Rules/ReviewUnusedParameter.tests.ps1
+++ b/Tests/Rules/ReviewUnusedParameter.tests.ps1
@@ -23,6 +23,26 @@ Describe "ReviewUnusedParameter" {
             $Violations.Count | Should -Be 1
         }
 
+        It "traverses child scriptblock scope" {
+            $ScriptDefinition = 'param($Param1) { $Param1 }'
+            Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName | Should -BeNullOrEmpty
+        }
+
+        It "traverses child scriptblock scope within simple function" {
+            $ScriptDefinition = 'function foo($Param1) { { $Param1 } }'
+            Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName | Should -BeNullOrEmpty
+        }
+
+        It "traverses child scriptblock scope within a function that uses param" {
+            $ScriptDefinition = 'function foo { param($Param1) { $Param1 } }'
+            Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName | Should -BeNullOrEmpty
+        }
+
+        It "traverse child function within a function" {
+            $ScriptDefinition = 'function foo($Param1) { function bar() { { $Param1 } } }'
+            Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName | Should -BeNullOrEmpty
+        }
+
         It "doesn't traverse scriptblock scope" {
             $ScriptDefinition = '{ param ($Param1) }; { $Param1 }'
             $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName


### PR DESCRIPTION
## PR Summary

Fixes #1472

This is WIP as at the moment, using a parameter in another function would yield a false negative.
An alternative implementation would be to allow only specific child scopes like e.g. the ones from ForEach-Object/Where-Object. I still have to figure out what would be better/easier

## PR Checklist

- [ ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.