### PR TITLE
Start using PowerShell1ES pool for official build

### DIFF
--- a/.ci/releaseBuild.yml
+++ b/.ci/releaseBuild.yml
@@ -1,4 +1,4 @@
-# The name of the build that will be seen in mscodehub
+ # The name of the build that will be seen in mscodehub
 name: PSSA-Release-$(Build.BuildId)
 # how is the build triggered
 # since this is a release build, no trigger as it's a manual release
@@ -34,7 +34,7 @@ stages:
 - stage: Build
   displayName: Build
   pool:
-    name: Package ES CodeHub Lab E
+    name: PowerShell1ES # was Package ES CodeHub Lab E
   jobs:
   - job: Build_Job
     displayName: Build Microsoft.PowerShell.ScriptAnalyzer
@@ -162,7 +162,7 @@ stages:
   jobs:
   - job: Compliance_Job
     pool:
-      name: Package ES CodeHub Lab E
+      name: PowerShell1ES # was Package ES CodeHub Lab E
     steps:
     - checkout: self
     - checkout: ComplianceRepo


### PR DESCRIPTION
## PR Summary

We need to use a different pool for build/sign as it is being decommissioned
<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.