### PR TITLE
Alternative way of obtaining function AST.

### DIFF
--- a/Rules/UseShouldProcessCorrectly.cs
+++ b/Rules/UseShouldProcessCorrectly.cs
@@ -350,7 +350,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         private bool TryGetShouldProcessValueFromAst(FunctionInfo functionInfo, out bool hasShouldProcessSet)
         {
             // Get the body of the function
-            ScriptBlockAst functionBodyAst = (ScriptBlockAst)functionInfo.ScriptBlock.Ast.Find(ast => ast is ScriptBlockAst, searchNestedScriptBlocks: false);
+            ScriptBlockAst functionBodyAst = (ScriptBlockAst)functionInfo.ScriptBlock.Ast.Find(ast => ast is ScriptBlockAst, searchNestedScriptBlocks: true);
 
             // Go through attributes on the parameter block, since this is where [CmdletBinding()] will be
             foreach (AttributeAst attributeAst in functionBodyAst.ParamBlock.Attributes)


### PR DESCRIPTION
## PR Summary

Method `UseShouldProcessCorrectly.TryGetShouldProcessValueFromAst` is trying to obtain function body AST using `Find` with `ScriptBlockAst` filter. Unfortunately `FunctionInfo` exposes only `FunctionDefinitionAst` so the `Find` method fails.
This PR improves this behavior by checking existence of FunctionDefinitionAst first and using old code as a fallback mechanism.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation.
    - Changed code is executed only when an exception is thrown in a "regular" execution path. This exception is hard to trigger in a controller environment. No already created tests were checking the changed code.
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.