### PR TITLE
Implement -IncludeSuppressions parameter

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                     WriteToOutput(diagnosticsList);
                 }
             }
-            else if (String.Equals(this.ParameterSetName, "ScriptDefinition", StringComparison.OrdinalIgnoreCase))
+            else
             {
                 diagnosticsList = ScriptAnalyzer.Instance.AnalyzeScriptDefinition(scriptDefinition, out _, out _);
                 WriteToOutput(diagnosticsList);
@@ -517,10 +517,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             }
         }
 
-        private bool IsFileParameterSet()
-        {
-            return String.Equals(this.ParameterSetName, "File", StringComparison.OrdinalIgnoreCase);
-        }
+        private bool IsFileParameterSet() => Path is not null;
 
         private bool OverrideSwitchParam(bool paramValue, string paramName)
         {

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -21,11 +21,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
     /// </summary>
     [Cmdlet(VerbsLifecycle.Invoke,
         "ScriptAnalyzer",
-        DefaultParameterSetName = "File",
+        DefaultParameterSetName = ParameterSet_File_IncludeSuppressed,
         SupportsShouldProcess = true,
         HelpUri = "https://go.microsoft.com/fwlink/?LinkId=525914")]
-    [OutputType(typeof(DiagnosticRecord))]
-    [OutputType(typeof(SuppressedRecord))]
+    [OutputType(typeof(DiagnosticRecord), typeof(SuppressedRecord))]
     public class InvokeScriptAnalyzerCommand : PSCmdlet, IOutputWriter
     {
         private const string ParameterSet_File_SuppressedOnly = "File_SuppressedOnly";

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -29,11 +29,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
     public class InvokeScriptAnalyzerCommand : PSCmdlet, IOutputWriter
     {
         private const string ParameterSet_File_SuppressedOnly = "File_SuppressedOnly";
-
         private const string ParameterSet_File_IncludeSuppressed = "File_IncludeSuppressed";
-
         private const string ParameterSet_Inline_SuppressedOnly = "Inline_SuppressedOnly";
-
         private const string ParameterSet_Inline_IncludeSuppressed = "Inline_IncludeSuppressed";
 
         #region Private variables

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
     /// </summary>
     [Cmdlet(VerbsLifecycle.Invoke,
         "ScriptAnalyzer",
-        DefaultParameterSetName = ParameterSet_File_IncludeSuppressed,
+        DefaultParameterSetName = ParameterSet_File_SuppressedOnly,
         SupportsShouldProcess = true,
         HelpUri = "https://go.microsoft.com/fwlink/?LinkId=525914")]
     [OutputType(typeof(DiagnosticRecord), typeof(SuppressedRecord))]
@@ -177,8 +177,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         /// <summary>
         /// Include suppressed diagnostics in the output.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSet_File_IncludeSuppressed)]
-        [Parameter(ParameterSetName = ParameterSet_Inline_IncludeSuppressed)]
+        [Parameter(ParameterSetName = ParameterSet_File_IncludeSuppressed, Mandatory = true)]
+        [Parameter(ParameterSetName = ParameterSet_Inline_IncludeSuppressed, Mandatory = true)]
         public SwitchParameter IncludeSuppressed { get; set; }
 
         /// <summary>

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -21,16 +21,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
     /// </summary>
     [Cmdlet(VerbsLifecycle.Invoke,
         "ScriptAnalyzer",
-        DefaultParameterSetName = ParameterSet_File_SuppressedOnly,
+        DefaultParameterSetName = ParameterSet_Path_SuppressedOnly,
         SupportsShouldProcess = true,
         HelpUri = "https://go.microsoft.com/fwlink/?LinkId=525914")]
     [OutputType(typeof(DiagnosticRecord), typeof(SuppressedRecord))]
     public class InvokeScriptAnalyzerCommand : PSCmdlet, IOutputWriter
     {
-        private const string ParameterSet_File_SuppressedOnly = "File_SuppressedOnly";
-        private const string ParameterSet_File_IncludeSuppressed = "File_IncludeSuppressed";
-        private const string ParameterSet_Inline_SuppressedOnly = "Inline_SuppressedOnly";
-        private const string ParameterSet_Inline_IncludeSuppressed = "Inline_IncludeSuppressed";
+        private const string ParameterSet_Path_SuppressedOnly = nameof(Path) + "_" + nameof(SuppressedOnly);
+        private const string ParameterSet_Path_IncludeSuppressed = nameof(Path) + "_" + nameof(IncludeSuppressed);
+        private const string ParameterSet_ScriptDefinition_SuppressedOnly = nameof(ScriptDefinition) + "_" + nameof(SuppressedOnly);
+        private const string ParameterSet_ScriptDefinition_IncludeSuppressed = nameof(ScriptDefinition) + "_" + nameof(IncludeSuppressed);
 
         #region Private variables
         List<string> processedPaths;
@@ -41,12 +41,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         /// Path: The path to the file or folder to invoke PSScriptAnalyzer on.
         /// </summary>
         [Parameter(Position = 0,
-            ParameterSetName = ParameterSet_File_IncludeSuppressed,
+            ParameterSetName = ParameterSet_Path_IncludeSuppressed,
             Mandatory = true,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         [Parameter(Position = 0,
-            ParameterSetName = ParameterSet_File_SuppressedOnly,
+            ParameterSetName = ParameterSet_Path_SuppressedOnly,
             Mandatory = true,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
@@ -63,12 +63,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         /// ScriptDefinition: a script definition in the form of a string to run rules on.
         /// </summary>
         [Parameter(Position = 0,
-            ParameterSetName = ParameterSet_Inline_IncludeSuppressed,
+            ParameterSetName = ParameterSet_ScriptDefinition_IncludeSuppressed,
             Mandatory = true,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         [Parameter(Position = 0,
-            ParameterSetName = ParameterSet_Inline_SuppressedOnly,
+            ParameterSetName = ParameterSet_ScriptDefinition_SuppressedOnly,
             Mandatory = true,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
@@ -158,8 +158,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         /// <summary>
         /// Recurse: Apply to all files within subfolders under the path
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSet_File_IncludeSuppressed)]
-        [Parameter(ParameterSetName = ParameterSet_File_SuppressedOnly)]
+        [Parameter(ParameterSetName = ParameterSet_Path_IncludeSuppressed)]
+        [Parameter(ParameterSetName = ParameterSet_Path_SuppressedOnly)]
         public SwitchParameter Recurse
         {
             get { return recurse; }
@@ -170,21 +170,22 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         /// <summary>
         /// ShowSuppressed: Show the suppressed message
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSet_File_SuppressedOnly)]
-        [Parameter(ParameterSetName = ParameterSet_Inline_SuppressedOnly)]
+        [Parameter(ParameterSetName = ParameterSet_Path_SuppressedOnly)]
+        [Parameter(ParameterSetName = ParameterSet_ScriptDefinition_SuppressedOnly)]
         public SwitchParameter SuppressedOnly { get; set; }
 
         /// <summary>
         /// Include suppressed diagnostics in the output.
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSet_File_IncludeSuppressed, Mandatory = true)]
-        [Parameter(ParameterSetName = ParameterSet_Inline_IncludeSuppressed, Mandatory = true)]
+        [Parameter(ParameterSetName = ParameterSet_Path_IncludeSuppressed, Mandatory = true)]
+        [Parameter(ParameterSetName = ParameterSet_ScriptDefinition_IncludeSuppressed, Mandatory = true)]
         public SwitchParameter IncludeSuppressed { get; set; }
 
         /// <summary>
         /// Resolves rule violations automatically where possible.
         /// </summary>
-        [Parameter(Mandatory = false, ParameterSetName = "File")]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_Path_IncludeSuppressed)]
+        [Parameter(Mandatory = false, ParameterSetName = ParameterSet_Path_SuppressedOnly)]
         public SwitchParameter Fix
         {
             get { return fix; }

--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -155,11 +155,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         }
         private string[] severity;
 
+        // TODO: This should be only in the Path parameter sets, and is ignored otherwise,
+        //       but we already have a test that depends on it being otherwise
+        //[Parameter(ParameterSetName = ParameterSet_Path_IncludeSuppressed)]
+        //[Parameter(ParameterSetName = ParameterSet_Path_SuppressedOnly)]
+        //
         /// <summary>
         /// Recurse: Apply to all files within subfolders under the path
         /// </summary>
-        [Parameter(ParameterSetName = ParameterSet_Path_IncludeSuppressed)]
-        [Parameter(ParameterSetName = ParameterSet_Path_SuppressedOnly)]
+        [Parameter]
         public SwitchParameter Recurse
         {
             get { return recurse; }

--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -7,6 +7,7 @@
     <AssemblyVersion>1.20.0</AssemblyVersion>
     <PackageId>Engine</PackageId>
     <RootNamespace>Microsoft.Windows.PowerShell.ScriptAnalyzer</RootNamespace> <!-- Namespace needs to match Assembly name for ressource binding -->
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/Engine/Formatter.cs
+++ b/Engine/Formatter.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
                 var currentSettings = GetCurrentSettings(settings, rule);
                 ScriptAnalyzer.Instance.UpdateSettings(currentSettings);
-                ScriptAnalyzer.Instance.Initialize(cmdlet, null, null, null, null, true, false);
+                ScriptAnalyzer.Instance.Initialize(cmdlet, null, null, null, null, true, SuppressionPreference.Omit);
 
                 text = ScriptAnalyzer.Instance.Fix(text, range, skipParsing, out Range updatedRange, out bool fixesWereApplied, ref scriptAst, ref scriptTokens, skipVariableAnalysis: true);
                 skipParsing = !fixesWereApplied;

--- a/Engine/Generic/DiagnosticRecord.cs
+++ b/Engine/Generic/DiagnosticRecord.cs
@@ -92,12 +92,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             set { suggestedCorrections = value; }
         }
 
+        public bool IsSuppressed { get; protected set; } = false;
+
         /// <summary>
         /// DiagnosticRecord: The constructor for DiagnosticRecord class.
         /// </summary>
         public DiagnosticRecord()
         {
-
         }
         
         /// <summary>
@@ -109,7 +110,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         /// <param name="severity">The severity of this diagnostic</param>
         /// <param name="scriptPath">The full path of the script file being analyzed</param>
         /// <param name="suggestedCorrections">The correction suggested by the rule to replace the extent text</param>
-        public DiagnosticRecord(string message, IScriptExtent extent, string ruleName, DiagnosticSeverity severity, string scriptPath, string ruleId = null, IEnumerable<CorrectionExtent> suggestedCorrections = null)
+        public DiagnosticRecord(
+            string message,
+            IScriptExtent extent,
+            string ruleName,
+            DiagnosticSeverity severity,
+            string scriptPath,
+            string ruleId = null,
+            IEnumerable<CorrectionExtent> suggestedCorrections = null)
         {
             Message  = message;
             RuleName = ruleName;
@@ -119,7 +127,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             RuleSuppressionID = ruleId;
             this.suggestedCorrections = suggestedCorrections;
         }
-
     }
 
 

--- a/Engine/Generic/SuppressedRecord.cs
+++ b/Engine/Generic/SuppressedRecord.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         public SuppressedRecord(DiagnosticRecord record, IReadOnlyList<RuleSuppression> suppressions)
         {
             Suppression = new ReadOnlyCollection<RuleSuppression>(new List<RuleSuppression>(suppressions));
+            IsSuppressed = true;
             if (record != null)
             {
                 RuleName = record.RuleName;

--- a/README.md
+++ b/README.md
@@ -54,9 +54,25 @@ Usage
 ``` PowerShell
 Get-ScriptAnalyzerRule [-CustomRulePath <String[]>] [-RecurseCustomRulePath] [-Name <String[]>] [-Severity <String[]>] [<CommonParameters>]
 
-Invoke-ScriptAnalyzer [-Path] <String> [-CustomRulePath <String[]>] [-RecurseCustomRulePath] [-ExcludeRule <String[]>] [-IncludeDefaultRules] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-Fix] [-EnableExit] [-ReportSummary] [-Settings <Object>] [-SaveDscDependency] [<CommonParameters>]
+Invoke-ScriptAnalyzer [-Path] <String> [-CustomRulePath <String[]>] [-RecurseCustomRulePath]
+ [-IncludeDefaultRules] [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse]
+ [-SuppressedOnly] [-Fix] [-EnableExit] [-Settings <Object>] [-SaveDscDependency] [-ReportSummary] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 
-Invoke-ScriptAnalyzer [-ScriptDefinition] <String> [-CustomRulePath <String[]>] [-RecurseCustomRulePath] [-ExcludeRule <String[]>] [-IncludeDefaultRules] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-EnableExit] [-ReportSummary] [-Settings <Object>] [-SaveDscDependency] [<CommonParameters>]
+Invoke-ScriptAnalyzer [-Path] <String> [-CustomRulePath <String[]>] [-RecurseCustomRulePath]
+ [-IncludeDefaultRules] [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse]
+ [-IncludeSuppressed] [-Fix] [-EnableExit] [-Settings <Object>] [-SaveDscDependency] [-ReportSummary] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+
+Invoke-ScriptAnalyzer [-ScriptDefinition] <String> [-CustomRulePath <String[]>] [-RecurseCustomRulePath]
+ [-IncludeDefaultRules] [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>]
+ [-IncludeSuppressed] [-EnableExit] [-Settings <Object>] [-SaveDscDependency] [-ReportSummary] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+
+Invoke-ScriptAnalyzer [-ScriptDefinition] <String> [-CustomRulePath <String[]>] [-RecurseCustomRulePath]
+ [-IncludeDefaultRules] [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>]
+ [-SuppressedOnly] [-EnableExit] [-Settings <Object>] [-SaveDscDependency] [-ReportSummary] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 
 Invoke-Formatter [-ScriptDefinition] <String> [[-Settings] <Object>] [[-Range] <Int32[]>] [<CommonParameters>]
 ```

--- a/Tests/DisabledRules/AvoidOneChar.tests.ps1
+++ b/Tests/DisabledRules/AvoidOneChar.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$oneCharMessage = "The cmdlet name O only has one character."
+﻿$oneCharMessage = "The cmdlet name O only has one character."
 $oneCharName = "PSOneChar"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $invoke = Invoke-ScriptAnalyzer $directory\AvoidUsingReservedCharOneCharNames.ps1 | Where-Object {$_.RuleName -eq $oneCharName}

--- a/Tests/DisabledRules/AvoidTrapStatements.tests.ps1
+++ b/Tests/DisabledRules/AvoidTrapStatements.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = "Trap found."
+﻿$violationMessage = "Trap found."
 $violationName = "PSAvoidTrapStatement"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidTrapStatements.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/DisabledRules/AvoidUnloadableModule.tests.ps1
+++ b/Tests/DisabledRules/AvoidUnloadableModule.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer 
-$unloadableMessage = [regex]::Escape("Cannot load the module TestBadModule that the file TestBadModule.psd1 is in.")
+﻿$unloadableMessage = [regex]::Escape("Cannot load the module TestBadModule that the file TestBadModule.psd1 is in.")
 $unloadableName = "PSAvoidUnloadableModule"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\TestBadModule\TestBadModule.psd1 | Where-Object {$_.RuleName -eq $unloadableName}

--- a/Tests/DisabledRules/AvoidUsingClearHost.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingClearHost.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-Set-Alias ctss ConvertTo-SecureString
+﻿Set-Alias ctss ConvertTo-SecureString
 $clearHostMessage = "File 'AvoidUsingClearHostWriteHost.ps1' uses Clear-Host. This is not recommended because it may not work in some hosts or there may even be no hosts at all."
 $clearHostName = "PSAvoidUsingClearHost"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingFilePath.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = @'
+﻿$violationMessage = @'
 The file path "D:\\Code" of AvoidUsingFilePath.ps1 is rooted. This should be avoided if AvoidUsingFilePath.ps1 is published online
 '@
 $violationUNCMessage = @'

--- a/Tests/DisabledRules/AvoidUsingInternalURLs.tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingInternalURLs.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = "could be an internal URL. Using internal URL directly in the script may cause potential information disclosure."
+﻿$violationMessage = "could be an internal URL. Using internal URL directly in the script may cause potential information disclosure."
 $violationName = "PSAvoidUsingInternalURLs"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidUsingInternalURLs.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/DisabledRules/AvoidUsingUninitializedVariable.Tests.ps1
+++ b/Tests/DisabledRules/AvoidUsingUninitializedVariable.Tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$AvoidUninitializedVariable = "PSAvoidUninitializedVariable"
+﻿$AvoidUninitializedVariable = "PSAvoidUninitializedVariable"
 $violationMessage = "Variable 'MyVerbosePreference' is not initialized. Non-global variables must be initialized. To fix a violation of this rule, please initialize non-global variables."
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\AvoidUsingUninitializedVariable.ps1 -IncludeRule $AvoidUninitializedVariable
@@ -12,7 +11,7 @@ Describe "AvoidUsingUninitializedVariable" {
         }
 
         It "has the correct description message for UninitializedVariable rule violation" {
-            $violations[0].Message | Should -Be $violationMessage            
+            $violations[0].Message | Should -Be $violationMessage
         }
     }
 

--- a/Tests/DisabledRules/CommandNotFound.tests.ps1
+++ b/Tests/DisabledRules/CommandNotFound.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module -Verbose ScriptAnalyzer
-$violationMessage = "Command Get-WrongCommand Is Not Found"
+﻿$violationMessage = "Command Get-WrongCommand Is Not Found"
 $violationName = "PSCommandNotFound"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\CommandNotFound.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/DisabledRules/ProvideVerboseMessage.tests.ps1
+++ b/Tests/DisabledRules/ProvideVerboseMessage.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module PSScriptAnalyzer
-$violationMessage = [regex]::Escape("There is no call to Write-Verbose in the function 'Verb-Files'.")
+﻿$violationMessage = [regex]::Escape("There is no call to Write-Verbose in the function 'Verb-Files'.")
 $violationName = "PSProvideVerboseMessage"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\BadCmdlet.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/DisabledRules/TypeNotFound.tests.ps1
+++ b/Tests/DisabledRules/TypeNotFound.tests.ps1
@@ -1,5 +1,4 @@
-﻿Import-Module -Verbose PSScriptAnalyzer
-$violationMessage = "Type Stre is not found"
+﻿$violationMessage = "Type Stre is not found"
 $violationName = "PSTypeNotFound"
 $directory = Split-Path -Parent $MyInvocation.MyCommand.Path
 $violations = Invoke-ScriptAnalyzer $directory\TypeNotFound.ps1 | Where-Object {$_.RuleName -eq $violationName}

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -10,6 +10,15 @@ BeforeAll {
     $useRules = "PSUse*"
 }
 
+Describe "PSScriptAnalyzer module being tested" {
+    It "Is the development asset" {
+        $repoRoot = Split-Path (Split-Path $PSScriptRoot)
+        $outDir = Join-Path $repoRoot 'out'
+        $modulePath = (Get-Module -Name PSScriptAnalyzer).Path
+        $modulePath.StartsWith($outDir) | Should -BeTrue -Because 'PSScriptAnalyzer module path should be under the output directory'
+    }
+}
+
 Describe "Test available parameters" {
     BeforeAll {
         $params = $sa.Parameters

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -629,6 +629,16 @@ Describe "Test -EnableExit Switch" {
 
 Describe 'Suppression switch parameter sets' {
     It 'Should not allow both suppression switches to be used' {
-        { Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -IncludeSuppressed -SuppressedOnly } | Should -Throw -ErrorId 'AmbiguousParameterSet,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand'
+        try
+        {
+            Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -IncludeSuppressed -SuppressedOnly
+        }
+        catch
+        {
+            $errorId = $_.FullyQualifiedErrorId
+        }
+
+        $errorId = $errorId.Substring(0, $errorId.IndexOf(','))
+        $errorId | Should -BeExactly 'AmbiguousParameterSet'
     }
 }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -83,21 +83,15 @@ Describe "Test available parameters" {
         }
     }
 
-    Context "It has 2 parameter sets: File and ScriptDefinition" {
-        It "Has 4 parameter sets" {
-            $sa.ParameterSets.Count | Should -Be 4
-        }
+    It "Has 4 parameter sets" {
+        $parameterSets = @(
+            'Path_IncludeSuppressed'
+            'Path_SuppressedOnly'
+            'ScriptDefinition_IncludeSuppressed'
+            'ScriptDefinition_SuppressedOnly'
+        )
 
-        It "Has <SetName> parameter set" -TestCases @(
-            @{ SetName = "File_IncludeSuppressions" }
-            @{ SetName = "File_SuppressedOnly" }
-            @{ SetName = "Inline_IncludeSuppressions" }
-            @{ SetName = "Inline_SuppressedOnly" }
-        ) {
-            param([string]$SetName)
-
-            $sa.ParameterSets | Select-Object -ExpandProperty Name | Should -Contain $SetName
-        }
+        $sa.ParameterSets | Select-Object -ExpandProperty Name | Sort-Object | Should -Be $parameterSets
     }
 }
 

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -566,13 +566,17 @@ Describe "Test -EnableExit Switch" {
             $pwshExe = 'powershell'
         }
 
-        & $pwshExe -Command 'Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit'
+        $pssaPath = (Get-Module PSScriptAnalyzer).Path
+
+        & $pwshExe -Command "Import-Module '$pssaPath'; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit"
 
         $LASTEXITCODE  | Should -Be 1
     }
 
     Describe "-ReportSummary switch" {
         BeforeAll {
+            $pssaPath = (Get-Module PSScriptAnalyzer).Path
+
             if ($IsCoreCLR)
             {
                 $pwshExe = (Get-Process -Id $PID).Path
@@ -586,12 +590,12 @@ Describe "Test -EnableExit Switch" {
         }
 
         It "prints the correct report summary using the -NoReportSummary switch" {
-            $result = & $pwshExe -Command 'Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -ScriptDefinition gci -ReportSummary'
+            $result = & $pwshExe -Command "Import-Module '$pssaPath'; Invoke-ScriptAnalyzer -ScriptDefinition gci -ReportSummary"
 
             "$result" | Should -BeLike $reportSummaryFor1Warning
         }
         It "does not print the report summary when not using -NoReportSummary switch" {
-            $result = & $pwshExe -Command 'Import-Module PSScriptAnalyzer; Invoke-ScriptAnalyzer -ScriptDefinition gci'
+            $result = & $pwshExe -Command "Import-Module '$pssaPath'; Invoke-ScriptAnalyzer -ScriptDefinition gci"
 
             "$result" | Should -Not -BeLike $reportSummaryFor1Warning
         }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -84,34 +84,20 @@ Describe "Test available parameters" {
     }
 
     Context "It has 2 parameter sets: File and ScriptDefinition" {
-        It "Has 2 parameter sets" {
-            $sa.ParameterSets.Count | Should -Be 2
+        It "Has 4 parameter sets" {
+            $sa.ParameterSets.Count | Should -Be 4
         }
 
-        It "Has File parameter set" {
-            $hasFile = $false
-            foreach ($paramSet in $sa.ParameterSets) {
-                if ($paramSet.Name -eq "File") {
-                    $hasFile = $true
-                    break
-                }
-            }
+        It "Has <SetName> parameter set" -TestCases @(
+            @{ SetName = "File_IncludeSuppressions" }
+            @{ SetName = "File_SuppressedOnly" }
+            @{ SetName = "Inline_IncludeSuppressions" }
+            @{ SetName = "Inline_SuppressedOnly" }
+        ) {
+            param([string]$SetName)
 
-            $hasFile | Should -BeTrue
+            $sa.ParameterSets | Select-Object -ExpandProperty Name | Should -Contain $SetName
         }
-
-        It "Has ScriptDefinition parameter set" {
-            $hasFile = $false
-            foreach ($paramSet in $sa.ParameterSets) {
-                if ($paramSet.Name -eq "ScriptDefinition") {
-                    $hasFile = $true
-                    break
-                }
-            }
-
-            $hasFile | Should -BeTrue
-        }
-
     }
 }
 
@@ -638,5 +624,11 @@ Describe "Test -EnableExit Switch" {
             $scriptDefinition = 'class T { static [T]$i }; function foo { [CmdletBinding()] param () $script:T.WriteLog() }'
             Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -ErrorAction Stop | Should -BeNullOrEmpty
         }
+    }
+}
+
+Describe 'Suppression switch parameter sets' {
+    It 'Should not allow both suppression switches to be used' {
+        { Invoke-ScriptAnalyzer -ScriptDefinition 'gci' -IncludeSuppressed -SuppressedOnly } | Should -Throw -ErrorId 'AmbiguousParameterSet,Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands.InvokeScriptAnalyzerCommand'
     }
 }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -10,6 +10,7 @@ BeforeAll {
     $useRules = "PSUse*"
 
     # Dump out Invoke-ScriptAnalyzer info to debug weird failures
+    Write-Verbose -Verbose "Command: $($sa)"
     Write-Verbose -Verbose "Module: $($sa.Module.Path)"
     Write-Verbose -Verbose "Version: $($sa.Module.Version)"
 }

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -10,8 +10,8 @@ BeforeAll {
     $useRules = "PSUse*"
 
     # Dump out Invoke-ScriptAnalyzer info to debug weird failures
-    Write-Verbose -Verbose "Module:" ($sa.Module.Path)
-    Write-Verbose -Verbose "Version:" ($sa.Module.Version)
+    Write-Verbose -Verbose "Module: $($sa.Module.Path)"
+    Write-Verbose -Verbose "Version: $($sa.Module.Version)"
 }
 
 Describe "Test available parameters" {

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -8,15 +8,10 @@ BeforeAll {
     $rules = Get-ScriptAnalyzerRule -Name ($singularNouns, "PSUseApprovedVerbs")
     $avoidRules = Get-ScriptAnalyzerRule -Name "PSAvoid*"
     $useRules = "PSUse*"
-}
 
-Describe "PSScriptAnalyzer module being tested" {
-    It "Is the development asset" {
-        $repoRoot = Split-Path (Split-Path $PSScriptRoot)
-        $outDir = Join-Path $repoRoot 'out'
-        $modulePath = (Get-Module -Name PSScriptAnalyzer).Path
-        $modulePath.StartsWith($outDir) | Should -BeTrue -Because 'PSScriptAnalyzer module path should be under the output directory'
-    }
+    # Dump out Invoke-ScriptAnalyzer info to debug weird failures
+    Write-Verbose -Verbose "Module:" ($sa.Module.Path)
+    Write-Verbose -Verbose "Version:" ($sa.Module.Version)
 }
 
 Describe "Test available parameters" {

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -2,17 +2,14 @@
 # Licensed under the MIT License.
 
 BeforeAll {
+    # NOTE: We also run these tests with a custom Invoke-ScriptAnalyzer function defined in LibraryUsage.Tests.ps1
+    #       This can cause issues if the cmdlet is updated and the function isn't
     $sa = Get-Command Invoke-ScriptAnalyzer
     $singularNouns = "PSUseSingularNouns"
     $approvedVerb = "PSUseApprovedVerbs"
     $rules = Get-ScriptAnalyzerRule -Name ($singularNouns, "PSUseApprovedVerbs")
     $avoidRules = Get-ScriptAnalyzerRule -Name "PSAvoid*"
     $useRules = "PSUse*"
-
-    # Dump out Invoke-ScriptAnalyzer info to debug weird failures
-    Write-Verbose -Verbose "Command: $($sa)"
-    Write-Verbose -Verbose "Module: $($sa.Module.Path)"
-    Write-Verbose -Verbose "Version: $($sa.Module.Version)"
 }
 
 Describe "Test available parameters" {

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -83,21 +83,21 @@ Describe 'Library Usage' -Skip:$IsCoreCLR {
 				$IncludeSuppressed
 			);
 
-			if ($PSCmdlet.ParameterSetName -eq "File")
+			if ($Path)
 			{
 				$supportsShouldProcessFunc = [Func[string, string, bool]] { return $PSCmdlet.Shouldprocess }
-				if ($Fix.IsPresent)
+				if ($Fix)
 				{
-					$results = $scriptAnalyzer.AnalyzeAndFixPath($Path, $supportsShouldProcessFunc, $Recurse.IsPresent);
+					$results = $scriptAnalyzer.AnalyzeAndFixPath($Path, $supportsShouldProcessFunc, $Recurse);
 				}
 				else
 				{
-					$results = $scriptAnalyzer.AnalyzePath($Path, $supportsShouldProcessFunc, $Recurse.IsPresent);
+					$results = $scriptAnalyzer.AnalyzePath($Path, $supportsShouldProcessFunc, $Recurse);
 				}
 			}
 			else
 			{
-        $results = $scriptAnalyzer.AnalyzeScriptDefinition($ScriptDefinition, [ref] $null, [ref] $null)
+				$results = $scriptAnalyzer.AnalyzeScriptDefinition($ScriptDefinition, [ref] $null, [ref] $null)
 			}
 
 			$results

--- a/Tests/Engine/LibraryUsage.tests.ps1
+++ b/Tests/Engine/LibraryUsage.tests.ps1
@@ -7,13 +7,15 @@ Describe 'Library Usage' -Skip:$IsCoreCLR {
 		# wraps the usage of ScriptAnalyzer as a .NET library
 		function Invoke-ScriptAnalyzer {
 			param (
-				[CmdletBinding(DefaultParameterSetName="File", SupportsShouldProcess = $true)]
+				[CmdletBinding(DefaultParameterSetName="Path_SuppressedOnly", SupportsShouldProcess = $true)]
 
-				[parameter(Mandatory = $true, Position = 0, ParameterSetName="File")]
+				[parameter(Mandatory = $true, Position = 0, ParameterSetName="Path_SuppressedOnly")]
+				[parameter(Mandatory = $true, Position = 0, ParameterSetName="Path_IncludeSuppressed")]
 				[Alias("PSPath")]
 				[string] $Path,
 
-				[parameter(Mandatory = $true, ParameterSetName="ScriptDefinition")]
+				[parameter(Mandatory = $true, ParameterSetName="ScriptDefinition_SuppressedOnly")]
+				[parameter(Mandatory = $true, ParameterSetName="ScriptDefinition_IncludeSuppressed")]
 				[string] $ScriptDefinition,
 
 				[Parameter(Mandatory = $false)]
@@ -39,8 +41,13 @@ Describe 'Library Usage' -Skip:$IsCoreCLR {
 				[Parameter(Mandatory = $false)]
 				[switch] $IncludeDefaultRules,
 
-				[Parameter(Mandatory = $false)]
+				[Parameter(Mandatory = $false, ParameterSetName = "Path_SuppressedOnly")]
+				[Parameter(Mandatory = $false, ParameterSetName = "ScriptDefinition_SuppressedOnly")]
 				[switch] $SuppressedOnly,
+
+				[Parameter(Mandatory, ParameterSetName = "Path_IncludeSuppressed")]
+				[Parameter(Mandatory, ParameterSetName = "ScriptDefinition_IncludeSuppressed")]
+				[switch] $IncludeSuppressed,
 
 				[Parameter(Mandatory = $false)]
 				[switch] $Fix,
@@ -71,8 +78,9 @@ Describe 'Library Usage' -Skip:$IsCoreCLR {
 				$IncludeRule,
 				$ExcludeRule,
 				$Severity,
-				$IncludeDefaultRules.IsPresent,
-				$SuppressedOnly.IsPresent
+				$IncludeDefaultRules,
+				$SuppressedOnly,
+				$IncludeSuppressed
 			);
 
 			if ($PSCmdlet.ParameterSetName -eq "File")

--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -180,7 +180,7 @@ Describe 'Cmdlet parameter help' {
 			)
 
 			BEGIN {
-				$Common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable', 'WhatIf', 'Confirm'
+				$Common = 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable', 'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable'
 				$parameters = @()
 			}
 			PROCESS {

--- a/Tests/Engine/RuleSuppression.tests.ps1
+++ b/Tests/Engine/RuleSuppression.tests.ps1
@@ -119,8 +119,10 @@ function MyFunc
             $diagnostics | Should -HaveCount 1
             $diagnostics[0].RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
             $diagnostics[0].RuleSuppressionID | Should -BeExactly "password2"
+            $diagnostics[0].IsSuppressed | Should -BeFalse
 
             $suppressions | Should -HaveCount 1
+            $suppressions[0].IsSuppressed | Should -BeTrue
             $suppressions[0].RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
             $suppressions[0].RuleSuppressionID | Should -BeExactly "password1"
             $suppressions[0].Suppression | Should -HaveCount 2
@@ -172,11 +174,13 @@ function MyFunc
             $diagnostics | Should -HaveCount 2
             $diagnostics[0].RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
             $diagnostics[0].RuleSuppressionID | Should -BeExactly "password2"
+            $diagnostics[0].IsSuppressed | Should -BeFalse
 
             $diagnostics[1].RuleName | Should -BeExactly "PSAvoidUsingPlainTextForPassword"
             $diagnostics[1].RuleSuppressionID | Should -BeExactly "password1"
             $diagnostics[1].Suppression | Should -HaveCount 2
             $diagnostics[1].Suppression.Justification | Sort-Object | Should -Be @('a', 'a')
+            $diagnostics[1].IsSuppressed | Should -BeTrue
         }
 
 

--- a/Utils/RuleMaker.psm1
+++ b/Utils/RuleMaker.psm1
@@ -344,7 +344,6 @@ Function Add-RuleTest($Rule)
     $ruleTestFilePath = Get-RuleTestFilePath $Rule
     New-Item -Path $ruleTestFilePath -ItemType File
     $ruleTestTemplate = @'
-Import-Module PSScriptAnalyzer
 $ruleName = "{0}"
 
 Describe "{0}" {{

--- a/build.psm1
+++ b/build.psm1
@@ -388,7 +388,8 @@ function Test-ScriptAnalyzer
             }
             $savedModulePath = $env:PSModulePath
             $env:PSModulePath = "${testModulePath}{0}${env:PSModulePath}" -f [System.IO.Path]::PathSeparator
-            $scriptBlock = [scriptblock]::Create("Import-Module PSScriptAnalyzer; Invoke-Pester -Path $testScripts")
+            $analyzerPsd1Path = Join-Path -Path $script:destinationDir -ChildPath "$analyzerName.psd1"
+            $scriptBlock = [scriptblock]::Create("Import-Module '$analyzerPsd1Path'; Invoke-Pester -Path $testScripts")
             if ( $InProcess ) {
                 & $scriptBlock
             }

--- a/docs/markdown/Invoke-ScriptAnalyzer.md
+++ b/docs/markdown/Invoke-ScriptAnalyzer.md
@@ -1,26 +1,46 @@
 ---
 external help file: Microsoft.Windows.PowerShell.ScriptAnalyzer.dll-Help.xml
+Module Name: PSScriptAnalyzer
 schema: 2.0.0
 ---
 
 # Invoke-ScriptAnalyzer
+
 ## SYNOPSIS
 Evaluates a script or module based on selected best practice rules
 
 ## SYNTAX
 
-### UNNAMED_PARAMETER_SET_1
+### Path_SuppressedOnly (Default)
 ```
-Invoke-ScriptAnalyzer [-Path] <String> [-CustomRulePath <String>] [-RecurseCustomRulePath]
- [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-Fix] [-EnableExit] [-ReportSummary]
- [-Settings <String>]
+Invoke-ScriptAnalyzer [-Path] <String> [-CustomRulePath <String[]>] [-RecurseCustomRulePath]
+ [-IncludeDefaultRules] [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse]
+ [-SuppressedOnly] [-Fix] [-EnableExit] [-Settings <Object>] [-SaveDscDependency] [-ReportSummary] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
-### UNNAMED_PARAMETER_SET_2
+### Path_IncludeSuppressed
 ```
-Invoke-ScriptAnalyzer [-ScriptDefinition] <String> [-CustomRulePath <String>] [-RecurseCustomRulePath]
- [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse] [-SuppressedOnly] [-EnableExit] [-ReportSummary]
- [-Settings <String>]
+Invoke-ScriptAnalyzer [-Path] <String> [-CustomRulePath <String[]>] [-RecurseCustomRulePath]
+ [-IncludeDefaultRules] [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>] [-Recurse]
+ [-IncludeSuppressed] [-Fix] [-EnableExit] [-Settings <Object>] [-SaveDscDependency] [-ReportSummary] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+### ScriptDefinition_IncludeSuppressed
+```
+Invoke-ScriptAnalyzer [-ScriptDefinition] <String> [-CustomRulePath <String[]>] [-RecurseCustomRulePath]
+ [-IncludeDefaultRules] [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>]
+ [-IncludeSuppressed] [-EnableExit] [-Settings <Object>] [-SaveDscDependency] [-ReportSummary] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
+```
+
+### ScriptDefinition_SuppressedOnly
+```
+Invoke-ScriptAnalyzer [-ScriptDefinition] <String> [-CustomRulePath <String[]>] [-RecurseCustomRulePath]
+ [-IncludeDefaultRules] [-ExcludeRule <String[]>] [-IncludeRule <String[]>] [-Severity <String[]>]
+ [-SuppressedOnly] [-EnableExit] [-Settings <Object>] [-SaveDscDependency] [-ReportSummary] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -46,14 +66,14 @@ For more information about PSScriptAnalyzer, to contribute or file an issue, see
 
 ## EXAMPLES
 
-### -------------------------- EXAMPLE 1 --------------------------
+### EXAMPLE 1
 ```
 Invoke-ScriptAnalyzer -Path C:\Scripts\Get-LogData.ps1
 ```
 
 This command runs all Script Analyzer rules on the Get-LogData.ps1 script.
 
-### -------------------------- EXAMPLE 2 --------------------------
+### EXAMPLE 2
 ```
 Invoke-ScriptAnalyzer -Path $home\Documents\WindowsPowerShell\Modules -Recurse
 ```
@@ -61,7 +81,7 @@ Invoke-ScriptAnalyzer -Path $home\Documents\WindowsPowerShell\Modules -Recurse
 This command runs all Script Analyzer rules on all .ps1 and .psm1 files in the Modules directory and its
 subdirectories.
 
-### -------------------------- EXAMPLE 3 --------------------------
+### EXAMPLE 3
 ```
 Invoke-ScriptAnalyzer -Path C:\Windows\System32\WindowsPowerShell\v1.0\Modules\PSDiagnostics -IncludeRule PSAvoidUsingPositionalParameters
 ```
@@ -69,21 +89,21 @@ Invoke-ScriptAnalyzer -Path C:\Windows\System32\WindowsPowerShell\v1.0\Modules\P
 This command runs only the PSAvoidUsingPositionalParameters rule on the files in the PSDiagnostics module.
 You might use a command like this to find all instances of a particular rule violation while working to eliminate it.
 
-### -------------------------- EXAMPLE 4 --------------------------
+### EXAMPLE 4
 ```
 Invoke-ScriptAnalyzer -Path C:\ps-test\MyModule -Recurse -ExcludeRule PSAvoidUsingCmdletAliases, PSAvoidUsingInternalURLs
 ```
 
 This command runs Script Analyzer on the .ps1 and .psm1 files in the MyModules directory, including the scripts in its subdirectories, with all rules except for PSAvoidUsingCmdletAliases and PSAvoidUsingInternalURLs.
 
-### -------------------------- EXAMPLE 5 --------------------------
+### EXAMPLE 5
 ```
 Invoke-ScriptAnalyzer -Path D:\test_scripts\Test-Script.ps1 -CustomRulePath C:\CommunityAnalyzerRules
 ```
 
 This command runs Script Analyzer on Test-Script.ps1 with the standard rules and rules in the C:\CommunityAnalyzerRules path.
 
-### -------------------------- EXAMPLE 6 --------------------------
+### EXAMPLE 6
 ```
 $DSCError = Get-ScriptAnalyzerRule -Severity Error | Where SourceName -eq PSDSC
 
@@ -94,7 +114,7 @@ PS C:\> Invoke-ScriptAnalyzerRule -Path $Path -IncludeRule $DSCError -Recurse
 
 This example runs only the rules that are Error severity and have the PSDSC source name.
 
-### -------------------------- EXAMPLE 7 --------------------------
+### EXAMPLE 7
 ```
 function Get-Widgets
 {
@@ -140,7 +160,7 @@ The second command uses the SuppressedOnly parameter to discover the rules that 
 file.
 The output reports the suppressed rules.
 
-### -------------------------- EXAMPLE 8 --------------------------
+### EXAMPLE 8
 ```
 # In .\ScriptAnalyzerProfile.txt
 @{
@@ -162,7 +182,7 @@ Script Analyzer profile.
 If you include a conflicting parameter in the Invoke-ScriptAnalyzer command, such as '-Severity Error',
 Invoke-ScriptAnalyzer uses the profile value and ignores the parameter.
 
-### -------------------------- EXAMPLE 9 --------------------------
+### EXAMPLE 9
 ```
 Invoke-ScriptAnalyzer -ScriptDefinition "function Get-Widgets {Write-Host 'Hello'}"
 
@@ -196,13 +216,13 @@ To analyze files that are not in the root directory of the specified path, use a
 
 ```yaml
 Type: String
-Parameter Sets: UNNAMED_PARAMETER_SET_1
+Parameter Sets: Path_SuppressedOnly, Path_IncludeSuppressed
 Aliases: PSPath
 
 Required: True
 Position: 0
-Default value:
-Accept pipeline input: False
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
@@ -224,7 +244,7 @@ Aliases: CustomizedRulePath
 
 Required: False
 Position: Named
-Default value:
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -241,7 +261,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value:
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -348,7 +368,7 @@ To search the CustomRulePath recursively, use the RecurseCustomRulePath paramete
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
+Parameter Sets: Path_SuppressedOnly, Path_IncludeSuppressed
 Aliases:
 
 Required: False
@@ -369,7 +389,7 @@ For help, see the examples.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: (All)
+Parameter Sets: Path_SuppressedOnly, ScriptDefinition_SuppressedOnly
 Aliases:
 
 Required: False
@@ -388,7 +408,7 @@ It tries to preserve the file encoding but there are still some cases where the 
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: UNNAMED_PARAMETER_SET_1
+Parameter Sets: Path_SuppressedOnly, Path_IncludeSuppressed
 Aliases:
 
 Required: False
@@ -476,7 +496,7 @@ Aliases: Profile
 
 Required: False
 Position: Named
-Default value:
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -489,13 +509,13 @@ Unlike ScriptBlock parameters, the ScriptDefinition parameter requires a string 
 
 ```yaml
 Type: String
-Parameter Sets: UNNAMED_PARAMETER_SET_2
+Parameter Sets: ScriptDefinition_IncludeSuppressed, ScriptDefinition_SuppressedOnly
 Aliases:
 
 Required: True
 Position: 0
-Default value:
-Accept pipeline input: False
+Default value: None
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
@@ -516,6 +536,53 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IncludeSuppressed
+Include suppressed diagnostics in output.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Path_IncludeSuppressed, ScriptDefinition_IncludeSuppressed
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs. The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -141,7 +141,7 @@ function Invoke-AppveyorTest {
     Write-Verbose -Verbose "Module versions:"
     Get-Module PSScriptAnalyzer,Pester,PowershellGet -ErrorAction SilentlyContinue |
         ForEach-Object {
-            Write-Verbose -Verbose "$($_.Name): $($_.Version)"
+            Write-Verbose -Verbose "$($_.Name): $($_.Version) [$($_.Path)]"
         }
 
     $configuration = [PesterConfiguration]::Default


### PR DESCRIPTION
## PR Summary

Implements the `-IncludeSuppressions` parameter, allowing a single `Invoke-ScriptAnalyzer` invocation to emit all diagnostics including suppressed ones, decorating the suppressed ones accordingly.

Also adds an `IsSuppressed` property on diagnostics.

/cc @t-lipingma

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.