### PR TITLE
Remove conditional compilation for PSv6 and therefore netstandard2.0 for Engine and Rules projects

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.19.1</VersionPrefix>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
     <AssemblyName>Microsoft.Windows.PowerShell.ScriptAnalyzer</AssemblyName>
     <AssemblyVersion>1.19.1</AssemblyVersion>
     <PackageId>Engine</PackageId>
@@ -17,11 +17,11 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <Compile Remove="SafeDirectoryCatalog.cs" />
   </ItemGroup>
 
@@ -68,12 +68,6 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);PSV7;CORECLR</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);PSV6;CORECLR</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Management.Automation" Version="6.1.0" />
-  </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452' AND '$(Configuration)' == 'PSV3Release' AND '$(Configuration)' != 'PSV4Release'">
     <PackageReference Include="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />

--- a/Engine/PSScriptAnalyzer.psm1
+++ b/Engine/PSScriptAnalyzer.psm1
@@ -9,15 +9,13 @@ $PSModuleRoot = $PSModule.ModuleBase
 
 # Import the appropriate nested binary module based on the current PowerShell version
 $binaryModuleRoot = $PSModuleRoot
-if ($PSVersionTable.PSVersion.Major -eq 7 ) {
-    $binaryModuleRoot = Join-Path -Path $PSModuleRoot -ChildPath "PSv$($PSVersionTable.PSVersion.Major)"
-}
-elseif ($PSVersionTable.PSVersion.Major -eq 6 ) {
+[Version] $minimumPowerShellCoreVersion = '7.0.3'
+if ($PSVersionTable.PSVersion.Major -ge 6) {
     $binaryModuleRoot = Join-Path -Path $PSModuleRoot -ChildPath "PSv$($PSVersionTable.PSVersion.Major)"
     # Minimum PowerShell Core version given by PowerShell Core support itself and
-    # also the version of NewtonSoft.Json implicitly that PSSA ships with,
-    # which cannot be higher than the one that PowerShell ships with.
-    [Version] $minimumPowerShellCoreVersion = '6.2.4'
+    # the version of Nuget references, such as e.g. Newtonsoft.Json inside PowerShell itself
+    # or the version of the System.Management.Automation NuGet reference in PSSA.
+    
     if ($PSVersionTable.PSVersion -lt $minimumPowerShellCoreVersion) {
         throw "Minimum supported version of PSScriptAnalyzer for PowerShell Core is $minimumPowerShellCoreVersion but current version is '$($PSVersionTable.PSVersion)'. Please update PowerShell Core."
     }

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Exit
 #### Supported PowerShell Versions and Platforms
 
 - Windows PowerShell 3.0 or greater
-- PowerShell Core 6.2 or greater on Windows/Linux/macOS
+- PowerShell Core 7.0.3 or greater on Windows/Linux/macOS
 - Docker (tested only using Docker Desktop on Windows 10 1809)
   - PowerShell 6 Windows Image tags from [mcr.microsoft.com/powershell](https://hub.docker.com/r/microsoft/powershell). Example (1 warning gets produced by `Save-Module` but can be ignored):
 

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ Note: the PSScriptAnalyzer Chocolatey package is provided and supported by the c
     ```powershell
     .\build.ps1 -PSVersion 3
     ```
-    * PowerShell Core
+    * PowerShell 7
     ```powershell
-    .\build.ps1 -PSVersion 6
+    .\build.ps1 -PSVersion 7
     ```
 * Rebuild documentation since it gets built automatically only the first time
     ```powershell

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.19.1</VersionPrefix>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net452</TargetFrameworks>
     <AssemblyName>Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules</AssemblyName>
     <AssemblyVersion>1.19.1</AssemblyVersion>
     <PackageId>Rules</PackageId>
@@ -15,7 +15,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Management.Infrastructure" Version="2.0.0" />
   </ItemGroup>
 
@@ -27,10 +27,6 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DebugType>portable</DebugType>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -48,7 +44,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />
     <Compile Remove="UseSingularNouns.cs" />
   </ItemGroup>
@@ -63,10 +59,6 @@
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <DefineConstants>$(DefineConstants);PSV7;CORECLR</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);PSV6;CORECLR</DefineConstants>
   </PropertyGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,8 +35,8 @@ build_script:
   - pwsh: |
       if ($env:PowerShellEdition -eq 'PowerShellCore') {
           Set-Location $env:APPVEYOR_BUILD_FOLDER
-          ./build.ps1 -Configuration "$env:BuildConfiguration" -PSVersion 6
-          ./PSCompatibilityCollector/build.ps1 -Configuration "$env:BuildConfiguration" -Framework 'netstandard2.0'
+          ./build.ps1 -Configuration "$env:BuildConfiguration" -PSVersion 7
+          ./PSCompatibilityCollector/build.ps1 -Configuration "$env:BuildConfiguration" -Framework 'netcoreapp3.1'
       }
 
 test_script:

--- a/build.ps1
+++ b/build.ps1
@@ -7,7 +7,7 @@ param(
     [switch]$All,
 
     [Parameter(ParameterSetName="BuildOne")]
-    [ValidateRange(3, 7)]
+    [ValidateSet(3, 4, 5, 7)]
     [int]$PSVersion = $PSVersionTable.PSVersion.Major,
 
     [Parameter(ParameterSetName="BuildOne")]

--- a/build.psm1
+++ b/build.psm1
@@ -144,7 +144,7 @@ function Start-ScriptAnalyzerBuild
     param (
         [switch]$All,
 
-        [ValidateRange(3, 7)]
+        [ValidateSet(3, 4, 5, 7)]
         [int]$PSVersion = $PSVersionTable.PSVersion.Major,
 
         [ValidateSet("Debug", "Release")]
@@ -183,7 +183,7 @@ function Start-ScriptAnalyzerBuild
         if ( $All )
         {
             # Build all the versions of the analyzer
-            foreach($psVersion in 3..7) {
+            foreach ($psVersion in 3, 4, 5, 7) {
                 Start-ScriptAnalyzerBuild -Configuration $Configuration -PSVersion $psVersion -Verbose:$verboseWanted
             }
             if ( $Catalog ) {
@@ -200,14 +200,9 @@ function Start-ScriptAnalyzerBuild
             Set-Variable -Name profilesCopied -Value $true -Scope 1
         }
 
+        $framework = 'net452'
         if ($PSVersion -eq 7) {
             $framework = 'netcoreapp3.1'
-        }
-        elseif ($PSVersion -eq 6) {
-            $framework = 'netstandard2.0'
-        }
-        else {
-            $framework = "net452"
         }
 
         # build the appropriate assembly
@@ -241,10 +236,6 @@ function Start-ScriptAnalyzerBuild
             {
                 $destinationDirBinaries = "$script:destinationDir"
             }
-            6
-            {
-                $destinationDirBinaries = "$script:destinationDir\PSv6"
-            }
             7
             {
                 $destinationDirBinaries = "$script:destinationDir\PSv7"
@@ -256,7 +247,7 @@ function Start-ScriptAnalyzerBuild
         }
 
         $buildConfiguration = $Configuration
-        if ((3, 4, 6, 7) -contains $PSVersion) {
+        if ((3, 4, 7) -contains $PSVersion) {
             $buildConfiguration = "PSV${PSVersion}${Configuration}"
         }
 

--- a/tools/releaseBuild/AssemblySignConfig.xml
+++ b/tools/releaseBuild/AssemblySignConfig.xml
@@ -20,11 +20,6 @@
     <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\Settings\ScriptingStyle.psd1" signType="400" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\Settings\ScriptingStyle.psd1" />
     <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\Settings\ScriptSecurity.psd1" signType="400" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\Settings\ScriptSecurity.psd1" />
  </job>
- <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Script Analyzer PSv6" approvers="vigarg;gstolt">
-    <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll" signType="400" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll" />
-    <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.Windows.PowerShell.ScriptAnalyzer.dll" signType="400" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.Windows.PowerShell.ScriptAnalyzer.dll" />
-    <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.PowerShell.CrossCompatibility.dll" signType="400" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.PowerShell.CrossCompatibility.dll" />
- </job>
  <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Script Analyzer PSv7" approvers="vigarg;gstolt">
     <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\PSv7\Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll" signType="400" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\PSv7\Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll" />
     <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\PSv7\Microsoft.Windows.PowerShell.ScriptAnalyzer.dll" signType="400" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\PSv7\Microsoft.Windows.PowerShell.ScriptAnalyzer.dll" />

--- a/tools/releaseBuild/signing.xml
+++ b/tools/releaseBuild/signing.xml
@@ -20,11 +20,6 @@
     <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\Settings\ScriptingStyle.psd1" signType="Authenticode" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\Settings\ScriptingStyle.psd1" />
     <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\Settings\ScriptSecurity.psd1" signType="Authenticode" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\Settings\ScriptSecurity.psd1" />
  </job>
- <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Script Analyzer PSv6" approvers="vigarg;gstolt">
-    <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll" signType="Authenticode" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll" />
-    <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.Windows.PowerShell.ScriptAnalyzer.dll" signType="Authenticode" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.Windows.PowerShell.ScriptAnalyzer.dll" />
-    <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.PowerShell.CrossCompatibility.dll" signType="Authenticode" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\PSv6\Microsoft.PowerShell.CrossCompatibility.dll" />
- </job>
  <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PowerShell Script Analyzer PSv7" approvers="vigarg;gstolt">
     <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\PSv7\Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll" signType="Authenticode" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\PSv7\Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules.dll" />
     <file src="__INPATHROOT__\out\PSScriptAnalyzer\1.19.1\PSv7\Microsoft.Windows.PowerShell.ScriptAnalyzer.dll" signType="Authenticode" dest="__OUTPATHROOT__\PSScriptAnalyzer\1.19.1\PSv7\Microsoft.Windows.PowerShell.ScriptAnalyzer.dll" />


### PR DESCRIPTION
## PR Summary

This is due to PS 6.2 having reached EOL. The Engine and Rules projects target `netcoreapp3.1` for PS 7, therefore the `netstandard2.0` compilation target for them is not needed any more. Because the CrossCompatility project is still generic and is not targeting `netcoreapp3.1` for PS 7, we can and should keep that project using `netstandard2.0`.
This will make the module smaller in size and the build faster as a nice side-effect.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.