### PR TITLE
Also return suggestion to use PSCredential for AvoidUsingPlainTextForPassword rule

### DIFF
--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -1042,7 +1042,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Set {0} type to SecureString.
+        ///   Looks up a localized string similar to Set {0} type to {1}.
         /// </summary>
         internal static string AvoidUsingPlainTextForPasswordCorrectionDescription {
             get {
@@ -1060,7 +1060,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Parameter &apos;{0}&apos; should use SecureString, otherwise this will expose sensitive information. See ConvertTo-SecureString for more information..
+        ///   Looks up a localized string similar to Parameter &apos;{0}&apos; should not use String type but either SecureString or PSCredential, otherwise it increases the chance to to expose this sensitive information..
         /// </summary>
         internal static string AvoidUsingPlainTextForPasswordError {
             get {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -292,7 +292,7 @@
     <value>Password parameters that take in plaintext will expose passwords and compromise the security of your system.</value>
   </data>
   <data name="AvoidUsingPlainTextForPasswordError" xml:space="preserve">
-    <value>Parameter '{0}' should use SecureString, otherwise this will expose sensitive information. See ConvertTo-SecureString for more information.</value>
+    <value>Parameter '{0}' should not use String type but either SecureString or PSCredential, otherwise it increases the chance to to expose this sensitive information.</value>
   </data>
   <data name="AvoidUsingPlainTextForPasswordCommonName" xml:space="preserve">
     <value>Avoid Using Plain Text For Password Parameter</value>
@@ -778,7 +778,7 @@
     <value>Replace {0} with {1}</value>
   </data>
   <data name="AvoidUsingPlainTextForPasswordCorrectionDescription" xml:space="preserve">
-    <value>Set {0} type to SecureString</value>
+    <value>Set {0} type to {1}</value>
   </data>
   <data name="MissingModuleManifestFieldCorrectionDescription" xml:space="preserve">
     <value>Add {0} = {1} to the module manifest</value>


### PR DESCRIPTION
## PR Summary

Fixes #1767 by also adding an option for `PSCredential`.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.