### PR TITLE
Fix PSAvoidLongLines Example

### DIFF
--- a/RuleDocumentation/AvoidLongLines.md
+++ b/RuleDocumentation/AvoidLongLines.md
@@ -14,7 +14,7 @@ Lines should be no longer than a configured number of characters (default: 120),
     Rules = @{
         PSAvoidLongLines  = @{
             Enable     = $true
-            LineLength = 120
+            MaximumLineLength = 120
         }
     }
 ```


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->

In the example the parameter was not named correct.

## PR Checklist

- [x ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.