### PR TITLE
Broken link to list of approved verbs

### DIFF
--- a/docs/Rules/UseApprovedVerbs.md
+++ b/docs/Rules/UseApprovedVerbs.md
@@ -16,7 +16,7 @@ All cmdlets must used approved verbs.
 Approved verbs can be found by running the command `Get-Verb`.
 
 Additional documentation on approved verbs can be found in the microsoft docs page
-[Approved Verbs for PowerShell Commands](/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands).
+[Approved Verbs for PowerShell Commands](https://docs.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands?view=powershell-7.1).
 Some unapproved verbs are documented on the approved verbs page and point to approved alternatives.
 Try searching for the verb you used to find its approved form. For example, searching for `Read`,
 `Open`, or `Search` leads you to `Get`.


### PR DESCRIPTION
The link was missing part of the URL that redirected to the MS docs.
From
```
/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands
```
to
```
https://docs.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands
```

## PR Summary

Fixes a broken link that 404's on GitHub but should direct to MS doc for Approved Verbs

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.