### PR TITLE
UseCorrectCasing: Do not use CommandInfoCache when CommandInfoParameters property throws due to runspace affinity problem of PowerShell engine

### DIFF
--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -57,8 +57,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// </summary>
         /// <param name="commandName">Name of the command to get a commandinfo object for.</param>
         /// <param name="commandTypes">What types of command are needed. If omitted, all types are retrieved.</param>
+        /// <param name="bypassCache">When needed due to runspace affinity problems of some PowerShell objects.</param>
         /// <returns></returns>
-        public CommandInfo GetCommandInfo(string commandName, CommandTypes? commandTypes = null)
+        public CommandInfo GetCommandInfo(string commandName, CommandTypes? commandTypes = null, bool bypassCache = false)
         {
             if (string.IsNullOrWhiteSpace(commandName))
             {
@@ -67,6 +68,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
             var key = new CommandLookupKey(commandName, commandTypes);
             // Atomically either use PowerShell to query a command info object, or fetch it from the cache
+            if (bypassCache)
+            {
+                return GetCommandInfoInternal(commandName, commandTypes);
+            }
             return _commandInfoCache.GetOrAdd(key, new Lazy<CommandInfo>(() => GetCommandInfoInternal(commandName, commandTypes))).Value;
         }
 

--- a/Engine/CommandInfoCache.cs
+++ b/Engine/CommandInfoCache.cs
@@ -67,11 +67,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
 
             var key = new CommandLookupKey(commandName, commandTypes);
-            // Atomically either use PowerShell to query a command info object, or fetch it from the cache
             if (bypassCache)
             {
                 return GetCommandInfoInternal(commandName, commandTypes);
             }
+            // Atomically either use PowerShell to query a command info object, or fetch it from the cache
             return _commandInfoCache.GetOrAdd(key, new Lazy<CommandInfo>(() => GetCommandInfoInternal(commandName, commandTypes))).Value;
         }
 

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -673,10 +673,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// </summary>
         /// <param name="name"></param>
         /// <param name="commandType"></param>
+        /// <param name="bypassCache"></param>
         /// <returns></returns>
-        public CommandInfo GetCommandInfo(string name, CommandTypes? commandType = null)
+        public CommandInfo GetCommandInfo(string name, CommandTypes? commandType = null, bool bypassCache = false)
         {
-            return CommandInfoCache.GetCommandInfo(name, commandTypes: commandType);
+            return CommandInfoCache.GetCommandInfo(name, commandTypes: commandType, bypassCache: bypassCache);
         }
 
         /// <summary>

--- a/Rules/UseCorrectCasing.cs
+++ b/Rules/UseCorrectCasing.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     continue;
                 }
 
-                var commandInfo = Helper.Instance.GetCommandInfo(commandName);
+                var commandInfo = Helper.Instance.GetCommandInfo(commandName, bypassCache: false);
                 if (commandInfo == null || commandInfo.CommandType == CommandTypes.ExternalScript || commandInfo.CommandType == CommandTypes.Application)
                 {
                     continue;

--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -73,4 +73,13 @@ Describe "UseCorrectCasing" {
         Invoke-Formatter 'Get-Process -NonExistingParameterName' -ErrorAction Stop
     }
 
+    It "Does not throw when correcting certain cmdlets (issue 1516)" {
+        $scriptDefinition = 'Get-Content;Test-Path;Get-ChildItem;Get-Content;Test-Path;Get-ChildItem'
+        $settings = @{ 'Rules' = @{ 'PSUseCorrectCasing' = @{ 'Enable' = $true } } }
+        {
+            1..100 |
+            ForEach-Object { $null = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings -ErrorAction Stop }
+        } |
+        Should -Not -Throw
+    }
 }


### PR DESCRIPTION
## PR Summary

Fixes #1516 by not using the cache if the sporadic PowerShell bug happens due to the runspace affinity PowerShell/PowerShell#4003 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.