### PR TITLE
Make CI fail if tests fail and fix failing tests by making them Pester v5 compatible

### DIFF
--- a/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
+++ b/Tests/Rules/AvoidUsingDoubleQuotesForConstantString.tests.ps1
@@ -1,8 +1,10 @@
-﻿$settings = @{
-    IncludeRules = @('PSAvoidUsingDoubleQuotesForConstantString')
-    Rules        = @{
-        PSAvoidUsingDoubleQuotesForConstantString = @{
-            Enable = $true
+﻿BeforeAll {
+    $settings = @{
+        IncludeRules = @('PSAvoidUsingDoubleQuotesForConstantString')
+        Rules        = @{
+            PSAvoidUsingDoubleQuotesForConstantString = @{
+                Enable = $true
+            }
         }
     }
 }

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -124,6 +124,7 @@ function Invoke-AppveyorTest {
     $configuration = [PesterConfiguration]::Default
     $configuration.CodeCoverage.Enabled = $false
     $configuration.Output.Verbosity = 'Normal'
+    $configuration.Run.Exit = $true
     $configuration.Run.PassThru = $true
     $configuration.Run.Path = $testScripts
     $configuration.TestResult.Enabled = $true


### PR DESCRIPTION
## PR Summary

The migration to Pester v5 meant that the switch to make CI fail if there was a test failure, was not on. I did an individual commit for this fix so that you can see it fails now when there is a failed test.
Fix failing tests by making them Pester v5 compatible, this was because the PR  that added those tests was opened before the Pester v5 migration.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.