### PR TITLE
Fix #769 by setting PSUseConsistentWhitespace.CheckOperator to $false in default settings profiles

### DIFF
--- a/Engine/Settings/CodeFormatting.psd1
+++ b/Engine/Settings/CodeFormatting.psd1
@@ -24,10 +24,10 @@
         }
 
         PSUseConsistentIndentation = @{
-            Enable          = $true
-            Kind            = 'space'
+            Enable              = $true
+            Kind                = 'space'
             PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
-            IndentationSize = 4
+            IndentationSize     = 4
         }
 
         PSUseConsistentWhitespace  = @{
@@ -35,7 +35,7 @@
             CheckInnerBrace                 = $true
             CheckOpenBrace                  = $true
             CheckOpenParen                  = $true
-            CheckOperator                   = $true
+            CheckOperator                   = $false
             CheckPipe                       = $true
             CheckPipeForRedundantWhitespace = $false
             CheckSeparator                  = $true
@@ -47,8 +47,8 @@
             CheckHashtable = $true
         }
 
-        PSUseCorrectCasing     = @{
-            Enable             = $true
+        PSUseCorrectCasing         = @{
+            Enable = $true
         }
     }
 }

--- a/Engine/Settings/CodeFormattingAllman.psd1
+++ b/Engine/Settings/CodeFormattingAllman.psd1
@@ -24,10 +24,10 @@
         }
 
         PSUseConsistentIndentation = @{
-            Enable          = $true
-            Kind            = 'space'
+            Enable              = $true
+            Kind                = 'space'
             PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
-            IndentationSize = 4
+            IndentationSize     = 4
         }
 
         PSUseConsistentWhitespace  = @{
@@ -35,7 +35,7 @@
             CheckInnerBrace                 = $true
             CheckOpenBrace                  = $true
             CheckOpenParen                  = $true
-            CheckOperator                   = $true
+            CheckOperator                   = $false
             CheckPipe                       = $true
             CheckPipeForRedundantWhitespace = $false
             CheckSeparator                  = $true
@@ -47,8 +47,8 @@
             CheckHashtable = $true
         }
 
-        PSUseCorrectCasing     = @{
-            Enable             = $true
+        PSUseCorrectCasing         = @{
+            Enable = $true
         }
     }
 }

--- a/Engine/Settings/CodeFormattingOTBS.psd1
+++ b/Engine/Settings/CodeFormattingOTBS.psd1
@@ -24,10 +24,10 @@
         }
 
         PSUseConsistentIndentation = @{
-            Enable          = $true
-            Kind            = 'space'
+            Enable              = $true
+            Kind                = 'space'
             PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
-            IndentationSize = 4
+            IndentationSize     = 4
         }
 
         PSUseConsistentWhitespace  = @{
@@ -35,7 +35,7 @@
             CheckInnerBrace                 = $true
             CheckOpenBrace                  = $true
             CheckOpenParen                  = $true
-            CheckOperator                   = $true
+            CheckOperator                   = $false
             CheckPipe                       = $true
             CheckPipeForRedundantWhitespace = $false
             CheckSeparator                  = $true
@@ -47,8 +47,8 @@
             CheckHashtable = $true
         }
 
-        PSUseCorrectCasing     = @{
-            Enable             = $true
+        PSUseCorrectCasing         = @{
+            Enable = $true
         }
     }
 }

--- a/Engine/Settings/CodeFormattingStroustrup.psd1
+++ b/Engine/Settings/CodeFormattingStroustrup.psd1
@@ -9,15 +9,15 @@
         'PSUseCorrectCasing'
     )
 
-    Rules = @{
-        PSPlaceOpenBrace = @{
+    Rules        = @{
+        PSPlaceOpenBrace           = @{
             Enable             = $true
             OnSameLine         = $true
             NewLineAfter       = $true
             IgnoreOneLineBlock = $true
         }
 
-        PSPlaceCloseBrace = @{
+        PSPlaceCloseBrace          = @{
             Enable             = $true
             NewLineAfter       = $true
             IgnoreOneLineBlock = $true
@@ -25,10 +25,10 @@
         }
 
         PSUseConsistentIndentation = @{
-            Enable          = $true
-            Kind            = 'space'
+            Enable              = $true
+            Kind                = 'space'
             PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
-            IndentationSize = 4
+            IndentationSize     = 4
         }
 
         PSUseConsistentWhitespace  = @{
@@ -36,7 +36,7 @@
             CheckInnerBrace                 = $true
             CheckOpenBrace                  = $true
             CheckOpenParen                  = $true
-            CheckOperator                   = $true
+            CheckOperator                   = $false
             CheckPipe                       = $true
             CheckPipeForRedundantWhitespace = $false
             CheckSeparator                  = $true
@@ -48,8 +48,8 @@
             CheckHashtable = $true
         }
 
-        PSUseCorrectCasing     = @{
-            Enable             = $true
+        PSUseCorrectCasing         = @{
+            Enable = $true
         }
     }
 }


### PR DESCRIPTION
## PR Summary

Fix default settings profiles by implementing @kapilmb's [workaround in the original issue](https://github.com/PowerShell/PSScriptAnalyzer/issues/769#issuecomment-305331610) of disabling the `CheckOperator` attribute of `PSUseConsistentWhitespace`.

Also aligned the assignment statements within all the default settings profiles.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.