### PR TITLE
Replace red-herring warning around process aliasing get-process with warning around invalid syntax

### DIFF
--- a/Rules/AvoidAlias.cs
+++ b/Rules/AvoidAlias.cs
@@ -143,14 +143,27 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     commandType: CommandTypes.Cmdlet | CommandTypes.Function | CommandTypes.Script);
                 if (cmdletNameIfCommandWasMissingGetPrefix != null)
                 {
-                    yield return new DiagnosticRecord(
-                        string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingCmdletAliasesMissingGetPrefixError, commandName, commdNameWithGetPrefix),
-                        GetCommandExtent(cmdAst),
-                        GetName(),
-                        DiagnosticSeverity.Warning,
-                        fileName,
-                        commandName,
-                        suggestedCorrections: GetCorrectionExtent(cmdAst, commdNameWithGetPrefix));
+                    if (commandName.Equals("process", StringComparison.OrdinalIgnoreCase))
+                    {
+                        yield return new DiagnosticRecord(
+                            Strings.InvalidSyntaxAroundProcessBlockError,
+                            GetCommandExtent(cmdAst),
+                            "InvalidSyntaxAroundProcessBlock",
+                            DiagnosticSeverity.ParseError,
+                            fileName,
+                            commandName);
+                    }
+                    else
+                    {
+                        yield return new DiagnosticRecord(
+                            string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingCmdletAliasesMissingGetPrefixError, commandName, commdNameWithGetPrefix),
+                            GetCommandExtent(cmdAst),
+                            GetName(),
+                            DiagnosticSeverity.Warning,
+                            fileName,
+                            commandName,
+                            suggestedCorrections: GetCorrectionExtent(cmdAst, commdNameWithGetPrefix));
+                    }
                 }
 
             }

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -1285,6 +1285,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to When using a process block, only a begin or end block is allowed inside the function but no code..
+        /// </summary>
+        internal static string InvalidSyntaxAroundProcessBlockError {
+            get {
+                return ResourceManager.GetString("InvalidSyntaxAroundProcessBlockError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Misleading Backtick.
         /// </summary>
         internal static string MisleadingBacktickCommonName {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1150,6 +1150,6 @@
     <value>Use single quotes when a string is constant.</value>
   </data>
   <data name="InvalidSyntaxAroundProcessBlockError" xml:space="preserve">
-    <value>When using a process block, only a begin or end block is allowed inside the function but no code.</value>
+    <value>When using an explicit process block, no preceding code is allowed, only begin, end and dynamicparams blocks.</value>
   </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1149,4 +1149,7 @@
   <data name="AvoidUsingDoubleQuotesForConstantStringError" xml:space="preserve">
     <value>Use single quotes when a string is constant.</value>
   </data>
+  <data name="InvalidSyntaxAroundProcessBlockError" xml:space="preserve">
+    <value>When using a process block, only a begin or end block is allowed inside the function but no code.</value>
+  </data>
 </root>

--- a/Tests/Rules/AvoidUsingAlias.tests.ps1
+++ b/Tests/Rules/AvoidUsingAlias.tests.ps1
@@ -117,5 +117,12 @@ Configuration MyDscConfiguration {
 
             $violations.Count | Should -Be $expectedViolations
         }
+
+        It 'Warn about incorrect syntax around process block' {
+            $scriptDefinition = { function foo { IShouldNotBeHere; process {} } }
+            $violations = Invoke-ScriptAnalyzer -IncludeRule PSAvoidUsingCmdletAliases -ScriptDefinition "$scriptDefinition"
+            $violations.Count | Should -Be 1
+            $violations.Severity | Should -Be ([Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.DiagnosticSeverity]::ParseError)
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

Fixes #1402 by not warning around `process` aliasing `get-process` but rather that there is likely invalid syntax around the proces block since it is technically not possible to execute `process` as a command.

It would be better to have a rule of it's own for checking the begin/process/end blocks within a scriptblock but issue #1571 tracks this. This PR fixes the red-herring warning, whilst also giving a better warning to the user in the short term.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.