### PR TITLE
Fix erroneous `?` with `-` in `AvoidUsingWMICmdlet.md` in function call example

### DIFF
--- a/docs/Rules/AvoidUsingWMICmdlet.md
+++ b/docs/Rules/AvoidUsingWMICmdlet.md
@@ -48,12 +48,12 @@ Change to the equivalent CIM based cmdlet.
 
 ```powershell
 Get-WmiObject -Query 'Select * from Win32_Process where name LIKE "myprocess%"' | Remove-WmiObject
-Invoke-WmiMethod ?Class Win32_Process ?Name "Create" ?ArgumentList @{ CommandLine = "notepad.exe" }
+Invoke-WmiMethod -Class Win32_Process -Name "Create" -ArgumentList @{ CommandLine = "notepad.exe" }
 ```
 
 ### Correct
 
 ```powershell
 Get-CimInstance -Query 'Select * from Win32_Process where name LIKE "myprocess%"' | Remove-CIMInstance
-Invoke-CimMethod ?ClassName Win32_Process ?MethodName "Create" ?Arguments @{ CommandLine = "notepad.exe" }
+Invoke-CimMethod -ClassName Win32_Process -MethodName "Create" -Arguments @{ CommandLine = "notepad.exe" }
 ```


### PR DESCRIPTION
Strange character correction

## PR Summary

Replacing `?` with `-` in function parameter call.