### PR TITLE
Fix errors in ShouldProcess rule document

### DIFF
--- a/docs/Rules/README.md
+++ b/docs/Rules/README.md
@@ -55,7 +55,7 @@ The PSScriptAnalyzer contains the following rule definitions.
 | [ReservedCmdletChar](./ReservedCmdletChar.md)                                                     | Error       |        Yes         |                 |
 | [ReservedParams](./ReservedParams.md)                                                             | Error       |        Yes         |                 |
 | [ReviewUnusedParameter](./ReviewUnusedParameter.md)                                               | Warning     |        Yes         |                 |
-| [ShouldProcess](./ShouldProcess.md)                                                               | Error       |        Yes         |                 |
+| [ShouldProcess](./ShouldProcess.md)                                                               | Warning     |        Yes         |                 |
 | [UseApprovedVerbs](./UseApprovedVerbs.md)                                                         | Warning     |        Yes         |                 |
 | [UseBOMForUnicodeEncodedFile](./UseBOMForUnicodeEncodedFile.md)                                   | Warning     |        Yes         |                 |
 | [UseCmdletCorrectly](./UseCmdletCorrectly.md)                                                     | Warning     |        Yes         |                 |

--- a/docs/Rules/ShouldProcess.md
+++ b/docs/Rules/ShouldProcess.md
@@ -1,7 +1,7 @@
 ---
 description: Should Process
 ms.custom: PSSA v1.20.0
-ms.date: 10/18/2021
+ms.date: 01/23/2022
 ms.topic: reference
 title: ShouldProcess
 ---
@@ -14,55 +14,52 @@ title: ShouldProcess
 If a cmdlet declares the `SupportsShouldProcess` attribute, then it should also call
 `ShouldProcess`. A violation is any function which either declares `SupportsShouldProcess` attribute
 but makes no calls to `ShouldProcess` or it calls `ShouldProcess` but does not declare
-`SupportsShouldProcess`
+`SupportsShouldProcess`.
 
 For more information, please refer to `about_Functions_Advanced_Methods` and
-`about_Functions_CmdletBindingAttribute`
+`about_Functions_CmdletBindingAttribute`.
 
 ## How
 
 To fix a violation of this rule, please call `ShouldProcess` method when a cmdlet declares
 `SupportsShouldProcess` attribute. Or please add `SupportsShouldProcess` attribute argument when
-calling `ShouldProcess`
+calling `ShouldProcess`.
 
 ## Example
 
 ### Wrong
 
 ```powershell
-    function Set-File
-    {
-        [CmdletBinding(SupportsShouldProcess=$true)]
-        Param
-        (
-            # Path to file
-            [Parameter(Mandatory=$true)]
-            $Path
-        )
-        "String" | Out-File -FilePath $FilePath
-    }
+function Set-File
+{
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    Param
+    (
+        # Path to file
+        [Parameter(Mandatory=$true)]
+        $Path
+    )
+
+    "String" | Out-File -FilePath $Path
+}
 ```
 
 ### Correct
 
 ```powershell
-    function Set-File
-    {
-        [CmdletBinding(SupportsShouldProcess=$true)]
-        Param
-        (
-            # Path to file
-            [Parameter(Mandatory=$true)]
-            $Path
-        )
+function Set-File
+{
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    Param
+    (
+        # Path to file
+        [Parameter(Mandatory=$true)]
+        $Path
+    )
 
-        if ($PSCmdlet.ShouldProcess("Target", "Operation"))
-        {
-            "String" | Out-File -FilePath $FilePath
-        }
-        else
-        {
-            Write-Host ('Write "String" to file {0}' -f $FilePath)
-        }
+    if ($PSCmdlet.ShouldProcess($Path, "Write"))
+    {
+        "String" | Out-File -FilePath $Path
     }
+}
 ```


### PR DESCRIPTION
## PR Summary

* Fix wrong variable names in examples.
* Remove `Write-Host` from the correct example. It is duplicated with outputs of `-WhatIf` or `-Confirm`. It also violates "Avoid Using Write-Host" rule.
* Correct the severity of `ShouldProcess` rule as mentioned in `ShouldProcess.md`. `Get-ScriptAnalyzerRule -Name PSShouldProcess | % Severity` also returns "Warning" with ScriptAnalyzer 1.20.0

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ ] ~~[Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)~~
- [ ] ~~Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation~~
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.
- [x] Update examples can run successfully on PowerShell 7.2.1.
- [ ] ~~Script Analyzer 1.20.0 detects a `ShouldProcess` violation in the updated wrong example.~~ **For some reason, Script Analyzer 1.20.0 doesn't detect any `ShouldProcess` violation in the updated wrong example.**
- [x] Script Analyzer 1.20.0 detects no error in the updated correct example.