### PR TITLE
Fix NRE when custom rules omit optional properties in diagnostics

### DIFF
--- a/Engine/Extensions.cs
+++ b/Engine/Extensions.cs
@@ -178,5 +178,19 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Extensions
 
             return false;
         }
+
+        internal static bool TryGetPropertyValue(this PSObject psObject, string propertyName, out object value)
+        {
+            PSMemberInfo property = psObject.Properties[propertyName];
+
+            if (property is null)
+            {
+                value = default;
+                return false;
+            }
+
+            value = property.Value;
+            return true;
+        }
     }
 }

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1638,7 +1638,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         private bool TryConvertPSObjectToDiagnostic(PSObject psObject, string filePath, out DiagnosticRecord diagnostic)
         {
             string message = psObject.Properties["Message"]?.Value?.ToString();
-            var extent = (IScriptExtent)psObject.Properties["Extent"]?.Value;
+            var extent = psObject.Properties["Extent"]?.Value as IScriptExtent;
             string ruleName = psObject.Properties["RuleName"]?.Value?.ToString();
             string ruleSuppressionID = psObject.Properties["RuleSuppressionID"]?.Value?.ToString();
             CorrectionExtent[] suggestedCorrections = psObject.TryGetPropertyValue("SuggestedCorrections", out object correctionsValue)

--- a/Tests/Engine/CustomRuleNREAssets/CLMTest.ps1
+++ b/Tests/Engine/CustomRuleNREAssets/CLMTest.ps1
@@ -1,0 +1,7 @@
+write-host "test"
+$a = "asdf"
+$a = $a.replace('s','ssssssss')
+[math]::abs(-1)
+Function ASDF1234{
+    "asdf"
+}

--- a/Tests/Engine/CustomRuleNREAssets/MyCustom.psm1
+++ b/Tests/Engine/CustomRuleNREAssets/MyCustom.psm1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Static methods are not allowed in constrained language mode.
+.DESCRIPTION
+    Static methods are not allowed in constrained language mode.
+    To fix a violation of this rule, use a cmdlet or function instead of a static method.
+.EXAMPLE
+    Test-StaticMethod -CommandAst $CommandAst
+.INPUTS
+    [System.Management.Automation.Language.ScriptBlockAst]
+.OUTPUTS
+    [PSCustomObject[]]
+.NOTES
+    Reference: Output, CLM info.
+#>
+function Test-StaticMethod
+{
+    [CmdletBinding()]
+    [OutputType([PSCustomObject[]])]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.Management.Automation.Language.ScriptBlockAst]
+        $ScriptBlockAst
+    )
+
+    Process
+    {
+        try
+        {
+            # Gets methods
+
+            $invokedMethods = $ScriptBlockAst.FindAll({$args[0] -is [System.Management.Automation.Language.CommandExpressionAst] -and $args[0].Expression -match "^\[.*\]::" },$true)
+            foreach ($invokedMethod in $invokedMethods)
+            {
+                [PSCustomObject]@{Message  = "Avoid Using Static Methods";
+                                  Extent   = $invokedMethod.Extent;
+                                  RuleName = $PSCmdlet.MyInvocation.InvocationName;
+                                  Severity = "Warning"}
+            }
+        }
+        catch
+        {
+            $PSCmdlet.ThrowTerminatingError($PSItem)
+        }
+    }
+}

--- a/Tests/Engine/CustomizedRule.tests.ps1
+++ b/Tests/Engine/CustomizedRule.tests.ps1
@@ -199,6 +199,19 @@ Describe "Test importing correct customized rules" {
             $violations[0].RuleSuppressionID   | Should -Be "MyRuleSuppressionID"
         }
 
+		It "Does not throw an exception when optional diagnostic properties are not present" {
+			$violations = Invoke-ScriptAnalyzer -Path "$PSScriptRoot\CustomRuleNREAssets\CLMTest.ps1" -CustomizedRulePath "$PSScriptRoot\CustomRuleNREAssets\MyCustom.psm1"
+
+			$violations.Count | Should -Be 1
+			$violations[0].RuleName | Should -BeExactly 'MyCustom\Test-StaticMethod'
+			$violations[0].Severity | Should -Be 'Warning'
+			$violations[0].ScriptName | Should -BeExactly 'CLMTest.ps1'
+			$violations[0].Extent.StartLineNumber | Should -Be 4
+			$violations[0].Message | Should -BeExactly 'Avoid Using Static Methods'
+			$violations[0].RuleSuppressionID | Should -BeNullOrEmpty
+			$violations[0].SuggestedCorrections | Should -BeNullOrEmpty
+		}
+
 		Context "Test Invoke-ScriptAnalyzer with customized rules - Advanced test cases" -Skip:$testingLibraryUsage {
             It "will show the custom rule in the results when given a rule folder path with trailing backslash" {
 				# needs fixing for Linux


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/PowerShell/PSScriptAnalyzer/issues/1714.

These changes allow custom rules to emit diagnostics (or PSObjects that turn into diagnostics) with optional properties unset.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.