### PR TITLE
Pester: Install latest version on WMF builds and skip installation if version is new enough for Azure DevOps which now ships with Pester

### DIFF
--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -4,13 +4,12 @@
 $ErrorActionPreference = 'Stop'
 
 function Install-Pester {
-    $requiredPesterVersion = '5.0.2'
-    $pester = Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq $requiredPesterVersion }
+    $pester = Get-Module Pester -ListAvailable | Where-Object { $_.Version -gt [version]'5.1' }
     if ($null -eq $pester) {
         if ($null -eq (Get-Module -ListAvailable PowershellGet)) {
             # WMF 4 image build
             Write-Verbose -Verbose "Installing Pester via nuget"
-            nuget install Pester -Version $requiredPesterVersion -source https://www.powershellgallery.com/api/v2 -outputDirectory "$env:ProgramFiles\WindowsPowerShell\Modules\." -ExcludeVersion
+            nuget install Pester -source https://www.powershellgallery.com/api/v2 -outputDirectory "$env:ProgramFiles\WindowsPowerShell\Modules\." -ExcludeVersion
         }
         else {
             # Visual Studio 2017 build (has already Pester v3, therefore a different installation mechanism is needed to make it also use the new version 4)


### PR DESCRIPTION
## PR Summary

This has the following benefits:
- Azure DevOps images now ship with Pester by default, therefore we will be able to skip the installation step and rely on them bumping the Pester version. It saves around 8 seconds on Ubuntu and 20 seconds on Windows
- The WMF build will always have the latest version of Pester
- no more manual changes :-)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.