### PR TITLE
Remove unneeded powershell-core NuGet feed, which sometimes causes build failures

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,6 +3,5 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="powershell-core" value="https://powershell.myget.org/F/powershell-core/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
## PR Summary

See here for an example where I had to re-run the build due to this sporadic failure where it tries to use this feed
https://dev.azure.com/powershell/psscriptanalyzer/_build/results?buildId=72298&view=logs&j=4655027d-76cb-566f-39c5-ca24e588f38c&t=4655027d-76cb-566f-39c5-ca24e588f38c

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.