### PR TITLE
WIP: Possible alternate implementation of UseConsistentWhitespace CheckOperator feature

### DIFF
--- a/Engine/FindAstPositionVisitor.cs
+++ b/Engine/FindAstPositionVisitor.cs
@@ -1,0 +1,369 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Management.Automation.Language;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
+{
+    /// <summary>
+    /// Provides an efficient way to find the position in the AST corresponding to a given script position.
+    /// </summary>
+#if !(PSV3 || PSV4)
+    internal class FindAstPositionVisitor : AstVisitor2
+#else
+    internal class FindAstPositionVisitor : AstVisitor
+#endif
+    {
+        private IScriptPosition searchPosition;
+
+        /// <summary>
+        /// Contains the position in the AST corresponding to the provided <see cref="IScriptPosition"/> upon completion of the <see cref="Ast.Visit(AstVisitor)"/> method.
+        /// </summary>
+        public Ast AstPosition { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FindAstPositionVisitor"/> class with the postition to search for.
+        /// </summary>
+        /// <param name="position">The script position to search for.</param>
+        public FindAstPositionVisitor(IScriptPosition position)
+        {
+            this.searchPosition = position;
+        }
+
+        /// <summary>
+        /// Traverses the AST based on offests to find the leaf node which contains the provided <see cref="IScriptPosition"/>.
+        /// This method implements the entire functionality of this visitor. All <see cref="AstVisitor2"/> methods are overridden to simply invoke this one.
+        /// </summary>
+        /// <param name="ast">Current AST node to process.</param>
+        /// <returns>An <see cref="AstVisitAction"/> indicating whether to visit children of the current node.</returns>
+        private AstVisitAction Visit(Ast ast)
+        {
+            if (ast.Extent.StartOffset > searchPosition.Offset || ast.Extent.EndOffset <= searchPosition.Offset)
+            {
+                return AstVisitAction.SkipChildren;
+            }
+            AstPosition = ast;
+            return AstVisitAction.Continue;
+        }
+
+         public override AstVisitAction VisitArrayExpression(ArrayExpressionAst arrayExpressionAst)
+         {
+             return Visit(arrayExpressionAst);
+         }
+
+         public override AstVisitAction VisitArrayLiteral(ArrayLiteralAst arrayLiteralAst)
+         {
+             return Visit(arrayLiteralAst);
+         }
+
+         public override AstVisitAction VisitAssignmentStatement(AssignmentStatementAst assignmentStatementAst)
+         {
+             return Visit(assignmentStatementAst);
+         }
+
+         public override AstVisitAction VisitAttribute(AttributeAst attributeAst)
+         {
+             return Visit(attributeAst);
+         }
+
+         public override AstVisitAction VisitAttributedExpression(AttributedExpressionAst attributedExpressionAst)
+         {
+             return Visit(attributedExpressionAst);
+         }
+
+         public override AstVisitAction VisitBinaryExpression(BinaryExpressionAst binaryExpressionAst)
+         {
+             return Visit(binaryExpressionAst);
+         }
+
+         public override AstVisitAction VisitBlockStatement(BlockStatementAst blockStatementAst)
+         {
+             return Visit(blockStatementAst);
+         }
+
+         public override AstVisitAction VisitBreakStatement(BreakStatementAst breakStatementAst)
+         {
+             return Visit(breakStatementAst);
+         }
+
+         public override AstVisitAction VisitCatchClause(CatchClauseAst catchClauseAst)
+         {
+             return Visit(catchClauseAst);
+         }
+
+         public override AstVisitAction VisitCommand(CommandAst commandAst)
+         {
+             return Visit(commandAst);
+         }
+
+         public override AstVisitAction VisitCommandExpression(CommandExpressionAst commandExpressionAst)
+         {
+             return Visit(commandExpressionAst);
+         }
+
+         public override AstVisitAction VisitCommandParameter(CommandParameterAst commandParameterAst)
+         {
+             return Visit(commandParameterAst);
+         }
+
+         public override AstVisitAction VisitConstantExpression(ConstantExpressionAst constantExpressionAst)
+         {
+             return Visit(constantExpressionAst);
+         }
+
+         public override AstVisitAction VisitContinueStatement(ContinueStatementAst continueStatementAst)
+         {
+             return Visit(continueStatementAst);
+         }
+
+         public override AstVisitAction VisitConvertExpression(ConvertExpressionAst convertExpressionAst)
+         {
+             return Visit(convertExpressionAst);
+         }
+
+         public override AstVisitAction VisitDataStatement(DataStatementAst dataStatementAst)
+         {
+             return Visit(dataStatementAst);
+         }
+
+         public override AstVisitAction VisitDoUntilStatement(DoUntilStatementAst doUntilStatementAst)
+         {
+             return Visit(doUntilStatementAst);
+         }
+
+         public override AstVisitAction VisitDoWhileStatement(DoWhileStatementAst doWhileStatementAst)
+         {
+             return Visit(doWhileStatementAst);
+         }
+
+         public override AstVisitAction VisitErrorExpression(ErrorExpressionAst errorExpressionAst)
+         {
+             return Visit(errorExpressionAst);
+         }
+
+         public override AstVisitAction VisitErrorStatement(ErrorStatementAst errorStatementAst)
+         {
+             return Visit(errorStatementAst);
+         }
+
+         public override AstVisitAction VisitExitStatement(ExitStatementAst exitStatementAst)
+         {
+             return Visit(exitStatementAst);
+         }
+
+         public override AstVisitAction VisitExpandableStringExpression(ExpandableStringExpressionAst expandableStringExpressionAst)
+         {
+             return Visit(expandableStringExpressionAst);
+         }
+
+         public override AstVisitAction VisitFileRedirection(FileRedirectionAst fileRedirectionAst)
+         {
+             return Visit(fileRedirectionAst);
+         }
+
+         public override AstVisitAction VisitForEachStatement(ForEachStatementAst forEachStatementAst)
+         {
+             return Visit(forEachStatementAst);
+         }
+
+         public override AstVisitAction VisitForStatement(ForStatementAst forStatementAst)
+         {
+             return Visit(forStatementAst);
+         }
+
+         public override AstVisitAction VisitFunctionDefinition(FunctionDefinitionAst functionDefinitionAst)
+         {
+             return Visit(functionDefinitionAst);
+         }
+
+         public override AstVisitAction VisitHashtable(HashtableAst hashtableAst)
+         {
+             return Visit(hashtableAst);
+         }
+
+         public override AstVisitAction VisitIfStatement(IfStatementAst ifStatementAst)
+         {
+             return Visit(ifStatementAst);
+         }
+
+         public override AstVisitAction VisitIndexExpression(IndexExpressionAst indexExpressionAst)
+         {
+             return Visit(indexExpressionAst);
+         }
+
+         public override AstVisitAction VisitInvokeMemberExpression(InvokeMemberExpressionAst invokeMemberExpressionAst)
+         {
+             return Visit(invokeMemberExpressionAst);
+         }
+
+         public override AstVisitAction VisitMemberExpression(MemberExpressionAst memberExpressionAst)
+         {
+             return Visit(memberExpressionAst);
+         }
+
+         public override AstVisitAction VisitMergingRedirection(MergingRedirectionAst mergingRedirectionAst)
+         {
+             return Visit(mergingRedirectionAst);
+         }
+
+         public override AstVisitAction VisitNamedAttributeArgument(NamedAttributeArgumentAst namedAttributeArgumentAst)
+         {
+             return Visit(namedAttributeArgumentAst);
+         }
+
+         public override AstVisitAction VisitNamedBlock(NamedBlockAst namedBlockAst)
+         {
+             return Visit(namedBlockAst);
+         }
+
+         public override AstVisitAction VisitParamBlock(ParamBlockAst paramBlockAst)
+         {
+             return Visit(paramBlockAst);
+         }
+
+         public override AstVisitAction VisitParameter(ParameterAst parameterAst)
+         {
+             return Visit(parameterAst);
+         }
+
+         public override AstVisitAction VisitParenExpression(ParenExpressionAst parenExpressionAst)
+         {
+             return Visit(parenExpressionAst);
+         }
+
+         public override AstVisitAction VisitPipeline(PipelineAst pipelineAst)
+         {
+             return Visit(pipelineAst);
+         }
+
+         public override AstVisitAction VisitReturnStatement(ReturnStatementAst returnStatementAst)
+         {
+             return Visit(returnStatementAst);
+         }
+
+         public override AstVisitAction VisitScriptBlock(ScriptBlockAst scriptBlockAst)
+         {
+             return Visit(scriptBlockAst);
+         }
+
+         public override AstVisitAction VisitScriptBlockExpression(ScriptBlockExpressionAst scriptBlockExpressionAst)
+         {
+             return Visit(scriptBlockExpressionAst);
+         }
+
+         public override AstVisitAction VisitStatementBlock(StatementBlockAst statementBlockAst)
+         {
+             return Visit(statementBlockAst);
+         }
+
+         public override AstVisitAction VisitStringConstantExpression(StringConstantExpressionAst stringConstantExpressionAst)
+         {
+             return Visit(stringConstantExpressionAst);
+         }
+
+         public override AstVisitAction VisitSubExpression(SubExpressionAst subExpressionAst)
+         {
+             return Visit(subExpressionAst);
+         }
+
+         public override AstVisitAction VisitSwitchStatement(SwitchStatementAst switchStatementAst)
+         {
+             return Visit(switchStatementAst);
+         }
+
+         public override AstVisitAction VisitThrowStatement(ThrowStatementAst throwStatementAst)
+         {
+             return Visit(throwStatementAst);
+         }
+
+         public override AstVisitAction VisitTrap(TrapStatementAst trapStatementAst)
+         {
+             return Visit(trapStatementAst);
+         }
+
+         public override AstVisitAction VisitTryStatement(TryStatementAst tryStatementAst)
+         {
+             return Visit(tryStatementAst);
+         }
+
+         public override AstVisitAction VisitTypeConstraint(TypeConstraintAst typeConstraintAst)
+         {
+             return Visit(typeConstraintAst);
+         }
+
+         public override AstVisitAction VisitTypeExpression(TypeExpressionAst typeExpressionAst)
+         {
+             return Visit(typeExpressionAst);
+         }
+
+         public override AstVisitAction VisitUnaryExpression(UnaryExpressionAst unaryExpressionAst)
+         {
+             return Visit(unaryExpressionAst);
+         }
+
+         public override AstVisitAction VisitUsingExpression(UsingExpressionAst usingExpressionAst)
+         {
+             return Visit(usingExpressionAst);
+         }
+
+         public override AstVisitAction VisitVariableExpression(VariableExpressionAst variableExpressionAst)
+         {
+             return Visit(variableExpressionAst);
+         }
+
+         public override AstVisitAction VisitWhileStatement(WhileStatementAst whileStatementAst)
+         {
+             return Visit(whileStatementAst);
+         }
+
+#if !(PSV3 || PSV4)
+         public override AstVisitAction VisitBaseCtorInvokeMemberExpression(BaseCtorInvokeMemberExpressionAst baseCtorInvokeMemberExpressionAst)
+         {
+             return Visit(baseCtorInvokeMemberExpressionAst);
+         }
+
+         public override AstVisitAction VisitConfigurationDefinition(ConfigurationDefinitionAst configurationDefinitionAst)
+         {
+             return Visit(configurationDefinitionAst);
+         }
+
+         public override AstVisitAction VisitDynamicKeywordStatement(DynamicKeywordStatementAst dynamicKeywordStatementAst)
+         {
+             return Visit(dynamicKeywordStatementAst);
+         }
+
+         public override AstVisitAction VisitFunctionMember(FunctionMemberAst functionMemberAst)
+         {
+             return Visit(functionMemberAst);
+         }
+
+         public override AstVisitAction VisitPropertyMember(PropertyMemberAst propertyMemberAst)
+         {
+             return Visit(propertyMemberAst);
+         }
+
+         public override AstVisitAction VisitTypeDefinition(TypeDefinitionAst typeDefinitionAst)
+         {
+             return Visit(typeDefinitionAst);
+         }
+
+         public override AstVisitAction VisitUsingStatement(UsingStatementAst usingStatementAst)
+         {
+             return Visit(usingStatementAst);
+         }
+#endif
+
+#if !(NET452 || PSV6) // NET452 includes V3,4,5
+         public override AstVisitAction VisitPipelineChain(PipelineChainAst pipelineChainAst)
+         {
+             return Visit(pipelineChainAst);
+         }
+
+         public override AstVisitAction VisitTernaryExpression(TernaryExpressionAst ternaryExpressionAst)
+         {
+             return Visit(ternaryExpressionAst);
+         }
+#endif
+
+    }
+}

--- a/Engine/TokenOperations.cs
+++ b/Engine/TokenOperations.cs
@@ -232,5 +232,18 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         {
             return token1.Extent.StartLineNumber == token2.Extent.EndLineNumber;
         }
+
+        /// <summary>
+        /// Finds the position of a given token in the AST.
+        /// </summary>
+        /// <param name="token">The <see cref="Token"/> to search for.</param>
+        /// <returns>The Ast node directly containing the provided <see cref="Token"/>.</returns>
+        public Ast GetAstPosition(Token token)
+        {
+            FindAstPositionVisitor findAstVisitor = new FindAstPositionVisitor(token.Extent.StartScriptPosition);
+            ast.Visit(findAstVisitor);
+            return findAstVisitor.AstPosition;
+        }
+
     }
 }

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -186,15 +186,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             return SourceType.Builtin;
         }
 
-        private bool IsOperator(Token token)
-        {
-            return TokenTraits.HasTrait(token.Kind, TokenFlags.AssignmentOperator)
-                    || TokenTraits.HasTrait(token.Kind, TokenFlags.BinaryPrecedenceAdd)
-                    || TokenTraits.HasTrait(token.Kind, TokenFlags.BinaryPrecedenceMultiply)
-                    || token.Kind == TokenKind.AndAnd
-                    || token.Kind == TokenKind.OrOr;
-        }
-
         private string GetError(ErrorKind kind)
         {
             switch (kind)
@@ -513,45 +504,87 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         private IEnumerable<DiagnosticRecord> FindOperatorViolations(TokenOperations tokenOperations)
         {
-            foreach (var tokenNode in tokenOperations.GetTokenNodes(IsOperator))
+            foreach (LinkedListNode<Token> tokenNode in tokenOperations.GetTokenNodes((t)=>true))
             {
-                if (tokenNode.Previous == null
-                    || tokenNode.Next == null
-                    || tokenNode.Value.Kind == TokenKind.DotDot)
+                bool tokenHasUnaryFlag = TokenTraits.HasTrait(tokenNode.Value.Kind, TokenFlags.UnaryOperator);
+                bool tokenHasBinaryFlag = TokenTraits.HasTrait(tokenNode.Value.Kind, TokenFlags.BinaryOperator);
+                bool checkLeftSide = false;
+                bool checkRightSide = false;
+                bool operatorIsPrefixOrPostfix = false;
+
+                // Exclude operators handled by other UseConsistentWhitespace rule options
+                if (tokenNode.Value.Kind == TokenKind.DotDot
+                    || tokenNode.Value.Kind == TokenKind.Comma) {
+                    continue;
+                }
+                // First check operators that have unary flag (may be unary or binary)
+                else if (tokenHasUnaryFlag)
+                {
+                    Ast operatorAst = tokenOperations.GetAstPosition(tokenNode.Value);
+                    // If both unary and binary flags are set, check type of AST node to determine which it is in this case.
+                    if (tokenHasBinaryFlag && operatorAst is BinaryExpressionAst)
+                    {
+                        checkLeftSide = true;
+                        checkRightSide = true;
+                    }
+                    else // Token must be unary operator.
+                    {
+                        operatorIsPrefixOrPostfix = TokenTraits.HasTrait(tokenNode.Value.Kind, TokenFlags.PrefixOrPostfixOperator)
+                                                    || tokenNode.Value.Kind == TokenKind.Minus
+                                                    || tokenNode.Value.Kind == TokenKind.Exclaim;
+                        // If token and its AST node start at same position, operand is on the right.
+                        if (tokenNode.Value.Extent.StartOffset == operatorAst.Extent.StartOffset)
+                        {
+                            checkRightSide = true;
+                        }
+                        else
+                        {
+                            checkLeftSide = true;
+                        }
+                    }
+                }
+                // Handle operators that are definitely binary
+                else if (tokenHasBinaryFlag // binary flag is set but not unary
+                         // include other (non-expression) binary operators
+                         || TokenTraits.HasTrait(tokenNode.Value.Kind, TokenFlags.AssignmentOperator)
+                         || tokenNode.Value.Kind == TokenKind.AndAnd
+                         || tokenNode.Value.Kind == TokenKind.OrOr
+                         ) {
+                    checkLeftSide = true;
+                    checkRightSide = true;
+                }
+                else // Token is not an operator
                 {
                     continue;
                 }
 
-                // exclude unary operator for cases like $foo.bar(-$Var)
-                if (TokenTraits.HasTrait(tokenNode.Value.Kind, TokenFlags.UnaryOperator) &&
-                    tokenNode.Previous.Value.Kind == TokenKind.LParen &&
-                    tokenNode.Next.Value.Kind == TokenKind.Variable)
+                if (!operatorIsPrefixOrPostfix)
                 {
-                    continue;
-                }
+                    bool leftSideOK = !checkLeftSide || IsPreviousTokenOnSameLineAndApartByWhitespace(tokenNode);
 
-                var hasWhitespaceBefore = IsPreviousTokenOnSameLineAndApartByWhitespace(tokenNode);
-                var hasWhitespaceAfter = tokenNode.Next.Value.Kind == TokenKind.NewLine
-                            || IsPreviousTokenOnSameLineAndApartByWhitespace(tokenNode.Next);
+                    bool rightSideOK = !checkRightSide || tokenNode.Next.Value.Kind == TokenKind.NewLine
+                                    || IsPreviousTokenOnSameLineAndApartByWhitespace(tokenNode.Next);
 
-                if (!hasWhitespaceAfter || !hasWhitespaceBefore)
-                {
-                    yield return new DiagnosticRecord(
-                        GetError(ErrorKind.Operator),
-                        tokenNode.Value.Extent,
-                        GetName(),
-                        GetDiagnosticSeverity(),
-                        tokenOperations.Ast.Extent.File,
-                        null,
-                        GetCorrections(
-                            tokenNode.Previous.Value,
-                            tokenNode.Value,
-                            tokenNode.Next.Value,
-                            hasWhitespaceBefore,
-                            hasWhitespaceAfter));
+                    if (!leftSideOK || !rightSideOK)
+                    {
+                        yield return new DiagnosticRecord(
+                            GetError(ErrorKind.Operator),
+                            tokenNode.Value.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            tokenOperations.Ast.Extent.File,
+                            null,
+                            GetCorrections(
+                                tokenNode.Previous?.Value,
+                                tokenNode.Value,
+                                tokenNode.Next?.Value,
+                                leftSideOK,
+                                rightSideOK));
+                    }
                 }
             }
         }
+
 
         private List<CorrectionExtent> GetCorrections(
             Token prevToken,


### PR DESCRIPTION
## PR Summary

OK, so this far from ready, but I wanted to get it out there as a suggestion. It all started with trying to work on unary operator issues describe in #1239. But after discovering the problem in #1606, I was thinking maybe the best thing would be to re-implement the feature and an idea of how to do it came to me. 

I started by writing a bunch more tests (https://github.com/PowerShell/PSScriptAnalyzer/commit/3a47f4af6b3c0869f27557fd1b596a8271383f83) both as a way to establish a baseline for how the feature behaves now, and to hopefully be a tool to help with any fixes for the linked issues. In order to come up with this list of tests, I looked through [about_Operators](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7) and related topics. I added a test for any type of operator that I felt was somehow different, but didn't already have a test and could possibly fall into the category of operators that one might possibly want `CheckOperator` to enforce whitespace around (or to ignore).

Then, I wrote a new implementation (https://github.com/PowerShell/PSScriptAnalyzer/commit/d3da1e420c4ef661a9ad629c9be5f1c3ac4a0020)  which more-or-less corresponds with the current behavior, except (at least in my opinion) handles unary operators better and fixes the inconsistencies with bitwise operators between PS 5.1 and 7. Since it already passed the tests for most types of operators I decided to go ahead and write code that might handle the other types (https://github.com/PowerShell/PSScriptAnalyzer/commit/3943377c0bdcc582aeef86dd1310551c459847bc). I realize that that code may not be complete enough and maybe not all of those operators should be implemented.

Hopefully the code comments explain the strategy pretty well but I will add a couple things. The code for the visitor is the same as I used in PR #1566. Also, I chose to remove the `IsOperator` function because it wasn't used anywhere else, and the tests that would be used just to determine whether the token is an operator are so similar to the ones used to determine what sort of operator, I figured it would be simpler not to run through them twice.

With this implementation, it would also be reasonably easy to enforce no whitespace around operators like `++`,`--`,`-`,`!` as described in #1239 (which could also easily be made optional). See [possible implementation](https://github.com/daviesj/PSScriptAnalyzer/compare/operatorfix...daviesj:operatorfix_prefix_postfix).
## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.