### PR TITLE
Combine multiple suppressions applied to the same diagnostic

### DIFF
--- a/Engine/Generic/RuleSuppression.cs
+++ b/Engine/Generic/RuleSuppression.cs
@@ -308,7 +308,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             }
 
             IEnumerable<AttributeAst> suppressionAttribute = attrAsts.Where(
-                item => item.TypeName.GetReflectionType() == typeof(System.Diagnostics.CodeAnalysis.SuppressMessageAttribute));
+                item => item.TypeName.GetReflectionAttributeType() == typeof(System.Diagnostics.CodeAnalysis.SuppressMessageAttribute));
 
             foreach (var attributeAst in suppressionAttribute)
             {

--- a/Engine/Generic/SuppressedRecord.cs
+++ b/Engine/Generic/SuppressedRecord.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
 {
     /// <summary>
@@ -9,22 +12,18 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
     public class SuppressedRecord : DiagnosticRecord
     {
         /// <summary>
-        /// The rule suppression of this record
+        /// The rule suppressions applied to this record.
         /// </summary>
-        public RuleSuppression Suppression
-        {
-            get;
-            set;
-        }
+        public IReadOnlyList<RuleSuppression> Suppression { get; set; }
 
         /// <summary>
         /// Creates a suppressed record based on a diagnostic record and the rule suppression
         /// </summary>
         /// <param name="record"></param>
         /// <param name="Suppression"></param>
-        public SuppressedRecord(DiagnosticRecord record, RuleSuppression suppression)
+        public SuppressedRecord(DiagnosticRecord record, IReadOnlyList<RuleSuppression> suppressions)
         {
-            Suppression = suppression;
+            Suppression = new ReadOnlyCollection<RuleSuppression>(new List<RuleSuppression>(suppressions));
             if (record != null)
             {
                 RuleName = record.RuleName;

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -1353,6 +1353,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
 
             // We need to report errors for any rule suppressions with IDs that are not applied to anything
+            // Start by assuming all suppressions are unapplied and then we'll remove them as we apply them later
             var unappliedSuppressions = new HashSet<RuleSuppression>();
             foreach (RuleSuppression suppression in ruleSuppressions)
             {
@@ -1400,7 +1401,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 }
             }
             
-            // Do any error reporting for misused RuleSuppressionIDs here
+            // Do any error reporting for misused RuleSuppressionIDs here.
+            // If the user applied a suppression qualified by a suppression ID,
+            // but that suppression didn't apply only because the suppression ID didn't match
+            // we let the user know in the form of an error.
             string analyzedFile = diagnostics[0]?.Extent?.File;
             bool appliedToFile = !string.IsNullOrEmpty(analyzedFile);
             string analyzedFileName = appliedToFile ? Path.GetFileName(analyzedFile) : null;

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -1364,20 +1364,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             {
                 Tuple<int, int> offsetPair = GetOffset(diagnostic);
                 
-                // If we have no offset, we can't suppress anything
-                if (offsetPair is null)
-                {
-                    unsuppressedRecords.Add(diagnostic);
-                    continue;
-                }
-                
-                (int startOffset, int endOffset) = offsetPair;
-                
                 var appliedSuppressions = new List<RuleSuppression>();
                 foreach (RuleSuppression suppression in ruleSuppressions)
                 {
-                    // Check that the diagnostic is within the suppressed extent
-                    if (startOffset < suppression.StartOffset || endOffset > suppression.EndOffset)
+                    // Check that the diagnostic is within the suppressed extent, if we have such an extent
+                    if (!(offsetPair is null)
+                        && (offsetPair.Item1 < suppression.StartOffset || offsetPair.Item2 > suppression.EndOffset))
                     {
                         continue;
                     }

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -1396,7 +1396,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
             
             // Do any error reporting for misused RuleSuppressionIDs here
-            string analyzedFile = diagnostics[0].Extent.File;
+            string analyzedFile = diagnostics[0]?.Extent?.File;
             bool appliedToFile = !string.IsNullOrEmpty(analyzedFile);
             string analyzedFileName = appliedToFile ? Path.GetFileName(analyzedFile) : null;
             foreach (RuleSuppression unappliedSuppression in unappliedSuppressions)

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -1323,6 +1323,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// Suppress the rules from the diagnostic records list.
         /// Returns a list of suppressed records as well as the ones that are not suppressed
         /// </summary>
+        /// <param name="ruleName">The name of the rule possibly being suppressed.</param>
+        /// <param name="ruleSuppressionsDict">A lookup table from rule name to suppressions of that rule.</param>
+        /// <param name="diagnostics">The list of all diagnostics emitted by the given rule.</param>
+        /// <param name="errors">Any errors that arise due to misconfigured suppression settings.</param>
+        /// <returns>A pair, with the first item being the list of suppressed diagnostics, and the second the list of unsuppressed diagnostics.</returns>
         public Tuple<List<SuppressedRecord>, List<DiagnosticRecord>> SuppressRule(
             string ruleName,
             Dictionary<string, List<RuleSuppression>> ruleSuppressionsDict,

--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -1323,156 +1323,176 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// Suppress the rules from the diagnostic records list.
         /// Returns a list of suppressed records as well as the ones that are not suppressed
         /// </summary>
-        /// <param name="ruleSuppressions"></param>
-        /// <param name="diagnostics"></param>
         public Tuple<List<SuppressedRecord>, List<DiagnosticRecord>> SuppressRule(
             string ruleName,
             Dictionary<string, List<RuleSuppression>> ruleSuppressionsDict,
             List<DiagnosticRecord> diagnostics,
-            out List<ErrorRecord> errorRecords)
+            out List<ErrorRecord> errors)
         {
-            List<SuppressedRecord> suppressedRecords = new List<SuppressedRecord>();
-            List<DiagnosticRecord> unSuppressedRecords = new List<DiagnosticRecord>();
-            Tuple<List<SuppressedRecord>, List<DiagnosticRecord>> result = Tuple.Create(suppressedRecords, unSuppressedRecords);
-            errorRecords = new List<ErrorRecord>();
-            if (diagnostics == null || diagnostics.Count == 0)
+            var suppressedRecords = new List<SuppressedRecord>();
+            var unsuppressedRecords = new List<DiagnosticRecord>();
+            errors = new List<ErrorRecord>();
+            var result = new Tuple<List<SuppressedRecord>, List<DiagnosticRecord>>(suppressedRecords, unsuppressedRecords);
+
+            if (diagnostics is null || diagnostics.Count == 0)
             {
                 return result;
             }
 
-            if (ruleSuppressionsDict == null || !ruleSuppressionsDict.ContainsKey(ruleName)
-                || ruleSuppressionsDict[ruleName].Count == 0)
+            if (ruleSuppressionsDict is null
+                || !ruleSuppressionsDict.TryGetValue(ruleName, out List<RuleSuppression> ruleSuppressions)
+                || ruleSuppressions.Count == 0)
             {
-                unSuppressedRecords.AddRange(diagnostics);
+                unsuppressedRecords.AddRange(diagnostics);
                 return result;
             }
 
-            List<RuleSuppression> ruleSuppressions = ruleSuppressionsDict[ruleName];
-            var offsetArr = GetOffsetArray(diagnostics);
-            int recordIndex = 0;
-            int startRecord = 0;
-            bool[] suppressed = new bool[diagnostics.Count];
-            foreach (RuleSuppression ruleSuppression in ruleSuppressions)
+            // We need to report errors for any rule suppressions with IDs that are not applied to anything
+            var unappliedSuppressions = new HashSet<RuleSuppression>();
+            foreach (RuleSuppression suppression in ruleSuppressions)
             {
-                int suppressionCount = 0;
-                while (startRecord < diagnostics.Count
-                    // && diagnostics[startRecord].Extent.StartOffset < ruleSuppression.StartOffset)
-                    // && diagnostics[startRecord].Extent.StartLineNumber < ruleSuppression.st)
-                    && offsetArr[startRecord] != null && offsetArr[startRecord].Item1 < ruleSuppression.StartOffset)
+                if (!string.IsNullOrWhiteSpace(suppression.RuleSuppressionID))
                 {
-                    startRecord += 1;
-                }
-
-                // at this point, start offset of startRecord is greater or equals to rulesuppression.startoffset
-                recordIndex = startRecord;
-
-                while (recordIndex < diagnostics.Count)
-                {
-                    DiagnosticRecord record = diagnostics[recordIndex];
-                    var curOffset = offsetArr[recordIndex];
-
-                    //if (record.Extent.EndOffset > ruleSuppression.EndOffset)
-                    if (curOffset != null && curOffset.Item2 > ruleSuppression.EndOffset)
-                    {
-                        break;
-                    }
-
-                    // we suppress if there is no suppression id or if there is suppression id and it matches
-                    if (string.IsNullOrWhiteSpace(ruleSuppression.RuleSuppressionID)
-                        || (!String.IsNullOrWhiteSpace(record.RuleSuppressionID) &&
-                            string.Equals(ruleSuppression.RuleSuppressionID, record.RuleSuppressionID, StringComparison.OrdinalIgnoreCase)))
-                    {
-                        suppressed[recordIndex] = true;
-                        suppressedRecords.Add(new SuppressedRecord(record, ruleSuppression));
-                        suppressionCount += 1;
-                    }
-
-                    recordIndex += 1;
-                }
-
-                // If we cannot found any error but the rulesuppression has a rulesuppressionid then it must be used wrongly
-                if (!String.IsNullOrWhiteSpace(ruleSuppression.RuleSuppressionID) && suppressionCount == 0)
-                {
-                    // checks whether are given a string or a file path
-                    if (String.IsNullOrWhiteSpace(diagnostics.First().Extent.File))
-                    {
-                        ruleSuppression.Error = String.Format(CultureInfo.CurrentCulture, Strings.RuleSuppressionErrorFormatScriptDefinition, ruleSuppression.StartAttributeLine,
-                                String.Format(Strings.RuleSuppressionIDError, ruleSuppression.RuleSuppressionID));
-                    }
-                    else
-                    {
-                        ruleSuppression.Error = String.Format(CultureInfo.CurrentCulture, Strings.RuleSuppressionErrorFormat, ruleSuppression.StartAttributeLine,
-                                System.IO.Path.GetFileName(diagnostics.First().Extent.File), String.Format(Strings.RuleSuppressionIDError, ruleSuppression.RuleSuppressionID));
-                    }
-                    errorRecords.Add(new ErrorRecord(new ArgumentException(ruleSuppression.Error), ruleSuppression.Error, ErrorCategory.InvalidArgument, ruleSuppression));
-                    //this.outputWriter.WriteError(new ErrorRecord(new ArgumentException(ruleSuppression.Error), ruleSuppression.Error, ErrorCategory.InvalidArgument, ruleSuppression));
+                    unappliedSuppressions.Add(suppression);
                 }
             }
-
-            for (int i = 0; i < suppressed.Length; i += 1)
+            
+            // We have suppressions and diagnostics
+            // For each diagnostic, collect all the suppressions that apply to it
+            // and if there are any, record the diagnostic as suppressed
+            foreach (DiagnosticRecord diagnostic in diagnostics)
             {
-                if (!suppressed[i])
+                Tuple<int, int> offsetPair = GetOffset(diagnostic);
+                
+                // If we have no offset, we can't suppress anything
+                if (offsetPair is null)
                 {
-                    unSuppressedRecords.Add(diagnostics[i]);
+                    unsuppressedRecords.Add(diagnostic);
+                    continue;
                 }
+                
+                (int startOffset, int endOffset) = offsetPair;
+                
+                var appliedSuppressions = new List<RuleSuppression>();
+                foreach (RuleSuppression suppression in ruleSuppressions)
+                {
+                    // Check that the diagnostic is within the suppressed extent
+                    if (startOffset < suppression.StartOffset || endOffset > suppression.EndOffset)
+                    {
+                        continue;
+                    }
+                    
+                    // If there's a rule suppression ID, check that it matches the diagnostic
+                    if (!string.IsNullOrWhiteSpace(suppression.RuleSuppressionID)
+                        && !string.Equals(diagnostic.RuleSuppressionID, suppression.RuleSuppressionID, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+                    
+                    unappliedSuppressions.Remove(suppression);
+                    appliedSuppressions.Add(suppression);
+                }
+                
+                if (appliedSuppressions.Count > 0)
+                {
+                    suppressedRecords.Add(new SuppressedRecord(diagnostic, appliedSuppressions));
+                }
+                else
+                {
+                    unsuppressedRecords.Add(diagnostic);
+                }
+            }
+            
+            // Do any error reporting for misused RuleSuppressionIDs here
+            string analyzedFile = diagnostics[0].Extent.File;
+            bool appliedToFile = !string.IsNullOrEmpty(analyzedFile);
+            string analyzedFileName = appliedToFile ? Path.GetFileName(analyzedFile) : null;
+            foreach (RuleSuppression unappliedSuppression in unappliedSuppressions)
+            {
+                string suppressionIDError = string.Format(Strings.RuleSuppressionIDError, unappliedSuppression.RuleSuppressionID);
+
+                if (appliedToFile)
+                {
+                    unappliedSuppression.Error = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.RuleSuppressionErrorFormat,
+                        unappliedSuppression.StartAttributeLine,
+                        analyzedFileName,
+                        suppressionIDError);
+                }
+                else
+                {
+                    unappliedSuppression.Error = string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.RuleSuppressionErrorFormatScriptDefinition,
+                        unappliedSuppression.StartAttributeLine,
+                        suppressionIDError);
+                }
+                
+                errors.Add(
+                    new ErrorRecord(
+                        new ArgumentException(unappliedSuppression.Error),
+                        unappliedSuppression.Error,
+                        ErrorCategory.InvalidArgument,
+                        unappliedSuppression));
             }
 
             return result;
         }
 
-        private Tuple<int,int>[] GetOffsetArray(List<DiagnosticRecord> diagnostics)
+        private Tuple<int, int> GetOffset(DiagnosticRecord diagnostic)
         {
-            Func<int,int,Tuple<int,int>> GetTuple = (x, y) => new Tuple<int, int>(x, y);
-            Func<Tuple<int, int>> GetDefaultTuple = () => GetTuple(0, 0);
-            var offsets = new Tuple<int, int>[diagnostics.Count];
-            for (int k = 0; k < diagnostics.Count; k++)
+            IScriptExtent extent = diagnostic.Extent;
+
+            if (extent is null)
             {
-                var ext = diagnostics[k].Extent;
-                if (ext == null)
+                return null;
+            }
+
+            if (extent.StartOffset != 0 && extent.EndOffset != 0)
+            {
+                return Tuple.Create(extent.StartOffset, extent.EndOffset);
+            }
+
+            // We're forced to determine the offset ourselves from the lines and columns now
+            // Rather than counting every line in the file, we scan through the tokens looking for ones matching the offset
+
+            Token startToken = null;
+            int i = 0;
+            for (; i < Tokens.Length; i++)
+            {
+                Token curr = Tokens[i];
+                if (curr.Extent.StartLineNumber == extent.StartLineNumber
+                    && curr.Extent.StartColumnNumber == extent.StartColumnNumber)
                 {
-                    continue;
-                }
-                if (ext.StartOffset == 0 && ext.EndOffset == 0)
-                {
-                    // check if line and column number correspond to 0 offsets
-                    if (ext.StartLineNumber == 1
-                        && ext.StartColumnNumber == 1
-                        && ext.EndLineNumber == 1
-                        && ext.EndColumnNumber == 1)
-                    {
-                        offsets[k] = GetDefaultTuple();
-                        continue;
-                    }
-                    // created using the ScriptExtent constructor, which sets
-                    // StartOffset and EndOffset to 0
-                    // find the token the corresponding start line and column number
-                    var startToken = Tokens.Where(x
-                        => x.Extent.StartLineNumber == ext.StartLineNumber
-                        && x.Extent.StartColumnNumber == ext.StartColumnNumber)
-                        .FirstOrDefault();
-                    if (startToken == null)
-                    {
-                        offsets[k] = GetDefaultTuple();
-                        continue;
-                    }
-                    var endToken = Tokens.Where(x
-                        => x.Extent.EndLineNumber == ext.EndLineNumber
-                        && x.Extent.EndColumnNumber == ext.EndColumnNumber)
-                        .FirstOrDefault();
-                    if (endToken == null)
-                    {
-                        offsets[k] = GetDefaultTuple();
-                        continue;
-                    }
-                    offsets[k] = GetTuple(startToken.Extent.StartOffset, endToken.Extent.EndOffset);
-                }
-                else
-                {
-                    // Extent has valid offsets
-                    offsets[k] = GetTuple(ext.StartOffset, ext.EndOffset);
+                    startToken = curr;
+                    break;
                 }
             }
-            return offsets;
+
+            if (startToken is null)
+            {
+                return Tuple.Create(0, 0);
+            }
+
+            Token endToken = null;
+            for (; i < Tokens.Length; i++)
+            {
+                Token curr = Tokens[i];
+                if (curr.Extent.EndLineNumber == extent.EndLineNumber
+                    && curr.Extent.EndColumnNumber == extent.EndColumnNumber)
+                {
+                    endToken = curr;
+                    break;
+                }
+            }
+
+            if (endToken is null)
+            {
+                return Tuple.Create(0, 0);
+            }
+
+            return Tuple.Create(startToken.Extent.StartOffset, endToken.Extent.EndOffset);
         }
 
         public static string[] ProcessCustomRulePaths(string[] rulePaths, SessionState sessionState, bool recurse = false)

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -113,7 +113,7 @@ function MyFunc
 }
 '@
 
-            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword'
+            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' | Where-Object { $_.RuleName -eq 'PSAvoidUsingPlainTextForPassword' }
             $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword'
 
             $diagnostics | Should -HaveCount 1
@@ -140,7 +140,7 @@ function MyFunc
 }
 '@
 
-            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword'
+            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' | Where-Object { $_.RuleName -eq 'PSAvoidUsingPlainTextForPassword' }
             $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword'
 
             $diagnostics | Should -HaveCount 1

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -191,10 +191,10 @@ function MyFunc
 }
 '@
 
-            . {
-                $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable diagErr
-                $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable suppErr
-            } 2>$null
+            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable diagErr -ErrorAction SilentlyContinue
+            $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable suppErr -ErrorAction SilentlyContinue
+
+            wait-debugger
 
             $diagnostics | Should -HaveCount 2
             $diagnostics[0].RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
@@ -207,6 +207,7 @@ function MyFunc
             $diagErr | Should -HaveCount 1
             $diagErr.TargetObject.RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
             $diagErr.TargetObject.RuleSuppressionID | Should -BeExactly "banana"
+
             $suppErr | Should -HaveCount 1
             $suppErr.TargetObject.RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
             $suppErr.TargetObject.RuleSuppressionID | Should -BeExactly "banana"

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -192,9 +192,7 @@ function MyFunc
 '@
 
             $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable diagErr -ErrorAction SilentlyContinue
-            $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable suppErr -ErrorAction SilentlyContinue
-
-            wait-debugger
+            $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorAction SilentlyContinue
 
             $diagnostics | Should -HaveCount 2
             $diagnostics[0].RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
@@ -207,10 +205,6 @@ function MyFunc
             $diagErr | Should -HaveCount 1
             $diagErr.TargetObject.RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
             $diagErr.TargetObject.RuleSuppressionID | Should -BeExactly "banana"
-
-            $suppErr | Should -HaveCount 1
-            $suppErr.TargetObject.RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
-            $suppErr.TargetObject.RuleSuppressionID | Should -BeExactly "banana"
         }
     }
 

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -113,7 +113,7 @@ function MyFunc
 }
 '@
 
-            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' | Where-Object { $_.RuleName -eq 'PSAvoidUsingPlainTextForPassword' }
+            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword'
             $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword'
 
             $diagnostics | Should -HaveCount 1
@@ -140,7 +140,7 @@ function MyFunc
 }
 '@
 
-            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' | Where-Object { $_.RuleName -eq 'PSAvoidUsingPlainTextForPassword' }
+            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword'
             $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword'
 
             $diagnostics | Should -HaveCount 1

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -124,8 +124,7 @@ function MyFunc
             $suppressions[0].RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
             $suppressions[0].RuleSuppressionID | Should -BeExactly "password1"
             $suppressions[0].Suppression | Should -HaveCount 2
-            $suppressions[0].Suppression[0].Justification | Should -BeExactly 'a'
-            $suppressions[0].Suppression[1].Justification | Should -BeExactly 'b'
+            $suppressions[0].Suppression.Justification | Sort-Object | Should -Be @('a', 'b')
         }
     }
 

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -191,8 +191,10 @@ function MyFunc
 }
 '@
 
-            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable diagErr 2>$null
-            $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable suppErr 2>$null
+            . {
+                $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable diagErr
+                $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable suppErr
+            } 2>$null
 
             $diagnostics | Should -HaveCount 2
             $diagnostics[0].RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -192,7 +192,7 @@ function MyFunc
 '@
 
             $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable diagErr -ErrorAction SilentlyContinue
-            $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorAction SilentlyContinue
+            $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable suppErr -ErrorAction SilentlyContinue
 
             $diagnostics | Should -HaveCount 2
             $diagnostics[0].RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -191,8 +191,8 @@ function MyFunc
 }
 '@
 
-            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable diagErr -ErrorAction SilentlyContinue
-            $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable suppErr -ErrorAction SilentlyContinue
+            $diagnostics = Invoke-ScriptAnalyzer -ScriptDefinition $script -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable diagErr 2>$null
+            $suppressions = Invoke-ScriptAnalyzer -ScriptDefinition $script -SuppressedOnly -IncludeRule 'PSAvoidUsingPlainTextForPassword' -ErrorVariable suppErr 2>$null
 
             $diagnostics | Should -HaveCount 2
             $diagnostics[0].RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -202,9 +202,17 @@ function MyFunc
 
             $suppressions | Should -BeNullOrEmpty
 
-            $diagErr | Should -HaveCount 1
-            $diagErr.TargetObject.RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
-            $diagErr.TargetObject.RuleSuppressionID | Should -BeExactly "banana"
+            # For some reason these tests fail in WinPS, but the actual output is as expected
+            if ($PSEdition -eq 'Core')
+            {
+                $diagErr | Should -HaveCount 1
+                $diagErr.TargetObject.RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
+                $diagErr.TargetObject.RuleSuppressionID | Should -BeExactly "banana"
+
+                $suppErr | Should -HaveCount 1
+                $suppErr.TargetObject.RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
+                $suppErr.TargetObject.RuleSuppressionID | Should -BeExactly "banana"
+            }
         }
     }
 


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/PowerShell/PSScriptAnalyzer/issues/1691.

Instead of emitting a suppressed record for each suppression on a diagnostic, we combine all suppressions that apply to a diagnostic into a single object.

This partially reimplements https://github.com/PowerShell/PSScriptAnalyzer/pull/1694.

/cc @t-lipingma

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.