### PR TITLE
Fix compatibility rule tests

### DIFF
--- a/Tests/PSScriptAnalyzerTestHelper.psm1
+++ b/Tests/PSScriptAnalyzerTestHelper.psm1
@@ -45,7 +45,8 @@ Function Test-CorrectionExtentFromContent {
         [string] $correctionText
     )
 
-	Import-Module Pester
+	Import-Module Pester -ErrorAction Stop
+
 
 	$corrections = $diagnosticRecord.SuggestedCorrections
 	$corrections.Count | Should -Be $correctionsCount

--- a/Tests/PSScriptAnalyzerTestHelper.psm1
+++ b/Tests/PSScriptAnalyzerTestHelper.psm1
@@ -45,6 +45,8 @@ Function Test-CorrectionExtentFromContent {
         [string] $correctionText
     )
 
+	Import-Module Pester
+
 	$corrections = $diagnosticRecord.SuggestedCorrections
 	$corrections.Count | Should -Be $correctionsCount
 	$corrections[0].Text | Should -Be $correctionText

--- a/Tests/PSScriptAnalyzerTestHelper.psm1
+++ b/Tests/PSScriptAnalyzerTestHelper.psm1
@@ -1,3 +1,5 @@
+$script:SafeShould = (Get-Command -Module Pester -Name Should -ErrorAction Stop)
+
 Function Get-ExtentTextFromContent
 {
 	    Param(
@@ -45,14 +47,12 @@ Function Test-CorrectionExtentFromContent {
         [string] $correctionText
     )
 
-	Import-Module Pester -ErrorAction Stop
-
-
 	$corrections = $diagnosticRecord.SuggestedCorrections
 	$corrections.Count | Should -Be $correctionsCount
 	$corrections[0].Text | Should -Be $correctionText
-	Get-ExtentTextFromContent $corrections[0] $rawContent | `
-		       Should -Be $violationText
+	$extent = Get-ExtentTextFromContent $corrections[0] $rawContent
+
+	& $script:SafeShould -ActualValue $extent -Be $violationText
 }
 
 Function Get-Count

--- a/Tests/Rules/UseCompatibleCommands.Tests.ps1
+++ b/Tests/Rules/UseCompatibleCommands.Tests.ps1
@@ -1,259 +1,261 @@
 ﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-$script:RuleName = 'PSUseCompatibleCommands'
+BeforeAll {
+    $RuleName = 'PSUseCompatibleCommands'
 
-$script:RunningInCIOnUbuntu = $IsLinux -and ($env:TF_BUILD -or $env:APPVEYOR) # some test cases randomly start and stop to fail in Ubuntu CI tests
-$script:TargetProfileConfigKey = 'TargetProfiles'
+    $RunningInCIOnUbuntu = $IsLinux -and ($env:TF_BUILD -or $env:APPVEYOR) # some test cases randomly start and stop to fail in Ubuntu CI tests
+    $TargetProfileConfigKey = 'TargetProfiles'
 
-$script:Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
-$script:Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
-$script:Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
-$script:Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
-$script:Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
-$script:Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-$script:Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
-$script:Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
-$script:Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-$script:Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
-$script:Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
-$script:Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
-$script:Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
+    $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
+    $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
+    $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
+    $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
+    $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
+    $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+    $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
+    $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
+    $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+    $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
+    $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
+    $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
+    $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
 
-$script:AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
-$script:AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
+    $AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
+    $AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
 
-$script:CompatibilityTestCases = @(
-    @{ Target = $script:Srv2012_3_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = '$Protected = "Hello World" | Protect-CmsMessage -To "*youralias@emailaddress.com*"'; Commands = @("Protect-CmsMessage"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-FileHash $pshome\powershell.exe | Format-List'; Commands = @("Get-FileHash"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Save-Help -Module $m -DestinationPath "C:\SavedHelp"'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'gci .'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+    $CompatibilityTestCases = @(
+        @{ Target = $Srv2012_3_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$Protected = "Hello World" | Protect-CmsMessage -To "*youralias@emailaddress.com*"'; Commands = @("Protect-CmsMessage"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-FileHash $pshome\powershell.exe | Format-List'; Commands = @("Get-FileHash"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012_3_profile; Script = 'Save-Help -Module $m -DestinationPath "C:\SavedHelp"'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012_3_profile; Script = 'gci .'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012_3_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
 
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'gci .'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'gci .'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
 
-    @{ Target = $script:Srv2019_5_profile; Script = "Remove-Alias gcm"; Commands = @("Remove-Alias"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_5_profile; Script = "Get-Uptime"; Commands = @("Get-Uptime"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_5_profile; Script = "Remove-Service 'MyService'"; Commands = @("Remove-Service"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'gci .'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'fhx $filePath'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_5_profile; Script = "Remove-Alias gcm"; Commands = @("Remove-Alias"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = "Get-Uptime"; Commands = @("Get-Uptime"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = "Remove-Service 'MyService'"; Commands = @("Remove-Service"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_5_profile; Script = 'gci .'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_5_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_5_profile; Script = 'fhx $filePath'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
 
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @("Out-Printer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Get-Process | Out-GridView"; Commands = @("Out-GridView"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Get-Process | ogv"; Commands = @("ogv"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Show-Command"; Commands = @("Show-Command"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Get-Counter "\Processor(*)\% Processor Time" | Export-Counter -Path $home\Counters.blg'; Commands = @("Get-Counter", "Export-Counter"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'curl $uri'; Commands = @("curl"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2016_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @("Out-Printer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-Process | Out-GridView"; Commands = @("Out-GridView"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-Process | ogv"; Commands = @("ogv"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Show-Command"; Commands = @("Show-Command"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-Counter "\Processor(*)\% Processor Time" | Export-Counter -Path $home\Counters.blg'; Commands = @("Get-Counter", "Export-Counter"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'curl $uri'; Commands = @("curl"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2016_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2019_7_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Get-Process | Out-GridView"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Get-Process | ogv"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Show-Command"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2016_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-Process | Out-GridView"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-Process | ogv"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Show-Command"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2016_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
+        @{ Target = $Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
 
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
 
-    @{ Target = $script:Ubuntu1804_7_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_7_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_7_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_7_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_7_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
-    @{ Target = $script:Ubuntu1804_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
-    @{ Target = $script:Ubuntu1804_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
 
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-)
+        @{ Target = $Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
+        @{ Target = $Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+    )
 
-$script:ParameterCompatibilityTestCases = @(
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '3.0'; OS = 'Windows'; ProblemCount = 2 }
-    @{ Target = $script:Srv2012_3_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'New-JobTrigger -At "1/20/2012 3:00 AM" -RepeatIndefinitely'; Commands = @('New-JobTrigger'); Parameters = @('RepeatIndefinitely'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = '$t = Get-ScheduledJob | Get-JobTrigger | Enable-JobTrigger -PassThru'; Commands = @('Enable-JobTrigger'); Parameters = @('PassThru'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; RequiredVersion = $reqVer }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = $m; MaximumVersion = $maxVer }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-Process -PipelineVariable proc | ForEach-Object { Format-Table $Proc }'; Commands = @('Get-Process'); Parameters = @('PipelineVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = 'Get-Process -IncludeUserName'; Commands = @('Get-Process'); Parameters = @('IncludeUserName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+    $ParameterCompatibilityTestCases = @(
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '3.0'; OS = 'Windows'; ProblemCount = 2 }
+        @{ Target = $Srv2012_3_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'New-JobTrigger -At "1/20/2012 3:00 AM" -RepeatIndefinitely'; Commands = @('New-JobTrigger'); Parameters = @('RepeatIndefinitely'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$t = Get-ScheduledJob | Get-JobTrigger | Enable-JobTrigger -PassThru'; Commands = @('Enable-JobTrigger'); Parameters = @('PassThru'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; RequiredVersion = $reqVer }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = $m; MaximumVersion = $maxVer }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Process -PipelineVariable proc | ForEach-Object { Format-Table $Proc }'; Commands = @('Get-Process'); Parameters = @('PipelineVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Process -IncludeUserName'; Commands = @('Get-Process'); Parameters = @('IncludeUserName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '4.0'; OS = 'Windows'; ProblemCount = 2 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '4.0'; OS = 'Windows'; ProblemCount = 2 }
+        @{ Target = $Srv2012r2_4_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
 
-    @{ Target = $script:Srv2019_5_profile; Script = 'Invoke-RestMethod "https://example.com" -FollowRelLink -MaximumFollowRelLink 10 -CustomMethod "Squash"'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('FollowRelLink', 'MaximumFollowRelLink', 'CustomMethod'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'Invoke-WebRequest "https://microsoft.com" -NoProxy -ContentType "something-strange" -SkipHeaderValidation'; Commands = @('Invoke-WebRequest', 'Invoke-WebRequest'); Parameters = @('NoProxy', 'SkipHeaderValidation'); Version = '5.1'; OS = 'Windows'; ProblemCount = 2 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'Invoke-RestMethod "https://mywebsite.com/auth" -Authentication OAuth -Token $tok -ResponseHeadersVariable resp'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('Authentication', 'Token', 'ResponseHeadersVariable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
-    @{ Target = $script:Srv2019_5_profile; Script = '$obj = ConvertFrom-Json $json -AsHashtable'; Commands = @('ConvertFrom-Json'); Parameters = @('AsHashtable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'Get-ChildItem . -FollowSymLink'; Commands = @('Get-ChildItem'); Parameters = @('FollowSymLink'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'Import-Module "MyModule" -ErrorAction SilentlyContinue'; Commands = @(); Parameters = @(); Version = '5.1'; OS = 'Windows'; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'Get-Location | Split-Path -LeafBase'; Commands = @('Split-Path'); Parameters = @('LeafBase'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'Get-Process | sort PagedMemorySize -Top 10'; Commands = @('sort'); Parameters = @('Top'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_5_profile; Script = 'Get-Process | select -first 1 | Out-String -NoNewline'; Commands = @('Out-String'); Parameters = @('NoNewline'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Invoke-RestMethod "https://example.com" -FollowRelLink -MaximumFollowRelLink 10 -CustomMethod "Squash"'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('FollowRelLink', 'MaximumFollowRelLink', 'CustomMethod'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
+        @{ Target = $Srv2019_5_profile; Script = 'Invoke-WebRequest "https://microsoft.com" -NoProxy -ContentType "something-strange" -SkipHeaderValidation'; Commands = @('Invoke-WebRequest', 'Invoke-WebRequest'); Parameters = @('NoProxy', 'SkipHeaderValidation'); Version = '5.1'; OS = 'Windows'; ProblemCount = 2 }
+        @{ Target = $Srv2019_5_profile; Script = 'Invoke-RestMethod "https://mywebsite.com/auth" -Authentication OAuth -Token $tok -ResponseHeadersVariable resp'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('Authentication', 'Token', 'ResponseHeadersVariable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
+        @{ Target = $Srv2019_5_profile; Script = '$obj = ConvertFrom-Json $json -AsHashtable'; Commands = @('ConvertFrom-Json'); Parameters = @('AsHashtable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Get-ChildItem . -FollowSymLink'; Commands = @('Get-ChildItem'); Parameters = @('FollowSymLink'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Import-Module "MyModule" -ErrorAction SilentlyContinue'; Commands = @(); Parameters = @(); Version = '5.1'; OS = 'Windows'; ProblemCount = 0 }
+        @{ Target = $Srv2019_5_profile; Script = 'Get-Location | Split-Path -LeafBase'; Commands = @('Split-Path'); Parameters = @('LeafBase'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Get-Process | sort PagedMemorySize -Top 10'; Commands = @('sort'); Parameters = @('Top'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Get-Process | select -first 1 | Out-String -NoNewline'; Commands = @('Out-String'); Parameters = @('NoNewline'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @('Get-Help'); Parameters = @('ShowWindow'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @('Get-Help'); Parameters = @('ShowWindow'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2019_7_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @(); Parameters = @(); Version = "7.0"; OS = 'Windows'; ProblemCount = 0 }
-    @{ Target = $script:Srv2019_7_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
-)
+        @{ Target = $Srv2019_7_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @(); Parameters = @(); Version = "7.0"; OS = 'Windows'; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
+    )
+}
 
 
 Describe 'UseCompatibleCommands' {
     Context 'Targeting a single profile' {
-        It "Reports <ProblemCount> command incompatibilties with '<Script>' on <OS> with PowerShell <Version>" -TestCases $script:CompatibilityTestCases -Skip:$script:RunningInCIOnUbuntu {
+        It "Reports <ProblemCount> command incompatibilties with '<Script>' on <OS> with PowerShell <Version>" -TestCases $CompatibilityTestCases -Skip:$RunningInCIOnUbuntu {
             param($Script, [string]$Target, [string[]]$Commands, [version]$Version, [string]$OS, [int]$ProblemCount)
 
             $settings = @{
                 Rules = @{
-                    $script:RuleName = @{
+                    $RuleName = @{
                         Enable = $true
-                        $script:TargetProfileConfigKey = @($Target)
+                        $TargetProfileConfigKey = @($Target)
                     }
                 }
             }
 
-            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $script:RuleName -ScriptDefinition $Script -Settings $settings `
+            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $RuleName -ScriptDefinition $Script -Settings $settings `
                 | Where-Object { -not $_.Parameter } # Filter out diagnostics about incompatible parameters
 
             $diagnostics.Count | Should -Be $ProblemCount -Because ($diagnostics.RuleName -join ', ')
@@ -267,19 +269,19 @@ Describe 'UseCompatibleCommands' {
             }
         }
 
-        It "Reports <ProblemCount> parameter incompatibilties for '<Parameters>' on '<Commands>' with '<Script>' on <OS> with PowerShell <Version>" -TestCases $script:ParameterCompatibilityTestCases -Skip:$script:RunningInCIOnUbuntu {
+        It "Reports <ProblemCount> parameter incompatibilties for '<Parameters>' on '<Commands>' with '<Script>' on <OS> with PowerShell <Version>" -TestCases $ParameterCompatibilityTestCases -Skip:$RunningInCIOnUbuntu {
             param($Script, [string]$Target, [string[]]$Commands, [string[]]$Parameters, [version]$Version, [string]$OS, [int]$ProblemCount)
 
             $settings = @{
                 Rules = @{
-                    $script:RuleName = @{
+                    $RuleName = @{
                         Enable = $true
-                        $script:TargetProfileConfigKey = @($Target)
+                        $TargetProfileConfigKey = @($Target)
                     }
                 }
             }
 
-            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $script:RuleName -ScriptDefinition $Script -Settings $settings `
+            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $RuleName -ScriptDefinition $Script -Settings $settings `
                 | Where-Object { $_.Parameter } # Filter out diagnostics about incompatible parameters
 
             $diagnostics.Count | Should -Be $ProblemCount -Because ($diagnostics.RuleName -join ', ')
@@ -295,25 +297,25 @@ Describe 'UseCompatibleCommands' {
     }
 
     Context "Checking a file against many targets" {
-        It "Finds all command problems" -Skip:$script:RunningInCIOnUbuntu {
+        It "Finds all command problems" -Skip:$RunningInCIOnUbuntu {
             $settings = @{
                 Rules = @{
-                    $script:RuleName = @{
+                    $RuleName = @{
                         Enable = $true
-                        $script:TargetProfileConfigKey = @(
-                            $script:Srv2012_3_profile
-                            $script:Srv2012r2_4_profile
-                            $script:Srv2019_5_profile
-                            $script:Srv2019_6_2_profile
-                            $script:Srv2019_7_profile
-                            $script:Ubuntu1804_6_2_profile
-                            $script:Ubuntu1804_7_profile
+                        $TargetProfileConfigKey = @(
+                            $Srv2012_3_profile
+                            $Srv2012r2_4_profile
+                            $Srv2019_5_profile
+                            $Srv2019_6_2_profile
+                            $Srv2019_7_profile
+                            $Ubuntu1804_6_2_profile
+                            $Ubuntu1804_7_profile
                         )
                     }
                 }
             }
 
-            $diagnostics = Invoke-ScriptAnalyzer -Path "$PSScriptRoot/CompatibilityRuleAssets/IncompatibleScript.ps1" -IncludeRule $script:RuleName -Settings $settings -Severity Information,Warning,Error
+            $diagnostics = Invoke-ScriptAnalyzer -Path "$PSScriptRoot/CompatibilityRuleAssets/IncompatibleScript.ps1" -IncludeRule $RuleName -Settings $settings -Severity Information,Warning,Error
 
             # Classes cause diagnostics to be emitted in PS 3 and 4
             $expectedNumber = 17
@@ -364,21 +366,21 @@ Describe 'UseCompatibleCommands' {
         It "Ensures that PSSA build scripts are cross compatible with everything" {
             $settings = @{
                 Rules = @{
-                    $script:RuleName = @{
+                    $RuleName = @{
                         Enable = $true
-                        $script:TargetProfileConfigKey = @(
-                            $script:Srv2012_3_profile
-                            $script:Srv2012r2_4_profile
-                            $script:Srv2016_5_profile
-                            $script:Srv2016_6_2_profile
-                            $script:Srv2019_5_profile
-                            $script:Srv2019_6_2_profile
-                            $script:Srv2019_7_profile
-                            $script:Win10_5_profile
-                            $script:Win10_6_2_profile
-                            $script:Win10_7_profile
-                            $script:Ubuntu1804_6_2_profile
-                            $script:Ubuntu1804_7_profile
+                        $TargetProfileConfigKey = @(
+                            $Srv2012_3_profile
+                            $Srv2012r2_4_profile
+                            $Srv2016_5_profile
+                            $Srv2016_6_2_profile
+                            $Srv2019_5_profile
+                            $Srv2019_6_2_profile
+                            $Srv2019_7_profile
+                            $Win10_5_profile
+                            $Win10_6_2_profile
+                            $Win10_7_profile
+                            $Ubuntu1804_6_2_profile
+                            $Ubuntu1804_7_profile
                         )
                         IgnoreCommands = @(
                             'Install-Module'
@@ -400,7 +402,7 @@ Describe 'UseCompatibleCommands' {
                 }
             }
 
-            $diagnostics = Invoke-ScriptAnalyzer -Path "$PSScriptRoot/../../" -IncludeRule $script:RuleName -Settings $settings
+            $diagnostics = Invoke-ScriptAnalyzer -Path "$PSScriptRoot/../../" -IncludeRule $RuleName -Settings $settings
             $diagnostics.Count | Should -Be 0 -Because ($diagnostics.Message -join ', ')
         }
     }
@@ -409,12 +411,12 @@ Describe 'UseCompatibleCommands' {
         BeforeAll {
             $settings = @{
                 Rules = @{
-                    $script:RuleName = @{
+                    $RuleName = @{
                         Enable = $true
-                        $script:TargetProfileConfigKey = @(
-                            $script:AzF_profile
-                            $script:AzA_profile
-                            $script:Win10_5_profile
+                        $TargetProfileConfigKey = @(
+                            $AzF_profile
+                            $AzA_profile
+                            $Win10_5_profile
                         )
                     }
                 }
@@ -422,7 +424,7 @@ Describe 'UseCompatibleCommands' {
         }
 
         It "Finds AzF problems with a script" {
-            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $script:RuleName -Settings $settings -ScriptDefinition '
+            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $RuleName -Settings $settings -ScriptDefinition '
                 Get-WmiObject Win32_Process
                 New-SelfSignedCertificate
                 Invoke-MySpecialFunction

--- a/Tests/Rules/UseCompatibleCommands.Tests.ps1
+++ b/Tests/Rules/UseCompatibleCommands.Tests.ps1
@@ -1,247 +1,246 @@
 ﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-BeforeAll {
-    $RuleName = 'PSUseCompatibleCommands'
-
-    $RunningInCIOnUbuntu = $IsLinux -and ($env:TF_BUILD -or $env:APPVEYOR) # some test cases randomly start and stop to fail in Ubuntu CI tests
-    $TargetProfileConfigKey = 'TargetProfiles'
-
-    $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
-    $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
-    $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
-    $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
-    $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
-    $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-    $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
-    $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
-    $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-    $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
-    $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
-    $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
-    $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
-
-    $AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
-    $AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
-
-    $CompatibilityTestCases = @(
-        @{ Target = $Srv2012_3_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = '$Protected = "Hello World" | Protect-CmsMessage -To "*youralias@emailaddress.com*"'; Commands = @("Protect-CmsMessage"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Get-FileHash $pshome\powershell.exe | Format-List'; Commands = @("Get-FileHash"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2012_3_profile; Script = 'Save-Help -Module $m -DestinationPath "C:\SavedHelp"'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2012_3_profile; Script = 'gci .'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2012_3_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-
-        @{ Target = $Srv2012r2_4_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'gci .'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
-
-        @{ Target = $Srv2019_5_profile; Script = "Remove-Alias gcm"; Commands = @("Remove-Alias"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_5_profile; Script = "Get-Uptime"; Commands = @("Get-Uptime"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_5_profile; Script = "Remove-Service 'MyService'"; Commands = @("Remove-Service"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_5_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_5_profile; Script = 'gci .'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_5_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_5_profile; Script = 'fhx $filePath'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
-
-        @{ Target = $Srv2019_6_2_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @("Out-Printer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Get-Process | Out-GridView"; Commands = @("Out-GridView"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Get-Process | ogv"; Commands = @("ogv"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Show-Command"; Commands = @("Show-Command"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Get-Counter "\Processor(*)\% Processor Time" | Export-Counter -Path $home\Counters.blg'; Commands = @("Get-Counter", "Export-Counter"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'curl $uri'; Commands = @("curl"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2016_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-
-        @{ Target = $Srv2019_7_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = "Get-Process | Out-GridView"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = "Get-Process | ogv"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = "Show-Command"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2016_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
-        @{ Target = $Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-
-        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
-        @{ Target = $Ubuntu1804_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
-        @{ Target = $Ubuntu1804_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
-
-        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_7_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
-        @{ Target = $Ubuntu1804_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
-        @{ Target = $Ubuntu1804_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
-
-        @{ Target = $Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-
-        @{ Target = $Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
-        @{ Target = $Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        @{ Target = $Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-    )
-
-    $ParameterCompatibilityTestCases = @(
-        @{ Target = $Srv2012_3_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '3.0'; OS = 'Windows'; ProblemCount = 2 }
-        @{ Target = $Srv2012_3_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'New-JobTrigger -At "1/20/2012 3:00 AM" -RepeatIndefinitely'; Commands = @('New-JobTrigger'); Parameters = @('RepeatIndefinitely'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = '$t = Get-ScheduledJob | Get-JobTrigger | Enable-JobTrigger -PassThru'; Commands = @('Enable-JobTrigger'); Parameters = @('PassThru'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; RequiredVersion = $reqVer }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = $m; MaximumVersion = $maxVer }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Get-Process -PipelineVariable proc | ForEach-Object { Format-Table $Proc }'; Commands = @('Get-Process'); Parameters = @('PipelineVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = 'Get-Process -IncludeUserName'; Commands = @('Get-Process'); Parameters = @('IncludeUserName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '4.0'; OS = 'Windows'; ProblemCount = 2 }
-        @{ Target = $Srv2012r2_4_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
-        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
-
-        @{ Target = $Srv2019_5_profile; Script = 'Invoke-RestMethod "https://example.com" -FollowRelLink -MaximumFollowRelLink 10 -CustomMethod "Squash"'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('FollowRelLink', 'MaximumFollowRelLink', 'CustomMethod'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
-        @{ Target = $Srv2019_5_profile; Script = 'Invoke-WebRequest "https://microsoft.com" -NoProxy -ContentType "something-strange" -SkipHeaderValidation'; Commands = @('Invoke-WebRequest', 'Invoke-WebRequest'); Parameters = @('NoProxy', 'SkipHeaderValidation'); Version = '5.1'; OS = 'Windows'; ProblemCount = 2 }
-        @{ Target = $Srv2019_5_profile; Script = 'Invoke-RestMethod "https://mywebsite.com/auth" -Authentication OAuth -Token $tok -ResponseHeadersVariable resp'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('Authentication', 'Token', 'ResponseHeadersVariable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
-        @{ Target = $Srv2019_5_profile; Script = '$obj = ConvertFrom-Json $json -AsHashtable'; Commands = @('ConvertFrom-Json'); Parameters = @('AsHashtable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2019_5_profile; Script = 'Get-ChildItem . -FollowSymLink'; Commands = @('Get-ChildItem'); Parameters = @('FollowSymLink'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2019_5_profile; Script = 'Import-Module "MyModule" -ErrorAction SilentlyContinue'; Commands = @(); Parameters = @(); Version = '5.1'; OS = 'Windows'; ProblemCount = 0 }
-        @{ Target = $Srv2019_5_profile; Script = 'Get-Location | Split-Path -LeafBase'; Commands = @('Split-Path'); Parameters = @('LeafBase'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2019_5_profile; Script = 'Get-Process | sort PagedMemorySize -Top 10'; Commands = @('sort'); Parameters = @('Top'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2019_5_profile; Script = 'Get-Process | select -first 1 | Out-String -NoNewline'; Commands = @('Out-String'); Parameters = @('NoNewline'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Srv2019_6_2_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @('Get-Help'); Parameters = @('ShowWindow'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2019_6_2_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Srv2019_7_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @(); Parameters = @(); Version = "7.0"; OS = 'Windows'; ProblemCount = 0 }
-        @{ Target = $Srv2019_7_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
-    )
-}
-
-
 Describe 'UseCompatibleCommands' {
+    BeforeAll {
+        $RuleName = 'PSUseCompatibleCommands'
+
+        $RunningInCIOnUbuntu = $IsLinux -and ($env:TF_BUILD -or $env:APPVEYOR) # some test cases randomly start and stop to fail in Ubuntu CI tests
+        $TargetProfileConfigKey = 'TargetProfiles'
+
+        $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
+        $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
+        $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
+        $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
+        $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
+        $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+        $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
+        $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
+        $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+        $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
+        $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
+        $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
+        $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
+
+        $AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
+        $AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
+
+        $CompatibilityTestCases = @(
+            @{ Target = $Srv2012_3_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = '$Protected = "Hello World" | Protect-CmsMessage -To "*youralias@emailaddress.com*"'; Commands = @("Protect-CmsMessage"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Get-FileHash $pshome\powershell.exe | Format-List'; Commands = @("Get-FileHash"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2012_3_profile; Script = 'Save-Help -Module $m -DestinationPath "C:\SavedHelp"'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2012_3_profile; Script = 'gci .'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2012_3_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+
+            @{ Target = $Srv2012r2_4_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'gci .'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
+
+            @{ Target = $Srv2019_5_profile; Script = "Remove-Alias gcm"; Commands = @("Remove-Alias"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_5_profile; Script = "Get-Uptime"; Commands = @("Get-Uptime"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_5_profile; Script = "Remove-Service 'MyService'"; Commands = @("Remove-Service"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_5_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_5_profile; Script = 'gci .'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_5_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_5_profile; Script = 'fhx $filePath'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+
+            @{ Target = $Srv2019_6_2_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @("Out-Printer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Get-Process | Out-GridView"; Commands = @("Out-GridView"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Get-Process | ogv"; Commands = @("ogv"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Show-Command"; Commands = @("Show-Command"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Get-Counter "\Processor(*)\% Processor Time" | Export-Counter -Path $home\Counters.blg'; Commands = @("Get-Counter", "Export-Counter"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'curl $uri'; Commands = @("curl"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2016_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+
+            @{ Target = $Srv2019_7_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = "Get-Process | Out-GridView"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = "Get-Process | ogv"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = "Show-Command"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2016_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
+            @{ Target = $Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+
+            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
+            @{ Target = $Ubuntu1804_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
+            @{ Target = $Ubuntu1804_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
+
+            @{ Target = $Ubuntu1804_7_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_7_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_7_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_7_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_7_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
+            @{ Target = $Ubuntu1804_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
+            @{ Target = $Ubuntu1804_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
+
+            @{ Target = $Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+
+            @{ Target = $Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
+            @{ Target = $Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+            @{ Target = $Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        )
+
+        $ParameterCompatibilityTestCases = @(
+            @{ Target = $Srv2012_3_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '3.0'; OS = 'Windows'; ProblemCount = 2 }
+            @{ Target = $Srv2012_3_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'New-JobTrigger -At "1/20/2012 3:00 AM" -RepeatIndefinitely'; Commands = @('New-JobTrigger'); Parameters = @('RepeatIndefinitely'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = '$t = Get-ScheduledJob | Get-JobTrigger | Enable-JobTrigger -PassThru'; Commands = @('Enable-JobTrigger'); Parameters = @('PassThru'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; RequiredVersion = $reqVer }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = $m; MaximumVersion = $maxVer }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Get-Process -PipelineVariable proc | ForEach-Object { Format-Table $Proc }'; Commands = @('Get-Process'); Parameters = @('PipelineVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = 'Get-Process -IncludeUserName'; Commands = @('Get-Process'); Parameters = @('IncludeUserName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Srv2012r2_4_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '4.0'; OS = 'Windows'; ProblemCount = 2 }
+            @{ Target = $Srv2012r2_4_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
+            @{ Target = $Srv2012r2_4_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
+
+            @{ Target = $Srv2019_5_profile; Script = 'Invoke-RestMethod "https://example.com" -FollowRelLink -MaximumFollowRelLink 10 -CustomMethod "Squash"'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('FollowRelLink', 'MaximumFollowRelLink', 'CustomMethod'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
+            @{ Target = $Srv2019_5_profile; Script = 'Invoke-WebRequest "https://microsoft.com" -NoProxy -ContentType "something-strange" -SkipHeaderValidation'; Commands = @('Invoke-WebRequest', 'Invoke-WebRequest'); Parameters = @('NoProxy', 'SkipHeaderValidation'); Version = '5.1'; OS = 'Windows'; ProblemCount = 2 }
+            @{ Target = $Srv2019_5_profile; Script = 'Invoke-RestMethod "https://mywebsite.com/auth" -Authentication OAuth -Token $tok -ResponseHeadersVariable resp'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('Authentication', 'Token', 'ResponseHeadersVariable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
+            @{ Target = $Srv2019_5_profile; Script = '$obj = ConvertFrom-Json $json -AsHashtable'; Commands = @('ConvertFrom-Json'); Parameters = @('AsHashtable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2019_5_profile; Script = 'Get-ChildItem . -FollowSymLink'; Commands = @('Get-ChildItem'); Parameters = @('FollowSymLink'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2019_5_profile; Script = 'Import-Module "MyModule" -ErrorAction SilentlyContinue'; Commands = @(); Parameters = @(); Version = '5.1'; OS = 'Windows'; ProblemCount = 0 }
+            @{ Target = $Srv2019_5_profile; Script = 'Get-Location | Split-Path -LeafBase'; Commands = @('Split-Path'); Parameters = @('LeafBase'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2019_5_profile; Script = 'Get-Process | sort PagedMemorySize -Top 10'; Commands = @('sort'); Parameters = @('Top'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2019_5_profile; Script = 'Get-Process | select -first 1 | Out-String -NoNewline'; Commands = @('Out-String'); Parameters = @('NoNewline'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Srv2019_6_2_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @('Get-Help'); Parameters = @('ShowWindow'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2019_6_2_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Srv2019_7_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @(); Parameters = @(); Version = "7.0"; OS = 'Windows'; ProblemCount = 0 }
+            @{ Target = $Srv2019_7_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
+        )
+    }
+
     Context 'Targeting a single profile' {
         It "Reports <ProblemCount> command incompatibilties with '<Script>' on <OS> with PowerShell <Version>" -TestCases $CompatibilityTestCases -Skip:$RunningInCIOnUbuntu {
             param($Script, [string]$Target, [string[]]$Commands, [version]$Version, [string]$OS, [int]$ProblemCount)

--- a/Tests/Rules/UseCompatibleCommands.Tests.ps1
+++ b/Tests/Rules/UseCompatibleCommands.Tests.ps1
@@ -1,244 +1,248 @@
 ﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+BeforeDiscovery {
+    $RunningInCIOnUbuntu = $IsLinux -and ($env:TF_BUILD -or $env:APPVEYOR) # some test cases randomly start and stop to fail in Ubuntu CI tests
+
+    $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
+    $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
+    $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
+    $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
+    $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
+    $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+    $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
+    $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
+    $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+    $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
+    $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
+    $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
+    $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
+
+    $CompatibilityTestCases = @(
+        @{ Target = $Srv2012_3_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$Protected = "Hello World" | Protect-CmsMessage -To "*youralias@emailaddress.com*"'; Commands = @("Protect-CmsMessage"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-FileHash $pshome\powershell.exe | Format-List'; Commands = @("Get-FileHash"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012_3_profile; Script = 'Save-Help -Module $m -DestinationPath "C:\SavedHelp"'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012_3_profile; Script = 'gci .'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012_3_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+
+        @{ Target = $Srv2012r2_4_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'gci .'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
+
+        @{ Target = $Srv2019_5_profile; Script = "Remove-Alias gcm"; Commands = @("Remove-Alias"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = "Get-Uptime"; Commands = @("Get-Uptime"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = "Remove-Service 'MyService'"; Commands = @("Remove-Service"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_5_profile; Script = 'gci .'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_5_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_5_profile; Script = 'fhx $filePath'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
+
+        @{ Target = $Srv2019_6_2_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @("Out-Printer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-Process | Out-GridView"; Commands = @("Out-GridView"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-Process | ogv"; Commands = @("ogv"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Show-Command"; Commands = @("Show-Command"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-Counter "\Processor(*)\% Processor Time" | Export-Counter -Path $home\Counters.blg'; Commands = @("Get-Counter", "Export-Counter"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'curl $uri'; Commands = @("curl"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2016_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+
+        @{ Target = $Srv2019_7_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-Process | Out-GridView"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-Process | ogv"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Show-Command"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2016_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
+        @{ Target = $Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
+
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
+        @{ Target = $Ubuntu1804_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
+
+        @{ Target = $Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
+
+        @{ Target = $Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
+        @{ Target = $Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
+    )
+
+    $ParameterCompatibilityTestCases = @(
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '3.0'; OS = 'Windows'; ProblemCount = 2 }
+        @{ Target = $Srv2012_3_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'New-JobTrigger -At "1/20/2012 3:00 AM" -RepeatIndefinitely'; Commands = @('New-JobTrigger'); Parameters = @('RepeatIndefinitely'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$t = Get-ScheduledJob | Get-JobTrigger | Enable-JobTrigger -PassThru'; Commands = @('Enable-JobTrigger'); Parameters = @('PassThru'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; RequiredVersion = $reqVer }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = $m; MaximumVersion = $maxVer }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Process -PipelineVariable proc | ForEach-Object { Format-Table $Proc }'; Commands = @('Get-Process'); Parameters = @('PipelineVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = 'Get-Process -IncludeUserName'; Commands = @('Get-Process'); Parameters = @('IncludeUserName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '4.0'; OS = 'Windows'; ProblemCount = 2 }
+        @{ Target = $Srv2012r2_4_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
+
+        @{ Target = $Srv2019_5_profile; Script = 'Invoke-RestMethod "https://example.com" -FollowRelLink -MaximumFollowRelLink 10 -CustomMethod "Squash"'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('FollowRelLink', 'MaximumFollowRelLink', 'CustomMethod'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
+        @{ Target = $Srv2019_5_profile; Script = 'Invoke-WebRequest "https://microsoft.com" -NoProxy -ContentType "something-strange" -SkipHeaderValidation'; Commands = @('Invoke-WebRequest', 'Invoke-WebRequest'); Parameters = @('NoProxy', 'SkipHeaderValidation'); Version = '5.1'; OS = 'Windows'; ProblemCount = 2 }
+        @{ Target = $Srv2019_5_profile; Script = 'Invoke-RestMethod "https://mywebsite.com/auth" -Authentication OAuth -Token $tok -ResponseHeadersVariable resp'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('Authentication', 'Token', 'ResponseHeadersVariable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
+        @{ Target = $Srv2019_5_profile; Script = '$obj = ConvertFrom-Json $json -AsHashtable'; Commands = @('ConvertFrom-Json'); Parameters = @('AsHashtable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Get-ChildItem . -FollowSymLink'; Commands = @('Get-ChildItem'); Parameters = @('FollowSymLink'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Import-Module "MyModule" -ErrorAction SilentlyContinue'; Commands = @(); Parameters = @(); Version = '5.1'; OS = 'Windows'; ProblemCount = 0 }
+        @{ Target = $Srv2019_5_profile; Script = 'Get-Location | Split-Path -LeafBase'; Commands = @('Split-Path'); Parameters = @('LeafBase'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Get-Process | sort PagedMemorySize -Top 10'; Commands = @('sort'); Parameters = @('Top'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = 'Get-Process | select -first 1 | Out-String -NoNewline'; Commands = @('Out-String'); Parameters = @('NoNewline'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Srv2019_6_2_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @('Get-Help'); Parameters = @('ShowWindow'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Srv2019_7_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @(); Parameters = @(); Version = "7.0"; OS = 'Windows'; ProblemCount = 0 }
+        @{ Target = $Srv2019_7_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
+    )
+}
+
 Describe 'UseCompatibleCommands' {
     BeforeAll {
         $RuleName = 'PSUseCompatibleCommands'
 
-        $RunningInCIOnUbuntu = $IsLinux -and ($env:TF_BUILD -or $env:APPVEYOR) # some test cases randomly start and stop to fail in Ubuntu CI tests
-        $TargetProfileConfigKey = 'TargetProfiles'
-
-        $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
-        $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
-        $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
-        $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
-        $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
-        $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-        $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
-        $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
-        $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-        $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
-        $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
-        $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
-        $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
-
         $AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
         $AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
 
-        $CompatibilityTestCases = @(
-            @{ Target = $Srv2012_3_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = '$Protected = "Hello World" | Protect-CmsMessage -To "*youralias@emailaddress.com*"'; Commands = @("Protect-CmsMessage"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Get-FileHash $pshome\powershell.exe | Format-List'; Commands = @("Get-FileHash"); Version = "3.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2012_3_profile; Script = 'Save-Help -Module $m -DestinationPath "C:\SavedHelp"'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2012_3_profile; Script = 'gci .'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2012_3_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
+        $TargetProfileConfigKey = 'TargetProfiles'
 
-            @{ Target = $Srv2012r2_4_profile; Script = 'Write-Information "Information"'; Commands = @("Write-Information"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = '"Hello World" | ConvertFrom-String | Get-Member'; Commands = @("ConvertFrom-String"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Compress-Archive -LiteralPath C:\Reference\Draftdoc.docx, C:\Reference\Images\diagram2.vsd -CompressionLevel Optimal -DestinationPath C:\Archives\Draft.Zip'; Commands = @("Compress-Archive"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Get-Runspace -Id 2'; Commands = @("Get-Runspace"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Format-Hex -Path "C:\temp\temp.t7f"'; Commands = @("Format-Hex"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Clear-RecycleBin -Force'; Commands = @("Clear-RecycleBin"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = '$TempFile = New-TemporaryFile'; Commands = @("New-TemporaryFile"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'New-Guid | Out-String'; Commands = @("New-Guid"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Enter-PSHostProcess -Name powershell_ise'; Commands = @("Enter-PSHostProcess"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Wait-Debugger'; Commands = @("Wait-Debugger"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Start-Job { Write-Host "Hello" } | Debug-Job'; Commands = @("Debug-Job"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Get-ItemPropertyValue -Path HKLM:\SOFTWARE\Microsoft\PowerShell\3\PowerShellEngine -Name ApplicationBase'; Commands = @("Get-ItemPropertyValue"); Version = "4.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'gci .'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "4.0"; OS = "Windows"; ProblemCount = 0 }
-
-            @{ Target = $Srv2019_5_profile; Script = "Remove-Alias gcm"; Commands = @("Remove-Alias"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_5_profile; Script = "Get-Uptime"; Commands = @("Get-Uptime"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_5_profile; Script = "Remove-Service 'MyService'"; Commands = @("Remove-Service"); Version = "5.1"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_5_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_5_profile; Script = 'gci .'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_5_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_5_profile; Script = 'fhx $filePath'; Commands = @(); Version = "5.1"; OS = "Windows"; ProblemCount = 0 }
-
-            @{ Target = $Srv2019_6_2_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @("Out-Printer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Get-Process | Out-GridView"; Commands = @("Out-GridView"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Get-Process | ogv"; Commands = @("ogv"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Show-Command"; Commands = @("Show-Command"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Get-Counter "\Processor(*)\% Processor Time" | Export-Counter -Path $home\Counters.blg'; Commands = @("Get-Counter", "Export-Counter"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'curl $uri'; Commands = @("curl"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "3.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2016_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-
-            @{ Target = $Srv2019_7_profile; Script = "Add-PSSnapIn MySnapIn"; Commands = @("Add-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = "Get-PSSnapIn MySnapIn"; Commands = @("Get-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = "Get-Content $pshome\about_signing.help.txt | Out-Printer"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = 'New-PSWorkflowSession -ComputerName "ServerNode01" -Name "WorkflowTests" -SessionOption (New-PSSessionOption -OutputBufferingMode Drop)'; Commands = @("New-PSWorkflowSession"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = "Get-Process | Out-GridView"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = "Get-Process | ogv"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = "Remove-PSSnapIn MySnapIn"; Commands = @("Remove-PSSnapIn"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = "Show-Command"; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = '$composers | Convert-String -Example "first middle last=last, first"'; Commands = @("Convert-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Export-Console -Path $pshome\Consoles\ConsoleS1.psc1'; Commands = @("Export-Console"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2016_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
-            @{ Target = $Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-
-            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "6.2"; OS = "Linux"; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_6_2_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
-            @{ Target = $Ubuntu1804_6_2_profile; Script = 'gci .'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
-            @{ Target = $Ubuntu1804_6_2_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "6.2"; OS = "Linux"; ProblemCount = 0 }
-
-            @{ Target = $Ubuntu1804_7_profile; Script = 'Get-AuthenticodeSignature ./script.ps1'; Commands = @("Get-AuthenticodeSignature"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_7_profile; Script = 'Get-Service systemd'; Commands = @("Get-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_7_profile; Script = 'Start-Service -Name "sshd"'; Commands = @("Start-Service"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_7_profile; Script = 'Get-PSSessionConfiguration -Name Full  | Format-List -Property *'; Commands = @("Get-PSSessionConfiguration"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_7_profile; Script = 'Get-CimInstance Win32_StartupCommand'; Commands = @("Get-CimInstance"); Version = "7.0"; OS = "Linux"; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_7_profile; Script = 'Get-ChildItem ./ | Format-List'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
-            @{ Target = $Ubuntu1804_7_profile; Script = 'gci .'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
-            @{ Target = $Ubuntu1804_7_profile; Script = 'iex $expr | % { Transform $_ }'; Commands = @(); Version = "7.0"; OS = "Linux"; ProblemCount = 0 }
-
-            @{ Target = $Srv2019_6_2_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @("Set-Clipboard"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Clear-RecycleBin'; Commands = @("Clear-RecycleBin"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "6.2"; OS = "Windows"; ProblemCount = 2 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @("Get-HotFix"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "6.2"; OS = "Windows"; ProblemCount = 1 }
-
-            @{ Target = $Srv2019_7_profile; Script = 'ConvertFrom-String $str'; Commands = @("ConvertFrom-String"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = "Get-WmiObject -Class Win32_Process"; Commands = @("Get-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = "Invoke-WmiMethod -Path win32_process -Name create -ArgumentList notepad.exe"; Commands = @("Invoke-WmiMethod"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = '$np | Remove-WmiObject'; Commands = @("Remove-WmiObject"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Set-Clipboard -Value "This is a test string"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = "Set-WmiInstance -Class Win32_WMISetting -Argument @{LoggingLevel=2}"; Commands = @("Set-WmiInstance"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Add-Computer -DomainName "Domain01" -Restart'; Commands = @("Add-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Checkpoint-Computer -Description "Install MyApp"'; Commands = @("Checkpoint-Computer"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Clear-EventLog "Windows PowerShell"'; Commands = @("Clear-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Clear-RecycleBin'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = 'Start-Transaction; New-Item MyCompany -UseTransaction; Complete-Transaction'; Commands = @("Start-Transaction", "Complete-Transaction"); Version = "7.0"; OS = "Windows"; ProblemCount = 2 }
-            @{ Target = $Srv2019_7_profile; Script = 'Disable-ComputerRestore -Drive "C:\"'; Commands = @("Disable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Enable-ComputerRestore -Drive "C:\", "D:\"'; Commands = @("Enable-ComputerRestore"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Get-ControlPanelItem -Name "*Program*", "*App*"'; Commands = @("Get-ControlPanelItem"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Get-EventLog -Newest 5 -LogName "Application"'; Commands = @("Get-EventLog"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-            @{ Target = $Srv2019_7_profile; Script = 'Get-HotFix -Description "Security*" -ComputerName "Server01", "Server02" -Cred "Server01\admin01"'; Commands = @(); Version = "7.0"; OS = "Windows"; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = '$zip = New-WebServiceProxy -Uri "http://www.webservicex.net/uszip.asmx?WSDL"'; Commands = @("New-WebServiceProxy"); Version = "7.0"; OS = "Windows"; ProblemCount = 1 }
-        )
-
-        $ParameterCompatibilityTestCases = @(
-            @{ Target = $Srv2012_3_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '3.0'; OS = 'Windows'; ProblemCount = 2 }
-            @{ Target = $Srv2012_3_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'New-JobTrigger -At "1/20/2012 3:00 AM" -RepeatIndefinitely'; Commands = @('New-JobTrigger'); Parameters = @('RepeatIndefinitely'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = '$t = Get-ScheduledJob | Get-JobTrigger | Enable-JobTrigger -PassThru'; Commands = @('Enable-JobTrigger'); Parameters = @('PassThru'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; RequiredVersion = $reqVer }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = $m; MaximumVersion = $maxVer }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Get-Process -PipelineVariable proc | ForEach-Object { Format-Table $Proc }'; Commands = @('Get-Process'); Parameters = @('PipelineVariable'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = 'Get-Process -IncludeUserName'; Commands = @('Get-Process'); Parameters = @('IncludeUserName'); Version = '3.0'; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Srv2012r2_4_profile; Script = 'Get-Item -Path ./ -InformationVariable i'; Commands = @('Get-Item'); Parameters = @('InformationVariable'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Get-ChildItem -Path ./ -Recurse -Depth 3'; Commands = @('Get-ChildItem'); Parameters = @('Depth'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Copy-Item -Path C:\myFile.txt -ToSession $s -DestinationFolder d:\destinationFolder'; Commands = @('Copy-Item', 'Copy-Item'); Parameters = @('ToSession', 'DestinationFolder'); Version = '4.0'; OS = 'Windows'; ProblemCount = 2 }
-            @{ Target = $Srv2012r2_4_profile; Script = '"File content" | Out-File ./file.txt -NoNewline'; Commands = @('Out-File'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Set-Content "Hi" -Path C:/path/to/thing.ps1 -NoNewline'; Commands = @('Set-Content'); Parameters = @('NoNewline'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Get-Command -ShowCommandInfo'; Commands = @('Get-Command'); Parameters = @('ShowCommandInfo'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Import-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Import-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Remove-Module -FullyQualifiedName @{ ModuleName = "PSScriptAnalyzer"; ModuleVersion = "1.17" }'; Commands = @('Remove-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Save-Help -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Save-Help'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Export-PSSession -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Export-PSSession'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Get-Command -FullyQualifiedModule @{ ModuleName = "MyModule"; MaximumVersion = "2.7" }'; Commands = @('Get-Command'); Parameters = @('FullyQualifiedModule'); Version = '4.0'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Register-ScheduledJob -RunNow -Trigger $t'; Commands = @('Register-ScheduledJob'); Parameters = @('RunNow'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
-            @{ Target = $Srv2012r2_4_profile; Script = 'Get-Module -FullyQualifiedName @{ ModuleName = $m; ModuleVersion = $v }'; Commands = @('Get-Module'); Parameters = @('FullyQualifiedName'); Version = '4.0'; OS = 'Windows'; ProblemCount = 0 }
-
-            @{ Target = $Srv2019_5_profile; Script = 'Invoke-RestMethod "https://example.com" -FollowRelLink -MaximumFollowRelLink 10 -CustomMethod "Squash"'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('FollowRelLink', 'MaximumFollowRelLink', 'CustomMethod'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
-            @{ Target = $Srv2019_5_profile; Script = 'Invoke-WebRequest "https://microsoft.com" -NoProxy -ContentType "something-strange" -SkipHeaderValidation'; Commands = @('Invoke-WebRequest', 'Invoke-WebRequest'); Parameters = @('NoProxy', 'SkipHeaderValidation'); Version = '5.1'; OS = 'Windows'; ProblemCount = 2 }
-            @{ Target = $Srv2019_5_profile; Script = 'Invoke-RestMethod "https://mywebsite.com/auth" -Authentication OAuth -Token $tok -ResponseHeadersVariable resp'; Commands = @('Invoke-RestMethod', 'Invoke-RestMethod', 'Invoke-RestMethod'); Parameters = @('Authentication', 'Token', 'ResponseHeadersVariable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 3 }
-            @{ Target = $Srv2019_5_profile; Script = '$obj = ConvertFrom-Json $json -AsHashtable'; Commands = @('ConvertFrom-Json'); Parameters = @('AsHashtable'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2019_5_profile; Script = 'Get-ChildItem . -FollowSymLink'; Commands = @('Get-ChildItem'); Parameters = @('FollowSymLink'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2019_5_profile; Script = 'Import-Module "MyModule" -ErrorAction SilentlyContinue'; Commands = @(); Parameters = @(); Version = '5.1'; OS = 'Windows'; ProblemCount = 0 }
-            @{ Target = $Srv2019_5_profile; Script = 'Get-Location | Split-Path -LeafBase'; Commands = @('Split-Path'); Parameters = @('LeafBase'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2019_5_profile; Script = 'Get-Process | sort PagedMemorySize -Top 10'; Commands = @('sort'); Parameters = @('Top'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2019_5_profile; Script = 'Get-Process | select -first 1 | Out-String -NoNewline'; Commands = @('Out-String'); Parameters = @('NoNewline'); Version = '5.1'; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Srv2019_6_2_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @('Get-Help'); Parameters = @('ShowWindow'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2019_6_2_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Srv2019_7_profile; Script = 'Get-Help "Invoke-WebRequest" -ShowWindow'; Commands = @(); Parameters = @(); Version = "7.0"; OS = 'Windows'; ProblemCount = 0 }
-            @{ Target = $Srv2019_7_profile; Script = 'Start-Service "eventlog" -ComputerName "MyComputer"'; Commands = @('Start-Service'); Parameters = @('ComputerName'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
-        )
     }
 
     Context 'Targeting a single profile' {

--- a/Tests/Rules/UseCompatibleCommands.Tests.ps1
+++ b/Tests/Rules/UseCompatibleCommands.Tests.ps1
@@ -1,9 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-BeforeAll {
-    $script:RuleName = 'PSUseCompatibleCommands'
-}
+$script:RuleName = 'PSUseCompatibleCommands'
 
 $script:RunningInCIOnUbuntu = $IsLinux -and ($env:TF_BUILD -or $env:APPVEYOR) # some test cases randomly start and stop to fail in Ubuntu CI tests
 $script:TargetProfileConfigKey = 'TargetProfiles'

--- a/Tests/Rules/UseCompatibleCommands.Tests.ps1
+++ b/Tests/Rules/UseCompatibleCommands.Tests.ps1
@@ -238,6 +238,20 @@ Describe 'UseCompatibleCommands' {
     BeforeAll {
         $RuleName = 'PSUseCompatibleCommands'
 
+        $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
+        $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
+        $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
+        $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
+        $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
+        $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+        $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
+        $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
+        $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+        $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
+        $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
+        $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
+        $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
+
         $AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
         $AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
 

--- a/Tests/Rules/UseCompatibleSyntax.Tests.ps1
+++ b/Tests/Rules/UseCompatibleSyntax.Tests.ps1
@@ -1,58 +1,59 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-$script:RuleName = 'PSUseCompatibleSyntax'
+BeforeAll {
+    $RuleName = 'PSUseCompatibleSyntax'
 
-$testCases = @(
-    @{ Script = '$x = [MyClass]::new()'; Versions = @(3,4) }
-    @{ Script = '$member = "Hi"; $x.$member'; Versions = @() }
-    @{ Script = 'Write-Host "Banana"'; Versions = @() }
-    @{ Script = '[System.VeryInnocuousType]::RunApiMethod($obj)'; Versions = @() }
-    @{ Script = '$y.$methodWithAVeryLongName()'; Versions = @(3) }
-    @{ Script = '$typeExpression::$staticMember'; Versions = @() }
-    @{ Script = '$typeExpression::$dynamicStaticMethodName()'; Versions = @(3) }
-)
-# PS v3/4 won't parse classes or enums
-if ($PSVersionTable.PSVersion.Major -ge 5)
-{
-    $testCases += @(
-        @{ Script = "class MyClass { }"; Versions = @(3,4) }
-        @{ Script = "enum MyEnum { One; Two }"; Versions = @(3,4) }
+    $testCases = @(
+        @{ Script = '$x = [MyClass]::new()'; Versions = @(3,4) }
+        @{ Script = '$member = "Hi"; $x.$member'; Versions = @() }
+        @{ Script = 'Write-Host "Banana"'; Versions = @() }
+        @{ Script = '[System.VeryInnocuousType]::RunApiMethod($obj)'; Versions = @() }
+        @{ Script = '$y.$methodWithAVeryLongName()'; Versions = @(3) }
+        @{ Script = '$typeExpression::$staticMember'; Versions = @() }
+        @{ Script = '$typeExpression::$dynamicStaticMethodName()'; Versions = @(3) }
     )
-}
-# PS v6+ won't parse workflows
-if ($PSVersionTable.PSVersion.Major -le 5)
-{
-    $testCases += @(
-        @{ Script = 'workflow Banana { Do-ExpensiveCommandOnAnotherMachine -Argument "Banana" }'; Versions = @(6) }
-    )
-}
-if ($PSVersionTable.PSVersion.Major -ge 7)
-{
-    $testCases += @(
-        @{ Script = '$x = $path ? (Get-Content -Raw $path) : "default"'; Versions = @(3,4,5,6) }
-        @{ Script = '$x ??= 7'; Versions = @(3,4,5,6) }
-        @{ Script = 'git pull origin master && git pull upstream master'; Versions = @(3,4,5,6) }
-    )
-
-    if ((Get-ExperimentalFeature -Name 'PSNullConditionalOperators').Enabled)
+    # PS v3/4 won't parse classes or enums
+    if ($PSVersionTable.PSVersion.Major -ge 5)
     {
         $testCases += @(
-            @{ Script = '${item}?.Invoke()'; Versions = @(3,4,5,6) }
-            @{ Script = '${object}?.Member'; Versions = @(3,4,5,6) }
+            @{ Script = "class MyClass { }"; Versions = @(3,4) }
+            @{ Script = "enum MyEnum { One; Two }"; Versions = @(3,4) }
         )
     }
-}
-$testCasesAllPSVersions = foreach ($version in 3, 4, 5, 6) {
-    foreach($testCase in $testCases) {
-        @{
-            Script = $testCase.Script
-            Versions = $testCase.Versions
-            TargetVersion = $version
+    # PS v6+ won't parse workflows
+    if ($PSVersionTable.PSVersion.Major -le 5)
+    {
+        $testCases += @(
+            @{ Script = 'workflow Banana { Do-ExpensiveCommandOnAnotherMachine -Argument "Banana" }'; Versions = @(6) }
+        )
+    }
+    if ($PSVersionTable.PSVersion.Major -ge 7)
+    {
+        $testCases += @(
+            @{ Script = '$x = $path ? (Get-Content -Raw $path) : "default"'; Versions = @(3,4,5,6) }
+            @{ Script = '$x ??= 7'; Versions = @(3,4,5,6) }
+            @{ Script = 'git pull origin master && git pull upstream master'; Versions = @(3,4,5,6) }
+        )
+
+        if ((Get-ExperimentalFeature -Name 'PSNullConditionalOperators').Enabled)
+        {
+            $testCases += @(
+                @{ Script = '${item}?.Invoke()'; Versions = @(3,4,5,6) }
+                @{ Script = '${object}?.Member'; Versions = @(3,4,5,6) }
+            )
+        }
+    }
+    $testCasesAllPSVersions = foreach ($version in 3, 4, 5, 6) {
+        foreach($testCase in $testCases) {
+            @{
+                Script = $testCase.Script
+                Versions = $testCase.Versions
+                TargetVersion = $version
+            }
         }
     }
 }
-
 
 Describe "PSUseCompatibleSyntax" {
     It "Finds issues for PSv<TargetVersion> in '<Script>'" -TestCases $testCasesAllPSVersions {

--- a/Tests/Rules/UseCompatibleSyntax.Tests.ps1
+++ b/Tests/Rules/UseCompatibleSyntax.Tests.ps1
@@ -1,61 +1,61 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-Describe "PSUseCompatibleSyntax" {
-    BeforeAll {
-        $RuleName = 'PSUseCompatibleSyntax'
+BeforeDiscovery {
+    $RuleName = 'PSUseCompatibleSyntax'
 
-        $testCases = @(
-            @{ Script = '$x = [MyClass]::new()'; Versions = @(3,4) }
-            @{ Script = '$member = "Hi"; $x.$member'; Versions = @() }
-            @{ Script = 'Write-Host "Banana"'; Versions = @() }
-            @{ Script = '[System.VeryInnocuousType]::RunApiMethod($obj)'; Versions = @() }
-            @{ Script = '$y.$methodWithAVeryLongName()'; Versions = @(3) }
-            @{ Script = '$typeExpression::$staticMember'; Versions = @() }
-            @{ Script = '$typeExpression::$dynamicStaticMethodName()'; Versions = @(3) }
+    $testCases = @(
+        @{ Script = '$x = [MyClass]::new()'; Versions = @(3,4) }
+        @{ Script = '$member = "Hi"; $x.$member'; Versions = @() }
+        @{ Script = 'Write-Host "Banana"'; Versions = @() }
+        @{ Script = '[System.VeryInnocuousType]::RunApiMethod($obj)'; Versions = @() }
+        @{ Script = '$y.$methodWithAVeryLongName()'; Versions = @(3) }
+        @{ Script = '$typeExpression::$staticMember'; Versions = @() }
+        @{ Script = '$typeExpression::$dynamicStaticMethodName()'; Versions = @(3) }
+    )
+    # PS v3/4 won't parse classes or enums
+    if ($PSVersionTable.PSVersion.Major -ge 5)
+    {
+        $testCases += @(
+            @{ Script = "class MyClass { }"; Versions = @(3,4) }
+            @{ Script = "enum MyEnum { One; Two }"; Versions = @(3,4) }
         )
-        # PS v3/4 won't parse classes or enums
-        if ($PSVersionTable.PSVersion.Major -ge 5)
-        {
-            $testCases += @(
-                @{ Script = "class MyClass { }"; Versions = @(3,4) }
-                @{ Script = "enum MyEnum { One; Two }"; Versions = @(3,4) }
-            )
-        }
-        # PS v6+ won't parse workflows
-        if ($PSVersionTable.PSVersion.Major -le 5)
-        {
-            $testCases += @(
-                @{ Script = 'workflow Banana { Do-ExpensiveCommandOnAnotherMachine -Argument "Banana" }'; Versions = @(6) }
-            )
-        }
-        if ($PSVersionTable.PSVersion.Major -ge 7)
-        {
-            $testCases += @(
-                @{ Script = '$x = $path ? (Get-Content -Raw $path) : "default"'; Versions = @(3,4,5,6) }
-                @{ Script = '$x ??= 7'; Versions = @(3,4,5,6) }
-                @{ Script = 'git pull origin master && git pull upstream master'; Versions = @(3,4,5,6) }
-            )
+    }
+    # PS v6+ won't parse workflows
+    if ($PSVersionTable.PSVersion.Major -le 5)
+    {
+        $testCases += @(
+            @{ Script = 'workflow Banana { Do-ExpensiveCommandOnAnotherMachine -Argument "Banana" }'; Versions = @(6) }
+        )
+    }
+    if ($PSVersionTable.PSVersion.Major -ge 7)
+    {
+        $testCases += @(
+            @{ Script = '$x = $path ? (Get-Content -Raw $path) : "default"'; Versions = @(3,4,5,6) }
+            @{ Script = '$x ??= 7'; Versions = @(3,4,5,6) }
+            @{ Script = 'git pull origin master && git pull upstream master'; Versions = @(3,4,5,6) }
+        )
 
-            if ((Get-ExperimentalFeature -Name 'PSNullConditionalOperators').Enabled)
-            {
-                $testCases += @(
-                    @{ Script = '${item}?.Invoke()'; Versions = @(3,4,5,6) }
-                    @{ Script = '${object}?.Member'; Versions = @(3,4,5,6) }
-                )
-            }
+        if ((Get-ExperimentalFeature -Name 'PSNullConditionalOperators').Enabled)
+        {
+            $testCases += @(
+                @{ Script = '${item}?.Invoke()'; Versions = @(3,4,5,6) }
+                @{ Script = '${object}?.Member'; Versions = @(3,4,5,6) }
+            )
         }
-        $testCasesAllPSVersions = foreach ($version in 3, 4, 5, 6) {
-            foreach($testCase in $testCases) {
-                @{
-                    Script = $testCase.Script
-                    Versions = $testCase.Versions
-                    TargetVersion = $version
-                }
+    }
+    $testCasesAllPSVersions = foreach ($version in 3, 4, 5, 6) {
+        foreach($testCase in $testCases) {
+            @{
+                Script = $testCase.Script
+                Versions = $testCase.Versions
+                TargetVersion = $version
             }
         }
     }
+}
 
+Describe "PSUseCompatibleSyntax" {
     It "Finds issues for PSv<TargetVersion> in '<Script>'" -TestCases $testCasesAllPSVersions {
         param([string]$Script, $Versions, $TargetVersion)
 

--- a/Tests/Rules/UseCompatibleSyntax.Tests.ps1
+++ b/Tests/Rules/UseCompatibleSyntax.Tests.ps1
@@ -1,9 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-BeforeAll {
-    $script:RuleName = 'PSUseCompatibleSyntax'
-}
+$script:RuleName = 'PSUseCompatibleSyntax'
 
 $testCases = @(
     @{ Script = '$x = [MyClass]::new()'; Versions = @(3,4) }

--- a/Tests/Rules/UseCompatibleSyntax.Tests.ps1
+++ b/Tests/Rules/UseCompatibleSyntax.Tests.ps1
@@ -1,61 +1,61 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-BeforeAll {
-    $RuleName = 'PSUseCompatibleSyntax'
+Describe "PSUseCompatibleSyntax" {
+    BeforeAll {
+        $RuleName = 'PSUseCompatibleSyntax'
 
-    $testCases = @(
-        @{ Script = '$x = [MyClass]::new()'; Versions = @(3,4) }
-        @{ Script = '$member = "Hi"; $x.$member'; Versions = @() }
-        @{ Script = 'Write-Host "Banana"'; Versions = @() }
-        @{ Script = '[System.VeryInnocuousType]::RunApiMethod($obj)'; Versions = @() }
-        @{ Script = '$y.$methodWithAVeryLongName()'; Versions = @(3) }
-        @{ Script = '$typeExpression::$staticMember'; Versions = @() }
-        @{ Script = '$typeExpression::$dynamicStaticMethodName()'; Versions = @(3) }
-    )
-    # PS v3/4 won't parse classes or enums
-    if ($PSVersionTable.PSVersion.Major -ge 5)
-    {
-        $testCases += @(
-            @{ Script = "class MyClass { }"; Versions = @(3,4) }
-            @{ Script = "enum MyEnum { One; Two }"; Versions = @(3,4) }
+        $testCases = @(
+            @{ Script = '$x = [MyClass]::new()'; Versions = @(3,4) }
+            @{ Script = '$member = "Hi"; $x.$member'; Versions = @() }
+            @{ Script = 'Write-Host "Banana"'; Versions = @() }
+            @{ Script = '[System.VeryInnocuousType]::RunApiMethod($obj)'; Versions = @() }
+            @{ Script = '$y.$methodWithAVeryLongName()'; Versions = @(3) }
+            @{ Script = '$typeExpression::$staticMember'; Versions = @() }
+            @{ Script = '$typeExpression::$dynamicStaticMethodName()'; Versions = @(3) }
         )
-    }
-    # PS v6+ won't parse workflows
-    if ($PSVersionTable.PSVersion.Major -le 5)
-    {
-        $testCases += @(
-            @{ Script = 'workflow Banana { Do-ExpensiveCommandOnAnotherMachine -Argument "Banana" }'; Versions = @(6) }
-        )
-    }
-    if ($PSVersionTable.PSVersion.Major -ge 7)
-    {
-        $testCases += @(
-            @{ Script = '$x = $path ? (Get-Content -Raw $path) : "default"'; Versions = @(3,4,5,6) }
-            @{ Script = '$x ??= 7'; Versions = @(3,4,5,6) }
-            @{ Script = 'git pull origin master && git pull upstream master'; Versions = @(3,4,5,6) }
-        )
-
-        if ((Get-ExperimentalFeature -Name 'PSNullConditionalOperators').Enabled)
+        # PS v3/4 won't parse classes or enums
+        if ($PSVersionTable.PSVersion.Major -ge 5)
         {
             $testCases += @(
-                @{ Script = '${item}?.Invoke()'; Versions = @(3,4,5,6) }
-                @{ Script = '${object}?.Member'; Versions = @(3,4,5,6) }
+                @{ Script = "class MyClass { }"; Versions = @(3,4) }
+                @{ Script = "enum MyEnum { One; Two }"; Versions = @(3,4) }
             )
         }
-    }
-    $testCasesAllPSVersions = foreach ($version in 3, 4, 5, 6) {
-        foreach($testCase in $testCases) {
-            @{
-                Script = $testCase.Script
-                Versions = $testCase.Versions
-                TargetVersion = $version
+        # PS v6+ won't parse workflows
+        if ($PSVersionTable.PSVersion.Major -le 5)
+        {
+            $testCases += @(
+                @{ Script = 'workflow Banana { Do-ExpensiveCommandOnAnotherMachine -Argument "Banana" }'; Versions = @(6) }
+            )
+        }
+        if ($PSVersionTable.PSVersion.Major -ge 7)
+        {
+            $testCases += @(
+                @{ Script = '$x = $path ? (Get-Content -Raw $path) : "default"'; Versions = @(3,4,5,6) }
+                @{ Script = '$x ??= 7'; Versions = @(3,4,5,6) }
+                @{ Script = 'git pull origin master && git pull upstream master'; Versions = @(3,4,5,6) }
+            )
+
+            if ((Get-ExperimentalFeature -Name 'PSNullConditionalOperators').Enabled)
+            {
+                $testCases += @(
+                    @{ Script = '${item}?.Invoke()'; Versions = @(3,4,5,6) }
+                    @{ Script = '${object}?.Member'; Versions = @(3,4,5,6) }
+                )
+            }
+        }
+        $testCasesAllPSVersions = foreach ($version in 3, 4, 5, 6) {
+            foreach($testCase in $testCases) {
+                @{
+                    Script = $testCase.Script
+                    Versions = $testCase.Versions
+                    TargetVersion = $version
+                }
             }
         }
     }
-}
 
-Describe "PSUseCompatibleSyntax" {
     It "Finds issues for PSv<TargetVersion> in '<Script>'" -TestCases $testCasesAllPSVersions {
         param([string]$Script, $Versions, $TargetVersion)
 

--- a/Tests/Rules/UseCompatibleTypes.Tests.ps1
+++ b/Tests/Rules/UseCompatibleTypes.Tests.ps1
@@ -68,6 +68,20 @@ Describe 'UseCompatibleTypes' {
 
         $TargetProfileConfigKey = 'TargetProfiles'
 
+        $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
+        $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
+        $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
+        $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
+        $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
+        $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+        $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
+        $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
+        $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+        $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
+        $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
+        $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
+        $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
+
         $AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
         $AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
     }

--- a/Tests/Rules/UseCompatibleTypes.Tests.ps1
+++ b/Tests/Rules/UseCompatibleTypes.Tests.ps1
@@ -1,88 +1,89 @@
 ﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-$script:RuleName = 'PSUseCompatibleTypes'
+BeforeAll {
+    $RuleName = 'PSUseCompatibleTypes'
 
-$script:TargetProfileConfigKey = 'TargetProfiles'
+    $TargetProfileConfigKey = 'TargetProfiles'
 
-$script:Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
-$script:Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
-$script:Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
-$script:Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
-$script:Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
-$script:Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-$script:Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
-$script:Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
-$script:Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-$script:Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
-$script:Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
-$script:Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
-$script:Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
+    $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
+    $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
+    $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
+    $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
+    $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
+    $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+    $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
+    $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
+    $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+    $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
+    $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
+    $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
+    $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
 
-$script:AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
-$script:AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
+    $AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
+    $AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
 
-$script:TypeCompatibilityTestCases = @(
-    @{ Target = $script:Srv2012_3_profile; Script = '[System.Management.Automation.ModuleIntrinsics]::GetModulePath("here", "there", "everywhere")'; Types = @('System.Management.Automation.ModuleIntrinsics'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = '$ast -is [System.Management.Automation.Language.FunctionMemberAst]'; Types = @('System.Management.Automation.Language.FunctionMemberAst'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = '$version = [System.Management.Automation.SemanticVersion]::Parse($version)'; Types = @('System.Management.Automation.SemanticVersion'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = '$kw = New-Object "System.Management.Automation.Language.DynamicKeyword"'; Types = @('System.Management.Automation.Language.DynamicKeyword'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = '& { param([Parameter(Position=0)][ArgumentCompleter({"Banana"})][string]$Hello) $Hello } "Banana"'; Types = @('ArgumentCompleter'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+    $TypeCompatibilityTestCases = @(
+        @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.ModuleIntrinsics]::GetModulePath("here", "there", "everywhere")'; Types = @('System.Management.Automation.ModuleIntrinsics'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$ast -is [System.Management.Automation.Language.FunctionMemberAst]'; Types = @('System.Management.Automation.Language.FunctionMemberAst'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$version = [System.Management.Automation.SemanticVersion]::Parse($version)'; Types = @('System.Management.Automation.SemanticVersion'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$kw = New-Object "System.Management.Automation.Language.DynamicKeyword"'; Types = @('System.Management.Automation.Language.DynamicKeyword'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '& { param([Parameter(Position=0)][ArgumentCompleter({"Banana"})][string]$Hello) $Hello } "Banana"'; Types = @('ArgumentCompleter'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2012r2_4_profile; Script = '[WildcardPattern]"bicycle*"'; Types = @('WildcardPattern'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = '$client = [System.Net.Http.HttpClient]::new()'; Types = @('System.Net.Http.HttpClient'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = '[Microsoft.PowerShell.EditMode]"Vi"'; Types = @('Microsoft.PowerShell.EditMode'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '[WildcardPattern]"bicycle*"'; Types = @('WildcardPattern'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '$client = [System.Net.Http.HttpClient]::new()'; Types = @('System.Net.Http.HttpClient'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '[Microsoft.PowerShell.EditMode]"Vi"'; Types = @('Microsoft.PowerShell.EditMode'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2019_5_profile; Script = '[Microsoft.PowerShell.Commands.WebSslProtocol]::Default -eq "Tls12"'; Types = @('Microsoft.PowerShell.Commands.WebSslProtocol'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_5_profile; Script = '[System.Collections.Immutable.ImmutableList[string]]::Empty'; Types = @('System.Collections.Immutable.ImmutableList'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_5_profile; Script = '[System.Collections.Generic.TreeSet[string]]::new(@("duck", "goose", "banana"))'; Types = @('System.Collections.Generic.TreeSet'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = '[Microsoft.PowerShell.Commands.WebSslProtocol]::Default -eq "Tls12"'; Types = @('Microsoft.PowerShell.Commands.WebSslProtocol'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = '[System.Collections.Immutable.ImmutableList[string]]::Empty'; Types = @('System.Collections.Immutable.ImmutableList'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = '[System.Collections.Generic.TreeSet[string]]::new(@("duck", "goose", "banana"))'; Types = @('System.Collections.Generic.TreeSet'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2019_6_2_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_6_2_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2019_7_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_7_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
 
-    @{ Target = $script:Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-    @{ Target = $script:Ubuntu1804_7_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-)
+        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+    )
 
-$script:MemberCompatibilityTestCases = @(
-    @{ Target = $script:Srv2012_3_profile; Script = '[System.Management.Automation.LanguagePrimitives]::ConvertTypeNameToPSTypeName("System.String")'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('ConvertTypeNameToPSTypeName'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012_3_profile; Script = '[System.Management.Automation.WildcardPattern]::Get("banana*", "None").IsMatch("bananaduck")'; Types = @('System.Management.Automation.WildcardPattern'); Members = @('Get'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+    $MemberCompatibilityTestCases = @(
+        @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.LanguagePrimitives]::ConvertTypeNameToPSTypeName("System.String")'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('ConvertTypeNameToPSTypeName'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.WildcardPattern]::Get("banana*", "None").IsMatch("bananaduck")'; Types = @('System.Management.Automation.WildcardPattern'); Members = @('Get'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2012r2_4_profile; Script = 'if (-not [Microsoft.PowerShell.Commands.ModuleSpecification]::TryParse($msStr, [ref]$modSpec)){ throw "Bad!" }'; Types = @('Microsoft.PowerShell.Commands.ModuleSpecification'); Members = @('TryParse'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2012r2_4_profile; Script = '[System.Management.Automation.LanguagePrimitives]::IsObjectEnumerable($obj)'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('IsObjectEnumerable'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = 'if (-not [Microsoft.PowerShell.Commands.ModuleSpecification]::TryParse($msStr, [ref]$modSpec)){ throw "Bad!" }'; Types = @('Microsoft.PowerShell.Commands.ModuleSpecification'); Members = @('TryParse'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '[System.Management.Automation.LanguagePrimitives]::IsObjectEnumerable($obj)'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('IsObjectEnumerable'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Srv2019_5_profile; Script = '$socket = [System.Net.WebSockets.WebSocket]::CreateFromStream($stream, $true, "http", [timespan]::FromMinutes(10))'; Types = @('System.Net.WebSockets.WebSocket'); Members = @('CreateFromStream'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-    @{ Target = $script:Srv2019_5_profile; Script = '[System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $runspace)'; Types = @('System.Management.Automation.HostUtilities'); Members = @('InvokeOnRunspace'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = '$socket = [System.Net.WebSockets.WebSocket]::CreateFromStream($stream, $true, "http", [timespan]::FromMinutes(10))'; Types = @('System.Net.WebSockets.WebSocket'); Members = @('CreateFromStream'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = '[System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $runspace)'; Types = @('System.Management.Automation.HostUtilities'); Members = @('InvokeOnRunspace'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
 
-    @{ Target = $script:Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
 
-    @{ Target = $script:Ubuntu1804_7_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-)
-
+        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+    )
+}
 
 Describe 'UseCompatibleTypes' {
     Context 'Targeting a single profile' {
-        It "Reports <ProblemCount> problem(s) with <Script> on <OS> with PowerShell <Version> targeting <Target>" -TestCases $script:TypeCompatibilityTestCases {
+        It "Reports <ProblemCount> problem(s) with <Script> on <OS> with PowerShell <Version> targeting <Target>" -TestCases $TypeCompatibilityTestCases {
             param($Script, [string]$Target, [string[]]$Types, [version]$Version, [string]$OS, [int]$ProblemCount)
 
             $settings = @{
                 Rules = @{
-                    $script:RuleName = @{
+                    $RuleName = @{
                         Enable = $true
-                        $script:TargetProfileConfigKey = @($Target)
+                        $TargetProfileConfigKey = @($Target)
                     }
                 }
             }
 
-            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $script:RuleName -ScriptDefinition $Script -Settings $settings
+            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $RuleName -ScriptDefinition $Script -Settings $settings
 
             $diagnostics.Count | Should -Be $ProblemCount
 
@@ -95,19 +96,19 @@ Describe 'UseCompatibleTypes' {
             }
         }
 
-        It "Reports <ProblemCount> problem(s) with <Script> on <OS> with PowerShell <Version> targeting <Target>" -TestCases $script:MemberCompatibilityTestCases {
+        It "Reports <ProblemCount> problem(s) with <Script> on <OS> with PowerShell <Version> targeting <Target>" -TestCases $MemberCompatibilityTestCases {
             param($Script, [string]$Target, [string[]]$Types, [string[]]$Members, [version]$Version, [string]$OS, [int]$ProblemCount)
 
             $settings = @{
                 Rules = @{
-                    $script:RuleName = @{
+                    $RuleName = @{
                         Enable = $true
-                        $script:TargetProfileConfigKey = @($Target)
+                        $TargetProfileConfigKey = @($Target)
                     }
                 }
             }
 
-            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $script:RuleName -ScriptDefinition $Script -Settings $settings
+            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $RuleName -ScriptDefinition $Script -Settings $settings
 
             $diagnostics.Count | Should -Be $ProblemCount
 
@@ -126,18 +127,18 @@ Describe 'UseCompatibleTypes' {
         It "Finds all incompatibilities in the script" {
             $settings = @{
                 Rules = @{
-                    $script:RuleName = @{
+                    $RuleName = @{
                         Enable = $true
-                        $script:TargetProfileConfigKey = @(
-                            $script:Srv2012_3_profile
-                            $script:Srv2012r2_4_profile
-                            $script:Srv2016_5_profile
-                            $script:Srv2016_6_2_profile
-                            $script:Srv2019_5_profile
-                            $script:Srv2019_6_2_profile
-                            $script:Win10_5_profile
-                            $script:Win10_6_2_profile
-                            $script:Ubuntu1804_6_2_profile
+                        $TargetProfileConfigKey = @(
+                            $Srv2012_3_profile
+                            $Srv2012r2_4_profile
+                            $Srv2016_5_profile
+                            $Srv2016_6_2_profile
+                            $Srv2019_5_profile
+                            $Srv2019_6_2_profile
+                            $Win10_5_profile
+                            $Win10_6_2_profile
+                            $Ubuntu1804_6_2_profile
                         )
                     }
                 }
@@ -159,20 +160,20 @@ Describe 'UseCompatibleTypes' {
         It "Checks that there are no incompatibilities in PSSA build scripts" {
             $settings = @{
                 Rules = @{
-                    $script:RuleName = @{
+                    $RuleName = @{
                         Enable = $true
-                        $script:TargetProfileConfigKey = @(
-                            $script:Srv2012_3_profile
-                            $script:Srv2012r2_4_profile
-                            $script:Srv2016_5_profile
-                            $script:Srv2016_6_2_profile
-                            $script:Srv2019_7_profile
-                            $script:Srv2019_5_profile
-                            $script:Srv2019_6_2_profile
-                            $script:Win10_5_profile
-                            $script:Win10_6_2_profile
-                            $script:Ubuntu1804_6_2_profile
-                            $script:Ubuntu1804_7_profile
+                        $TargetProfileConfigKey = @(
+                            $Srv2012_3_profile
+                            $Srv2012r2_4_profile
+                            $Srv2016_5_profile
+                            $Srv2016_6_2_profile
+                            $Srv2019_7_profile
+                            $Srv2019_5_profile
+                            $Srv2019_6_2_profile
+                            $Win10_5_profile
+                            $Win10_6_2_profile
+                            $Ubuntu1804_6_2_profile
+                            $Ubuntu1804_7_profile
                         )
                         IgnoreTypes = @('System.IO.Compression.ZipFile')
                     }
@@ -188,12 +189,12 @@ Describe 'UseCompatibleTypes' {
         BeforeAll {
             $settings = @{
                 Rules = @{
-                    $script:RuleName = @{
+                    $RuleName = @{
                         Enable = $true
-                        $script:TargetProfileConfigKey = @(
-                            $script:AzF_profile
-                            $script:AzA_profile
-                            $script:Win10_5_profile
+                        $TargetProfileConfigKey = @(
+                            $AzF_profile
+                            $AzA_profile
+                            $Win10_5_profile
                         )
                     }
                 }
@@ -201,7 +202,7 @@ Describe 'UseCompatibleTypes' {
         }
 
         It "Finds AzF problems with a script" {
-            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $script:RuleName -Settings $settings -ScriptDefinition '
+            $diagnostics = Invoke-ScriptAnalyzer -IncludeRule $RuleName -Settings $settings -ScriptDefinition '
             [System.Collections.Immutable.ImmutableList[string]]::Empty
             [Microsoft.PowerShell.ToStringCodeMethods]::PropertyValueCollection($obj)
             '

--- a/Tests/Rules/UseCompatibleTypes.Tests.ps1
+++ b/Tests/Rules/UseCompatibleTypes.Tests.ps1
@@ -1,73 +1,75 @@
 ﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+BeforeDiscovery {
+    $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
+    $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
+    $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
+    $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
+    $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
+    $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+    $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
+    $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
+    $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+    $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
+    $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
+    $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
+    $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
+
+    $TypeCompatibilityTestCases = @(
+        @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.ModuleIntrinsics]::GetModulePath("here", "there", "everywhere")'; Types = @('System.Management.Automation.ModuleIntrinsics'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$ast -is [System.Management.Automation.Language.FunctionMemberAst]'; Types = @('System.Management.Automation.Language.FunctionMemberAst'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$version = [System.Management.Automation.SemanticVersion]::Parse($version)'; Types = @('System.Management.Automation.SemanticVersion'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '$kw = New-Object "System.Management.Automation.Language.DynamicKeyword"'; Types = @('System.Management.Automation.Language.DynamicKeyword'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '& { param([Parameter(Position=0)][ArgumentCompleter({"Banana"})][string]$Hello) $Hello } "Banana"'; Types = @('ArgumentCompleter'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Srv2012r2_4_profile; Script = '[WildcardPattern]"bicycle*"'; Types = @('WildcardPattern'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '$client = [System.Net.Http.HttpClient]::new()'; Types = @('System.Net.Http.HttpClient'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '[Microsoft.PowerShell.EditMode]"Vi"'; Types = @('Microsoft.PowerShell.EditMode'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Srv2019_5_profile; Script = '[Microsoft.PowerShell.Commands.WebSslProtocol]::Default -eq "Tls12"'; Types = @('Microsoft.PowerShell.Commands.WebSslProtocol'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = '[System.Collections.Immutable.ImmutableList[string]]::Empty'; Types = @('System.Collections.Immutable.ImmutableList'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = '[System.Collections.Generic.TreeSet[string]]::new(@("duck", "goose", "banana"))'; Types = @('System.Collections.Generic.TreeSet'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Srv2019_6_2_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Srv2019_7_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_6_2_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+
+        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+        @{ Target = $Ubuntu1804_7_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+    )
+
+    $MemberCompatibilityTestCases = @(
+        @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.LanguagePrimitives]::ConvertTypeNameToPSTypeName("System.String")'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('ConvertTypeNameToPSTypeName'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.WildcardPattern]::Get("banana*", "None").IsMatch("bananaduck")'; Types = @('System.Management.Automation.WildcardPattern'); Members = @('Get'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Srv2012r2_4_profile; Script = 'if (-not [Microsoft.PowerShell.Commands.ModuleSpecification]::TryParse($msStr, [ref]$modSpec)){ throw "Bad!" }'; Types = @('Microsoft.PowerShell.Commands.ModuleSpecification'); Members = @('TryParse'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2012r2_4_profile; Script = '[System.Management.Automation.LanguagePrimitives]::IsObjectEnumerable($obj)'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('IsObjectEnumerable'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Srv2019_5_profile; Script = '$socket = [System.Net.WebSockets.WebSocket]::CreateFromStream($stream, $true, "http", [timespan]::FromMinutes(10))'; Types = @('System.Net.WebSockets.WebSocket'); Members = @('CreateFromStream'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+        @{ Target = $Srv2019_5_profile; Script = '[System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $runspace)'; Types = @('System.Management.Automation.HostUtilities'); Members = @('InvokeOnRunspace'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+
+        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+
+        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+    )
+}
+
 Describe 'UseCompatibleTypes' {
     BeforeAll {
         $RuleName = 'PSUseCompatibleTypes'
 
         $TargetProfileConfigKey = 'TargetProfiles'
 
-        $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
-        $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
-        $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
-        $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
-        $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
-        $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-        $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
-        $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
-        $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-        $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
-        $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
-        $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
-        $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
-
         $AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
         $AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
-
-        $TypeCompatibilityTestCases = @(
-            @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.ModuleIntrinsics]::GetModulePath("here", "there", "everywhere")'; Types = @('System.Management.Automation.ModuleIntrinsics'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = '$ast -is [System.Management.Automation.Language.FunctionMemberAst]'; Types = @('System.Management.Automation.Language.FunctionMemberAst'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = '$version = [System.Management.Automation.SemanticVersion]::Parse($version)'; Types = @('System.Management.Automation.SemanticVersion'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = '$kw = New-Object "System.Management.Automation.Language.DynamicKeyword"'; Types = @('System.Management.Automation.Language.DynamicKeyword'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = '& { param([Parameter(Position=0)][ArgumentCompleter({"Banana"})][string]$Hello) $Hello } "Banana"'; Types = @('ArgumentCompleter'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Srv2012r2_4_profile; Script = '[WildcardPattern]"bicycle*"'; Types = @('WildcardPattern'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = '$client = [System.Net.Http.HttpClient]::new()'; Types = @('System.Net.Http.HttpClient'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = '[Microsoft.PowerShell.EditMode]"Vi"'; Types = @('Microsoft.PowerShell.EditMode'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Srv2019_5_profile; Script = '[Microsoft.PowerShell.Commands.WebSslProtocol]::Default -eq "Tls12"'; Types = @('Microsoft.PowerShell.Commands.WebSslProtocol'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2019_5_profile; Script = '[System.Collections.Immutable.ImmutableList[string]]::Empty'; Types = @('System.Collections.Immutable.ImmutableList'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2019_5_profile; Script = '[System.Collections.Generic.TreeSet[string]]::new(@("duck", "goose", "banana"))'; Types = @('System.Collections.Generic.TreeSet'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Srv2019_6_2_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Srv2019_7_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_6_2_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-
-            @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-            @{ Target = $Ubuntu1804_7_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-        )
-
-        $MemberCompatibilityTestCases = @(
-            @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.LanguagePrimitives]::ConvertTypeNameToPSTypeName("System.String")'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('ConvertTypeNameToPSTypeName'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.WildcardPattern]::Get("banana*", "None").IsMatch("bananaduck")'; Types = @('System.Management.Automation.WildcardPattern'); Members = @('Get'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Srv2012r2_4_profile; Script = 'if (-not [Microsoft.PowerShell.Commands.ModuleSpecification]::TryParse($msStr, [ref]$modSpec)){ throw "Bad!" }'; Types = @('Microsoft.PowerShell.Commands.ModuleSpecification'); Members = @('TryParse'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2012r2_4_profile; Script = '[System.Management.Automation.LanguagePrimitives]::IsObjectEnumerable($obj)'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('IsObjectEnumerable'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Srv2019_5_profile; Script = '$socket = [System.Net.WebSockets.WebSocket]::CreateFromStream($stream, $true, "http", [timespan]::FromMinutes(10))'; Types = @('System.Net.WebSockets.WebSocket'); Members = @('CreateFromStream'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-            @{ Target = $Srv2019_5_profile; Script = '[System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $runspace)'; Types = @('System.Management.Automation.HostUtilities'); Members = @('InvokeOnRunspace'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-
-            @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-
-            @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-        )
     }
 
     Context 'Targeting a single profile' {

--- a/Tests/Rules/UseCompatibleTypes.Tests.ps1
+++ b/Tests/Rules/UseCompatibleTypes.Tests.ps1
@@ -1,9 +1,7 @@
 ﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-BeforeAll {
 $script:RuleName = 'PSUseCompatibleTypes'
-}
 
 $script:TargetProfileConfigKey = 'TargetProfiles'
 

--- a/Tests/Rules/UseCompatibleTypes.Tests.ps1
+++ b/Tests/Rules/UseCompatibleTypes.Tests.ps1
@@ -1,75 +1,75 @@
 ﻿# Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-BeforeAll {
-    $RuleName = 'PSUseCompatibleTypes'
-
-    $TargetProfileConfigKey = 'TargetProfiles'
-
-    $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
-    $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
-    $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
-    $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
-    $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
-    $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-    $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
-    $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
-    $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
-    $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
-    $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
-    $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
-    $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
-
-    $AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
-    $AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
-
-    $TypeCompatibilityTestCases = @(
-        @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.ModuleIntrinsics]::GetModulePath("here", "there", "everywhere")'; Types = @('System.Management.Automation.ModuleIntrinsics'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = '$ast -is [System.Management.Automation.Language.FunctionMemberAst]'; Types = @('System.Management.Automation.Language.FunctionMemberAst'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = '$version = [System.Management.Automation.SemanticVersion]::Parse($version)'; Types = @('System.Management.Automation.SemanticVersion'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = '$kw = New-Object "System.Management.Automation.Language.DynamicKeyword"'; Types = @('System.Management.Automation.Language.DynamicKeyword'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = '& { param([Parameter(Position=0)][ArgumentCompleter({"Banana"})][string]$Hello) $Hello } "Banana"'; Types = @('ArgumentCompleter'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Srv2012r2_4_profile; Script = '[WildcardPattern]"bicycle*"'; Types = @('WildcardPattern'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = '$client = [System.Net.Http.HttpClient]::new()'; Types = @('System.Net.Http.HttpClient'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = '[Microsoft.PowerShell.EditMode]"Vi"'; Types = @('Microsoft.PowerShell.EditMode'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Srv2019_5_profile; Script = '[Microsoft.PowerShell.Commands.WebSslProtocol]::Default -eq "Tls12"'; Types = @('Microsoft.PowerShell.Commands.WebSslProtocol'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2019_5_profile; Script = '[System.Collections.Immutable.ImmutableList[string]]::Empty'; Types = @('System.Collections.Immutable.ImmutableList'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2019_5_profile; Script = '[System.Collections.Generic.TreeSet[string]]::new(@("duck", "goose", "banana"))'; Types = @('System.Collections.Generic.TreeSet'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Srv2019_6_2_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Srv2019_7_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_6_2_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-
-        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-        @{ Target = $Ubuntu1804_7_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-    )
-
-    $MemberCompatibilityTestCases = @(
-        @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.LanguagePrimitives]::ConvertTypeNameToPSTypeName("System.String")'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('ConvertTypeNameToPSTypeName'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.WildcardPattern]::Get("banana*", "None").IsMatch("bananaduck")'; Types = @('System.Management.Automation.WildcardPattern'); Members = @('Get'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Srv2012r2_4_profile; Script = 'if (-not [Microsoft.PowerShell.Commands.ModuleSpecification]::TryParse($msStr, [ref]$modSpec)){ throw "Bad!" }'; Types = @('Microsoft.PowerShell.Commands.ModuleSpecification'); Members = @('TryParse'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2012r2_4_profile; Script = '[System.Management.Automation.LanguagePrimitives]::IsObjectEnumerable($obj)'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('IsObjectEnumerable'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Srv2019_5_profile; Script = '$socket = [System.Net.WebSockets.WebSocket]::CreateFromStream($stream, $true, "http", [timespan]::FromMinutes(10))'; Types = @('System.Net.WebSockets.WebSocket'); Members = @('CreateFromStream'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-        @{ Target = $Srv2019_5_profile; Script = '[System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $runspace)'; Types = @('System.Management.Automation.HostUtilities'); Members = @('InvokeOnRunspace'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
-
-        @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
-
-        @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
-    )
-}
-
 Describe 'UseCompatibleTypes' {
+    BeforeAll {
+        $RuleName = 'PSUseCompatibleTypes'
+
+        $TargetProfileConfigKey = 'TargetProfiles'
+
+        $Srv2012_3_profile = 'win-8_x64_6.2.9200.0_3.0_x64_4.0.30319.42000_framework'
+        $Srv2012r2_4_profile = 'win-8_x64_6.3.9600.0_4.0_x64_4.0.30319.42000_framework'
+        $Srv2016_5_profile = 'win-8_x64_10.0.14393.0_5.1.14393.2791_x64_4.0.30319.42000_framework'
+        $Srv2016_6_2_profile = 'win-8_x64_10.0.14393.0_6.2.4_x64_4.0.30319.42000_core'
+        $Srv2016_7_profile = 'win-8_x64_10.0.14393.0_7.0.0_x64_3.1.2_core'
+        $Srv2019_5_profile = 'win-8_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+        $Srv2019_6_2_profile = 'win-8_x64_10.0.17763.0_6.2.4_x64_4.0.30319.42000_core'
+        $Srv2019_7_profile = 'win-8_x64_10.0.17763.0_7.0.0_x64_3.1.2_core'
+        $Win10_5_profile = 'win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework'
+        $Win10_6_2_profile = 'win-4_x64_10.0.18362.0_6.2.4_x64_4.0.30319.42000_core'
+        $Win10_7_profile = 'win-4_x64_10.0.18362.0_7.0.0_x64_3.1.2_core'
+        $Ubuntu1804_6_2_profile = 'ubuntu_x64_18.04_6.2.4_x64_4.0.30319.42000_core'
+        $Ubuntu1804_7_profile = 'ubuntu_x64_18.04_7.0.0_x64_3.1.2_core'
+
+        $AzF_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azurefunctions.json").Path
+        $AzA_profile = (Resolve-Path "$PSScriptRoot/../../PSCompatibilityCollector/optional_profiles/azureautomation.json").Path
+
+        $TypeCompatibilityTestCases = @(
+            @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.ModuleIntrinsics]::GetModulePath("here", "there", "everywhere")'; Types = @('System.Management.Automation.ModuleIntrinsics'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = '$ast -is [System.Management.Automation.Language.FunctionMemberAst]'; Types = @('System.Management.Automation.Language.FunctionMemberAst'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = '$version = [System.Management.Automation.SemanticVersion]::Parse($version)'; Types = @('System.Management.Automation.SemanticVersion'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = '$kw = New-Object "System.Management.Automation.Language.DynamicKeyword"'; Types = @('System.Management.Automation.Language.DynamicKeyword'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = '& { param([Parameter(Position=0)][ArgumentCompleter({"Banana"})][string]$Hello) $Hello } "Banana"'; Types = @('ArgumentCompleter'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Srv2012r2_4_profile; Script = '[WildcardPattern]"bicycle*"'; Types = @('WildcardPattern'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = '$client = [System.Net.Http.HttpClient]::new()'; Types = @('System.Net.Http.HttpClient'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = '[Microsoft.PowerShell.EditMode]"Vi"'; Types = @('Microsoft.PowerShell.EditMode'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Srv2019_5_profile; Script = '[Microsoft.PowerShell.Commands.WebSslProtocol]::Default -eq "Tls12"'; Types = @('Microsoft.PowerShell.Commands.WebSslProtocol'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2019_5_profile; Script = '[System.Collections.Immutable.ImmutableList[string]]::Empty'; Types = @('System.Collections.Immutable.ImmutableList'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2019_5_profile; Script = '[System.Collections.Generic.TreeSet[string]]::new(@("duck", "goose", "banana"))'; Types = @('System.Collections.Generic.TreeSet'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Srv2019_6_2_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "6.2"; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Srv2019_7_profile; Script = 'function CertFunc { param([System.Net.ICertificatePolicy]$Policy) Do-Something $Policy }'; Types = @('System.Net.ICertificatePolicy'); Version = "7.0"; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_6_2_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+
+            @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy()'; Types = @('System.Management.Automation.Security.SystemPolicy'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Security.SystemEnforcementMode]$enforcementMode = "Audit"'; Types = @('System.Management.Automation.Security.SystemEnforcementMode'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+            @{ Target = $Ubuntu1804_7_profile; Script = '$ci = New-Object "Microsoft.PowerShell.Commands.ComputerInfo"'; Types = @('Microsoft.PowerShell.Commands.ComputerInfo'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+        )
+
+        $MemberCompatibilityTestCases = @(
+            @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.LanguagePrimitives]::ConvertTypeNameToPSTypeName("System.String")'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('ConvertTypeNameToPSTypeName'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012_3_profile; Script = '[System.Management.Automation.WildcardPattern]::Get("banana*", "None").IsMatch("bananaduck")'; Types = @('System.Management.Automation.WildcardPattern'); Members = @('Get'); Version = "3.0"; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Srv2012r2_4_profile; Script = 'if (-not [Microsoft.PowerShell.Commands.ModuleSpecification]::TryParse($msStr, [ref]$modSpec)){ throw "Bad!" }'; Types = @('Microsoft.PowerShell.Commands.ModuleSpecification'); Members = @('TryParse'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2012r2_4_profile; Script = '[System.Management.Automation.LanguagePrimitives]::IsObjectEnumerable($obj)'; Types = @('System.Management.Automation.LanguagePrimitives'); Members = @('IsObjectEnumerable'); Version = "4.0"; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Srv2019_5_profile; Script = '$socket = [System.Net.WebSockets.WebSocket]::CreateFromStream($stream, $true, "http", [timespan]::FromMinutes(10))'; Types = @('System.Net.WebSockets.WebSocket'); Members = @('CreateFromStream'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+            @{ Target = $Srv2019_5_profile; Script = '[System.Management.Automation.HostUtilities]::InvokeOnRunspace($command, $runspace)'; Types = @('System.Management.Automation.HostUtilities'); Members = @('InvokeOnRunspace'); Version = "5.1"; OS = 'Windows'; ProblemCount = 1 }
+
+            @{ Target = $Ubuntu1804_6_2_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "6.2"; OS = 'Linux'; ProblemCount = 1 }
+
+            @{ Target = $Ubuntu1804_7_profile; Script = '[System.Management.Automation.Tracing.Tracer]::GetExceptionString($e)'; Types = @('System.Management.Automation.Tracing.Tracer'); Members = @('GetExceptionString'); Version = "7.0"; OS = 'Linux'; ProblemCount = 1 }
+        )
+    }
+
     Context 'Targeting a single profile' {
         It "Reports <ProblemCount> problem(s) with <Script> on <OS> with PowerShell <Version> targeting <Target>" -TestCases $TypeCompatibilityTestCases {
             param($Script, [string]$Target, [string[]]$Types, [version]$Version, [string]$OS, [int]$ProblemCount)

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -137,6 +137,13 @@ function Invoke-AppveyorTest {
     # Run all tests
     Import-Module PSScriptAnalyzer
     Import-Module Pester
+
+    Write-Verbose -Verbose "Module versions:"
+    Get-Module PSScriptAnalyzer,Pester,PowershellGet -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            Write-Verbose -Verbose "$($_.Name): $($_.Version)"
+        }
+
     $configuration = [PesterConfiguration]::Default
     $configuration.CodeCoverage.Enabled = $false
     $configuration.Output.Verbosity = 'Normal'

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -4,7 +4,7 @@
 $ErrorActionPreference = 'Stop'
 
 function Install-Pester {
-    $requiredPesterVersion = '5.0.2'
+    $requiredPesterVersion = '5.2.2'
     $pester = Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq $requiredPesterVersion }
     if ($null -eq $pester) {
         if ($null -eq (Get-Module -ListAvailable PowershellGet)) {
@@ -15,9 +15,12 @@ function Install-Pester {
         else {
             # Visual Studio 2017 build (has already Pester v3, therefore a different installation mechanism is needed to make it also use the new version 4)
             Write-Verbose -Verbose "Installing Pester via Install-Module"
-            Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser -Repository PSGallery
+            $installedPester = Install-Module -Name Pester -Force -SkipPublisherCheck -Scope CurrentUser -Repository PSGallery -Verbose -PassThru
         }
-        Write-Verbose -Verbose 'Installed Pester'
+
+        $pesterVersion = if ($installedPester) { $installedPester.Version } else { $requiredPesterVersion }
+
+        Write-Verbose -Verbose "Installed Pester version $pesterVersion"
     }
 }
 


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/PowerShell/PSScriptAnalyzer/issues/1695.

We've been seeing failures in the compatibility rule tests, such as in https://github.com/PowerShell/PSScriptAnalyzer/pull/1696. This seems to be due to a hashtable key being null, which would be explained by a Pester 5 semantics issue. This attempts to simplify the situation to fix the issue.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.