### PR TITLE
UseConsistentWhitespace.CheckOperator: Add unary operators that start with a dash (-split, -join, -not, -bnot, isplit, csplit)

### DIFF
--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -63,6 +63,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         [ConfigurableRuleProperty(defaultValue: false)]
         public bool CheckParameter { get; protected set; }
 
+        [ConfigurableRuleProperty(defaultValue: true)]
+        public bool CheckUnaryOperatorWithDash { get; protected set; }
+
         public override void ConfigureRule(IDictionary<string, object> paramValueMap)
         {
             base.ConfigureRule(paramValueMap);
@@ -94,6 +97,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             if (CheckSeparator)
             {
                 violationFinders.Add(FindSeparatorViolations);
+            }
+
+            if (CheckUnaryOperatorWithDash)
+            {
+                violationFinders.Add(FindUnaryOperatorViolations);
             }
         }
 
@@ -360,6 +368,72 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     }
                 }
             }
+        }
+
+        private IEnumerable<DiagnosticRecord> FindUnaryOperatorViolations(TokenOperations tokenOperations)
+        {
+            bool isUnaryOperatorWithDash(Token token)
+            {
+                return token.TokenFlags == TokenFlags.UnaryOperator && token.Text.StartsWith("-");
+            }
+
+            foreach (var unaryOperatorWithDash in tokenOperations.GetTokenNodes(token => isUnaryOperatorWithDash(token)))
+            {
+                if (unaryOperatorWithDash.Next == null
+                    || !IsPreviousTokenOnSameLine(unaryOperatorWithDash)
+                    || unaryOperatorWithDash.Next.Value.Kind == TokenKind.NewLine
+                    || unaryOperatorWithDash.Next.Value.Kind == TokenKind.LineContinuation
+                    )
+                {
+                    continue;
+                }
+
+                if (!IsNextTokenApartByWhitespace(unaryOperatorWithDash, out bool hasRedundantWhitespace))
+                {
+                    // TODO put into if below: CheckPipeForRedundantWhitespace && hasRedundantWhitespace || 
+                    if (CheckUnaryOperatorWithDash && !hasRedundantWhitespace)
+                    {
+                        yield return new DiagnosticRecord(
+                            GetError(ErrorKind.AfterPipe),
+                            unaryOperatorWithDash.Value.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            tokenOperations.Ast.Extent.File,
+                            null,
+                            GetCorrections(
+                                unaryOperatorWithDash.Previous.Value, unaryOperatorWithDash.Value, unaryOperatorWithDash.Next.Value, true, false)
+                                .ToList());
+                    }
+                }
+            }
+
+            // foreach (var pipe in tokenOperations.GetTokenNodes(TokenKind.Pipe))
+            // {
+            //     if (pipe.Previous == null
+            //         || !IsPreviousTokenOnSameLine(pipe)
+            //         || pipe.Previous.Value.Kind == TokenKind.Pipe
+            //         || pipe.Previous.Value.Kind == TokenKind.NewLine
+            //         || pipe.Previous.Value.Kind == TokenKind.LineContinuation
+            //         )
+            //     {
+            //         continue;
+            //     }
+
+            //     if (!IsPreviousTokenApartByWhitespace(pipe, out bool hasRedundantWhitespace))
+            //     {
+            //         if (CheckPipeForRedundantWhitespace && hasRedundantWhitespace || CheckUnaryOperatorWithDash && !hasRedundantWhitespace)
+            //         {
+            //             yield return new DiagnosticRecord(
+            //             GetError(ErrorKind.BeforePipe),
+            //             pipe.Value.Extent,
+            //             GetName(),
+            //             GetDiagnosticSeverity(),
+            //             tokenOperations.Ast.Extent.File,
+            //             null,
+            //             GetCorrections(pipe.Previous.Value, pipe.Value, pipe.Next.Value, false, true).ToList());
+            //         }
+            //     }
+            // }
         }
 
         private IEnumerable<DiagnosticRecord> FindOpenParenViolations(TokenOperations tokenOperations)

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -99,10 +99,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 violationFinders.Add(FindSeparatorViolations);
             }
 
-            if (CheckUnaryOperatorWithDash)
-            {
-                violationFinders.Add(FindUnaryOperatorViolations);
-            }
+            // if (CheckUnaryOperatorWithDash)
+            // {
+            //     violationFinders.Add(FindUnaryOperatorViolations);
+            // }
         }
 
         /// <summary>
@@ -199,6 +199,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             return TokenTraits.HasTrait(token.Kind, TokenFlags.AssignmentOperator)
                     || TokenTraits.HasTrait(token.Kind, TokenFlags.BinaryPrecedenceAdd)
                     || TokenTraits.HasTrait(token.Kind, TokenFlags.BinaryPrecedenceMultiply)
+                    || TokenTraits.HasTrait(token.Kind, TokenFlags.UnaryOperator) && token.Text.StartsWith("-")
                     || token.Kind == TokenKind.AndAnd
                     || token.Kind == TokenKind.OrOr;
         }

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -63,7 +63,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         [ConfigurableRuleProperty(defaultValue: false)]
         public bool CheckParameter { get; protected set; }
 
-
         public override void ConfigureRule(IDictionary<string, object> paramValueMap)
         {
             base.ConfigureRule(paramValueMap);

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -180,6 +180,35 @@ $x = $true -and
             Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
+
+        It "Should not find violation if there are whitespaces of size 1 around a unary operator starting with a dash" {
+            Invoke-ScriptAnalyzer -ScriptDefinition '$x -join $y' -Settings $settings | Should -BeNullOrEmpty
+        }
+
+        It "Should find a violation if no whitespace around a unary operator starting with a dash" {
+            $def = '$x=1'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            Test-CorrectionExtentFromContent $def $violations 1 '=' ' = '
+        }
+
+        It "Should find a violation if no whitespace before a unary operator starting with a dash" {
+            $def = '$x-join $Y'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            Test-CorrectionExtentFromContent $def $violations 1 '' ' '
+        }
+
+        It "Should find a violation if no whitespace after a unary operator starting with a dash" {
+            $def = '$x -join$y'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            Test-CorrectionExtentFromContent $def $violations 1 '' ' '
+        }
+
+        It "Should find a violation if there is a whitespaces not of size 1 around a unary operator starting with a dash" {
+            $def = '$x  -join  $y'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            Test-CorrectionExtentFromContent $def $violations 1 '  -join  ' ' -join '
+        }
+
     }
 
     Context "When a comma is not followed by a space" {


### PR DESCRIPTION
## PR Summary

Related: #1239

In order to enable formatting corrections of this kind: `$a-join$b` --> `$a -join $b`
It adds or trims the required whitespace. The only exception that the existing code does not handle is adding a whitespace when there is no variable/value before the operator (e.g. `-split $a`), but since we are only adding more cases for this existing rule, we don't necessarily have to consider all cases that could be enabled as well.
The reason for adding the check that the unary operator starts with a dash is is to exclude things like `$a++` or `!$a` where we do not want a whitespace character separation by default

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.