### PR TITLE
Fix BuildModules tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ PSCompatibilityCollector/out/
 
 # Folder of build module 
 out
+
+# Explicitely Include test dir
+!/Tests/**

--- a/Tests/Build/BuildModule.tests.ps1
+++ b/Tests/Build/BuildModule.tests.ps1
@@ -3,11 +3,11 @@
 
 # these are tests for the build module
 
-import-module -force "./build.psm1"
+import-module -force "$PSScriptRoot\..\..\build.psm1"
 Describe "Build Module Tests" {
     Context "Global.json" {
         BeforeAll {
-            $globalJson = Get-Content (Join-Path $PSScriptRoot global.json) | ConvertFrom-Json
+            $globalJson = Get-Content (Join-Path "$PSScriptRoot\..\..\" global.json) | ConvertFrom-Json
             $expectedVersion = $globalJson.sdk.version
             $result = Get-GlobalJsonSdkVersion
         }
@@ -105,7 +105,7 @@ Describe "Build Module Tests" {
     Context "Test result functions" {
         BeforeAll {
             $xmlFile = @'
-﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <test-results xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="nunit_schema_2.5.xsd" name="Pester" total="2" errors="0" failures="1" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2019-02-19" time="11:36:56">
   <environment platform="Darwin" clr-version="Unknown" os-version="18.2.0" cwd="/Users/jimtru/src/github/forks/JamesWTruher/PSScriptAnalyzer" user="jimtru" user-domain="" machine-name="Jims-Mac-mini.guest.corp.microsoft.com" nunit-version="2.5.8.0" />
   <culture-info current-culture="en-US" current-uiculture="en-US" />
@@ -133,8 +133,8 @@ Describe "Build Module Tests" {
 '@
 
             $xmlFile | out-file TESTDRIVE:/results.xml
-            $results = Get-TestResults -logfile TESTDRIVE:/results.xml
-            $failures = Get-TestFailures -logfile TESTDRIVE:/results.xml
+            $results = @(Get-TestResults -logfile TESTDRIVE:/results.xml)
+            $failures = @(Get-TestFailures -logfile TESTDRIVE:/results.xml)
         }
 
         It "Get-TestResults finds 2 results" {

--- a/build.psm1
+++ b/build.psm1
@@ -378,7 +378,7 @@ function Test-ScriptAnalyzer
             $testModulePath = Join-Path "${projectRoot}" -ChildPath out
         }
         $testResultsFile = "'$(Join-Path ${projectRoot} -childPath TestResults.xml)'"
-        $testScripts = "'${projectRoot}\Tests\Engine','${projectRoot}\Tests\Rules','${projectRoot}\Tests\Documentation'"
+        $testScripts = "'${projectRoot}\Tests\Build','${projectRoot}\Tests\Engine','${projectRoot}\Tests\Rules','${projectRoot}\Tests\Documentation'"
         try {
             if ( $major -lt 5 ) {
                 Rename-Item $script:destinationDir ${testModulePath}


### PR DESCRIPTION
## PR Summary

Fixes #1653  

Fix failing tests in BuildModules.tests.ps1 .
Move the tests into /Build/ in the central tests dir.
Add a reference to include the new folder path when executing all tests.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.