### PR TITLE
Speedup CI by bootstrapping PowerShell module installations in background and in parallel, whilst the .NET SDK is being installed

### DIFF
--- a/.azure-pipelines-ci/ci.yaml
+++ b/.azure-pipelines-ci/ci.yaml
@@ -9,6 +9,8 @@ stages:
         pool:
           vmImage: windows-latest
         steps:
+        - checkout: self
+          fetchDepth: 1
         - pwsh: |
             Import-Module .\tools\appveyor.psm1
             Invoke-AppveyorInstall -SkipPesterInstallation

--- a/.azure-pipelines-ci/ci.yaml
+++ b/.azure-pipelines-ci/ci.yaml
@@ -9,8 +9,6 @@ stages:
         pool:
           vmImage: windows-latest
         steps:
-        - checkout: self
-          fetchDepth: 5
         - pwsh: |
             Import-Module .\tools\appveyor.psm1
             Invoke-AppveyorInstall -SkipPesterInstallation
@@ -52,6 +50,4 @@ stages:
         pool:
           vmImage: $[ variables['vmImage'] ]
         steps:
-        - checkout: self
-          fetchDepth: 5
         - template: templates/test-powershell.yaml

--- a/.azure-pipelines-ci/ci.yaml
+++ b/.azure-pipelines-ci/ci.yaml
@@ -10,7 +10,7 @@ stages:
           vmImage: windows-latest
         steps:
         - checkout: self
-          fetchDepth: 1
+          fetchDepth: 5
         - pwsh: |
             Import-Module .\tools\appveyor.psm1
             Invoke-AppveyorInstall -SkipPesterInstallation
@@ -52,4 +52,6 @@ stages:
         pool:
           vmImage: $[ variables['vmImage'] ]
         steps:
+        - checkout: self
+          fetchDepth: 5
         - template: templates/test-powershell.yaml

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -47,7 +47,7 @@ function Invoke-AppVeyorInstall {
     # Do not use 'build.ps1 -bootstrap' option for bootstraping the .Net SDK as it does not work well in CI with the AppVeyor Ubuntu image
     Write-Verbose -Verbose "Installing required .Net CORE SDK"
     # the legacy WMF4 image only has the old preview SDKs of dotnet
-    $globalDotJson = Get-Content (Join-Path $using:PSScriptRoot '..\global.json') -Raw | ConvertFrom-Json
+    $globalDotJson = Get-Content (Join-Path $PSScriptRoot '..\global.json') -Raw | ConvertFrom-Json
     $requiredDotNetCoreSDKVersion = $globalDotJson.sdk.version
     if ($PSVersionTable.PSVersion.Major -gt 4) {
         $requiredDotNetCoreSDKVersionPresent = (dotnet --list-sdks) -match $requiredDotNetCoreSDKVersion

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -32,7 +32,7 @@ function Invoke-AppVeyorInstall {
     $jobs = @()
 
     Write-Verbose -Verbose "test1"
-    if (-not $SkipPesterInstallation.IsPresent) { $jobs += Start-Job -ScriptBlock ${Function:Install-Pester} }
+    if (-not $SkipPesterInstallation.IsPresent) { $jobs += Start-Job ${Function:Install-Pester} }
 
     Write-Verbose -Verbose "test2"
     $jobs += Start-Job {

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -32,7 +32,7 @@ function Invoke-AppVeyorInstall {
     $jobs = @()
 
     Write-Verbose -Verbose "test1"
-    if (-not $SkipPesterInstallation.IsPresent) { $jobs += Start-Job -ScriptBlock $Function:Install-Pester }
+    if (-not $SkipPesterInstallation.IsPresent) { $jobs += Start-Job -ScriptBlock ${Function:Install-Pester} }
 
     Write-Verbose -Verbose "test2"
     $jobs += Start-Job {

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -27,6 +27,7 @@ function Invoke-AppVeyorInstall {
         [switch] $SkipPesterInstallation
     )
 
+    Write-Verbose -Verbose "Bootstrapping build dependencies"
     $jobs = @()
 
     if (-not $SkipPesterInstallation.IsPresent) { $jobs += Start-Job $Function:Install-Pester }
@@ -47,7 +48,7 @@ function Invoke-AppVeyorInstall {
         # Do not use 'build.ps1 -bootstrap' option for bootstraping the .Net SDK as it does not work well in CI with the AppVeyor Ubuntu image
         Write-Verbose -Verbose "Installing required .Net CORE SDK"
         # the legacy WMF4 image only has the old preview SDKs of dotnet
-        $globalDotJson = Get-Content (Join-Path $PSScriptRoot '..\global.json') -Raw | ConvertFrom-Json
+        $globalDotJson = Get-Content (Join-Path $using:PSScriptRoot '..\global.json') -Raw | ConvertFrom-Json
         $requiredDotNetCoreSDKVersion = $globalDotJson.sdk.version
         if ($PSVersionTable.PSVersion.Major -gt 4) {
             $requiredDotNetCoreSDKVersionPresent = (dotnet --list-sdks) -match $requiredDotNetCoreSDKVersion

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -17,6 +17,7 @@ function Install-Pester {
             Write-Verbose -Verbose "Installing Pester via Install-Module"
             Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser -Repository PSGallery
         }
+        Write-Verbose -Verbose "Installed Pester"
     }
 }
 
@@ -31,7 +32,7 @@ function Invoke-AppVeyorInstall {
     $jobs = @()
 
     Write-Verbose -Verbose "test1"
-    if (-not $SkipPesterInstallation.IsPresent) { $jobs += Start-Job $Function:Install-Pester }
+    if (-not $SkipPesterInstallation.IsPresent) { $jobs += Start-Job -ScriptBlock $Function:Install-Pester }
 
     Write-Verbose -Verbose "test2"
     $jobs += Start-Job {
@@ -44,6 +45,7 @@ function Invoke-AppVeyorInstall {
             Write-Verbose -Verbose "Installing platyPS via Install-Module"
             Install-Module -Name platyPS -Force -Scope CurrentUser -Repository PSGallery
         }
+        Write-Verbose -Verbose "Installed platyPS"
     }
 
     Write-Verbose -Verbose "test3"
@@ -79,6 +81,7 @@ function Invoke-AppVeyorInstall {
                 [Net.ServicePointManager]::SecurityProtocol = $originalSecurityProtocol
                 Remove-Item .\dotnet-install.*
             }
+            Write-Verbose -Verbose "Installed required .Net CORE SDK"
         }
     }
 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -29,9 +29,7 @@ function Invoke-AppVeyorInstall {
 
     $jobs = @()
 
-    $jobs += Start-Job {
-        if (-not $SkipPesterInstallation.IsPresent) { Install-Pester }
-    }
+    if (-not $SkipPesterInstallation.IsPresent) { $jobs += Start-Job $Function:Install-Pester }
 
     $jobs += Start-Job {
         if ($null -eq (Get-Module -ListAvailable PowershellGet)) {

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -30,8 +30,10 @@ function Invoke-AppVeyorInstall {
     Write-Verbose -Verbose "Bootstrapping build dependencies"
     $jobs = @()
 
+    Write-Verbose -Verbose "test1"
     if (-not $SkipPesterInstallation.IsPresent) { $jobs += Start-Job $Function:Install-Pester }
 
+    Write-Verbose -Verbose "test2"
     $jobs += Start-Job {
         if ($null -eq (Get-Module -ListAvailable PowershellGet)) {
             # WMF 4 image build
@@ -44,6 +46,7 @@ function Invoke-AppVeyorInstall {
         }
     }
 
+    Write-Verbose -Verbose "test3"
     $jobs += Start-Job  {
         # Do not use 'build.ps1 -bootstrap' option for bootstraping the .Net SDK as it does not work well in CI with the AppVeyor Ubuntu image
         Write-Verbose -Verbose "Installing required .Net CORE SDK"


### PR DESCRIPTION
## PR Summary

Most of the time is spent bootstrapping the .NET SDK, meaning the installation of other required PowerShell modules can be done in the background and in parallel. This reduces the build time by around 20 seconds. Due to indentation shift, please use a white-space ignoring diff.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.