### PR TITLE
UseConsistentWhitespace: Fix CheckParameter bug when using interpolated string

### DIFF
--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -390,7 +390,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     testAst => testAst is CommandAst, true);
             foreach (CommandAst commandAst in commandAsts)
             {
-                List<Ast> commandParameterAstElements = commandAst.FindAll(testAst => true, searchNestedScriptBlocks: false).ToList();
+                List<Ast> commandParameterAstElements = commandAst.FindAll(
+                    testAst => testAst.Parent == commandAst, searchNestedScriptBlocks: false).ToList();
                 for (int i = 0; i < commandParameterAstElements.Count - 1; i++)
                 {
                     IScriptExtent leftExtent = commandParameterAstElements[i].Extent;

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -474,11 +474,11 @@ bar -h i `
         }
 
         It "Should fix script to always have 1 space between parameters except when using colon syntax but not by default" {
-            $def = 'foo  -bar   $baz  -ParameterName:  $ParameterValue'
+            $def = 'foo  -bar   $baz  -ParameterName:  $ParameterValue "$PSScriptRoot\module.psd1"'
             Invoke-Formatter -ScriptDefinition $def |
                 Should -BeExactly $def -Because 'CheckParameter configuration is not turned on by default (yet) as the setting is new'
             Invoke-Formatter -ScriptDefinition $def -Settings $settings |
-                Should -BeExactly 'foo -bar $baz -ParameterName:  $ParameterValue'
+                Should -BeExactly 'foo -bar $baz -ParameterName:  $ParameterValue "$PSScriptRoot\module.psd1"'
         }
 
         It "Should fix script when newlines are involved" {


### PR DESCRIPTION
## PR Summary

Fixes #1495

I thought the `searchNestedScriptBlocks: false` option would not make it return nested objects in `commandAst.FindAll`. However, for an interpolated string, the `VariableExpressionAst` of the `ExpendableStringExpressionAst` is returned as well, therefore checking that only AST are returned whose parent is the `commandAst`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.