### PR TITLE
Fix links to work on GitHub

### DIFF
--- a/docs/Cmdlets/Invoke-ScriptAnalyzer.md
+++ b/docs/Cmdlets/Invoke-ScriptAnalyzer.md
@@ -514,7 +514,7 @@ following keys:
 
 The keys and values in the profile are interpreted as if they were standard parameters and values of
 `Invoke-ScriptAnalyzer`, similar to splatting. For more information, see
-[about_Splatting](/powershell/module/microsoft.powershell.com/about/about_splatting).
+[about_Splatting](https://docs.microsoft.com/powershell/module/microsoft.powershell.com/about/about_splatting).
 
 ```yaml
 Type: Object

--- a/docs/Cmdlets/Invoke-ScriptAnalyzer.md
+++ b/docs/Cmdlets/Invoke-ScriptAnalyzer.md
@@ -514,7 +514,7 @@ following keys:
 
 The keys and values in the profile are interpreted as if they were standard parameters and values of
 `Invoke-ScriptAnalyzer`, similar to splatting. For more information, see
-[about_Splatting](https://docs.microsoft.com/powershell/module/microsoft.powershell.com/about/about_splatting).
+[about_Splatting](https://docs.microsoft.com/powershell/module/microsoft.powershell.core/about/about_splatting).
 
 ```yaml
 Type: Object

--- a/docs/Rules/ProvideCommentHelp.md
+++ b/docs/Rules/ProvideCommentHelp.md
@@ -17,9 +17,9 @@ presence of comment based help and not on the validity or format.
 For assistance on comment based help, use the command `Get-Help about_comment_based_help` or the
 following articles:
 
-- [Writing Comment-based Help](/powershell/scripting/developer/help/writing-comment-based-help-topics)
-- [Writing Help for PowerShell Cmdlets](/powershell/scripting/developer/help/writing-help-for-windows-powershell-cmdlets)
-- [Create XML-based help using PlatyPS](/powershell/scripting/dev-cross-plat/create-help-using-platyps)
+- [Writing Comment-based Help](https://docs.microsoft.com/powershell/scripting/developer/help/writing-comment-based-help-topics)
+- [Writing Help for PowerShell Cmdlets](https://docs.microsoft.com/powershell/scripting/developer/help/writing-help-for-windows-powershell-cmdlets)
+- [Create XML-based help using PlatyPS](https://docs.microsoft.com/powershell/scripting/dev-cross-plat/create-help-using-platyps)
 
 ## Configuration
 

--- a/docs/Rules/UseApprovedVerbs.md
+++ b/docs/Rules/UseApprovedVerbs.md
@@ -16,7 +16,7 @@ All cmdlets must used approved verbs.
 Approved verbs can be found by running the command `Get-Verb`.
 
 Additional documentation on approved verbs can be found in the microsoft docs page
-[Approved Verbs for PowerShell Commands](/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands).
+[Approved Verbs for PowerShell Commands](https://docs.microsoft.com/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands).
 Some unapproved verbs are documented on the approved verbs page and point to approved alternatives.
 Try searching for the verb you used to find its approved form. For example, searching for `Read`,
 `Open`, or `Search` leads you to `Get`.


### PR DESCRIPTION
While we work through automating this for publishing.

Replaces #1734.

Regex find was `(\[.*\]\()/powershell` and replace was `$1https://docs.microsoft.com/powershell`.