### PR TITLE
Fix #824 Add the AvoidSemicolonsAsLineTerminators rule to warn about lines ending with a semicolon

### DIFF
--- a/Engine/Formatter.cs
+++ b/Engine/Formatter.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                 "PSUseCorrectCasing",
                 "PSAvoidUsingCmdletAliases",
                 "PSAvoidUsingDoubleQuotesForConstantString",
+                "PSAvoidSemicolonsAsLineTerminators"
             };
 
             var text = new EditableText(scriptDefinition);

--- a/Rules/AvoidSemicolonsAsLineTerminators.cs
+++ b/Rules/AvoidSemicolonsAsLineTerminators.cs
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+#if !CORECLR
+using System.ComponentModel.Composition;
+#endif
+using System.Globalization;
+using System.Linq;
+using System.Management.Automation.Language;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
+{
+    /// <summary>
+    /// AvoidSemicolonsAsLineTerminators: Checks for lines to don't end with semicolons
+    /// </summary>
+#if !CORECLR
+    [Export(typeof(IScriptRule))]
+#endif
+    public class AvoidSemicolonsAsLineTerminators : ConfigurableRule
+    {
+        /// <summary>
+        /// Construct an object of AvoidSemicolonsAsLineTerminators type.
+        /// </summary>
+        public AvoidSemicolonsAsLineTerminators()
+        {
+            Enable = false;
+        }
+
+        /// <summary>
+        /// Analyzes the given ast to find violations.
+        /// </summary>
+        /// <param name="ast">AST to be analyzed. This should be non-null</param>
+        /// <param name="fileName">Name of file that corresponds to the input AST.</param>
+        /// <returns>A an enumerable type containing the violations</returns>
+        public override IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
+            if (ast == null)
+            {
+                throw new ArgumentNullException(nameof(ast));
+            }
+
+
+            var diagnosticRecords = new List<DiagnosticRecord>();
+
+            IEnumerable<Ast> propertyDefinitions = ast.FindAll(item => item is PropertyMemberAst, true);
+
+            var tokens = Helper.Instance.Tokens;
+            for (int tokenIndex = 0; tokenIndex < tokens.Length; tokenIndex++)
+            {
+
+                var token = tokens[tokenIndex];
+                var semicolonTokenExtent = token.Extent;
+
+                var isSemicolonToken = token.Kind is TokenKind.Semi;
+                if (!isSemicolonToken)
+                {
+                    continue;
+                }
+
+                var isPartOfAnyPropertiesDefenitions = propertyDefinitions.Any(propertyDefinition => (propertyDefinition.Extent.EndOffset == semicolonTokenExtent.StartOffset + 1));
+                if (isPartOfAnyPropertiesDefenitions)
+                {
+                    continue;
+                }
+
+                var nextTokenIndex = tokenIndex + 1;
+                var isNextTokenIsNewLine = tokens[nextTokenIndex].Kind is TokenKind.NewLine;
+                var isNextTokenIsEndOfInput = tokens[nextTokenIndex].Kind is TokenKind.EndOfInput;
+
+                if (!isNextTokenIsNewLine && !isNextTokenIsEndOfInput)
+                {
+                    continue;
+                }
+
+                var violationExtent = new ScriptExtent(
+                new ScriptPosition(
+                    ast.Extent.File,
+                    semicolonTokenExtent.StartLineNumber,
+                    semicolonTokenExtent.StartColumnNumber,
+                    semicolonTokenExtent.StartScriptPosition.Line
+                ),
+                new ScriptPosition(
+                    ast.Extent.File,
+                    semicolonTokenExtent.EndLineNumber,
+                    semicolonTokenExtent.EndColumnNumber,
+                    semicolonTokenExtent.EndScriptPosition.Line
+                ));
+
+                var suggestedCorrections = new List<CorrectionExtent>();
+                suggestedCorrections.Add(new CorrectionExtent(
+                            violationExtent,
+                            string.Empty,
+                            ast.Extent.File
+                        ));
+
+                var record = new DiagnosticRecord(
+                        String.Format(CultureInfo.CurrentCulture, Strings.AvoidSemicolonsAsLineTerminatorsError),
+                        violationExtent,
+                        GetName(),
+                        GetDiagnosticSeverity(),
+                        ast.Extent.File,
+                        null,
+                        suggestedCorrections
+                    );
+                diagnosticRecords.Add(record);
+            }
+
+            return diagnosticRecords;
+        }
+
+        /// <summary>
+        /// Retrieves the common name of this rule.
+        /// </summary>
+        public override string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidSemicolonsAsLineTerminatorsCommonName);
+        }
+
+        /// <summary>
+        /// Retrieves the description of this rule.
+        /// </summary>
+        public override string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidSemicolonsAsLineTerminatorsDescription);
+        }
+
+        /// <summary>
+        /// Retrieves the name of this rule.
+        /// </summary>
+        public override string GetName()
+        {
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.NameSpaceFormat,
+                GetSourceName(),
+                Strings.AvoidSemicolonsAsLineTerminatorsName);
+        }
+
+        /// <summary>
+        /// Retrieves the severity of the rule: error, warning or information.
+        /// </summary>
+        public override RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
+
+        /// <summary>
+        /// Gets the severity of the returned diagnostic record: error, warning, or information.
+        /// </summary>
+        /// <returns></returns>
+        public DiagnosticSeverity GetDiagnosticSeverity()
+        {
+            return DiagnosticSeverity.Warning;
+        }
+
+        /// <summary>
+        /// Retrieves the name of the module/assembly the rule is from.
+        /// </summary>
+        public override string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+
+        /// <summary>
+        /// Retrieves the type of the rule, Builtin, Managed or Module.
+        /// </summary>
+        public override SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
+        }
+    }
+}

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -466,6 +466,42 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Avoid long lines.
+        /// </summary>
+        internal static string AvoidSemicolonsAsLineTerminatorsCommonName {
+            get {
+                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsCommonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Line should not end with a semicolon.
+        /// </summary>
+        internal static string AvoidSemicolonsAsLineTerminatorsDescription {
+            get {
+                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Line ends with a semicolon.
+        /// </summary>
+        internal static string AvoidSemicolonsAsLineTerminatorsError {
+            get {
+                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidSemicolonsAsLineTerminators.
+        /// </summary>
+        internal static string AvoidSemicolonsAsLineTerminatorsName {
+            get {
+                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsName", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Avoid multiple type specifiers on parameters.
         /// </summary>
         internal static string AvoidMultipleTypeAttributesCommonName {

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -921,6 +921,18 @@
   <data name="AvoidLongLinesError" xml:space="preserve">
     <value>Line exceeds the configured maximum length of {0} characters</value>
   </data>
+  <data name="AvoidSemicolonsAsLineTerminatorsName" xml:space="preserve">
+    <value>AvoidSemicolonsAsLineTerminators</value>
+  </data>
+  <data name="AvoidSemicolonsAsLineTerminatorsCommonName" xml:space="preserve">
+    <value>Avoid semicolons as line terminators</value>
+  </data>
+  <data name="AvoidSemicolonsAsLineTerminatorsDescription" xml:space="preserve">
+    <value>Line should not end with a semicolon</value>
+  </data>
+  <data name="AvoidSemicolonsAsLineTerminatorsError" xml:space="preserve">
+    <value>Line ends with a semicolon</value>
+  </data>
   <data name="PlaceOpenBraceName" xml:space="preserve">
     <value>PlaceOpenBrace</value>
   </data>

--- a/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
+++ b/Tests/Engine/GetScriptAnalyzerRule.tests.ps1
@@ -63,7 +63,7 @@ Describe "Test Name parameters" {
 
         It "get Rules with no parameters supplied" {
             $defaultRules = Get-ScriptAnalyzerRule
-            $expectedNumRules = 66
+            $expectedNumRules = 67
             if ($PSVersionTable.PSVersion.Major -le 4)
             {
                 # for PSv3 PSAvoidGlobalAliases is not shipped because

--- a/Tests/Rules/AvoidSemicolonsAsLineTerminators.tests.ps1
+++ b/Tests/Rules/AvoidSemicolonsAsLineTerminators.tests.ps1
@@ -1,0 +1,135 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+BeforeAll {
+    $ruleName = "PSAvoidSemicolonsAsLineTerminators"
+
+    $ruleSettings = @{
+        Enable = $true
+    }
+    $settings = @{
+        IncludeRules = @($ruleName)
+        Rules        = @{ $ruleName = $ruleSettings }
+    }
+}
+
+Describe "AvoidSemicolonsAsLineTerminators" {
+    Context "When the rule is not enabled explicitly" {
+        It "Should not find violations" {
+            $def = "'test';"
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def
+            $violations.Count | Should -Be 0
+        }
+    }
+
+    Context "Given a line ending with a semicolon" {
+        It "Should find one violation" {
+            $def = "'test';"
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should -Be 1
+        }
+    }
+
+    Context "Given a line with a semicolon in the middle and one at the end" {
+        It "Should find one violation" {
+            $def = "'test';'test';"
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations[0].Extent.StartLineNumber | Should -Be 1
+            $violations[0].Extent.EndLineNumber | Should -Be 1
+            $violations[0].Extent.StartColumnNumber | Should -Be 14
+            $violations[0].Extent.EndColumnNumber | Should -Be 15
+        }
+    }
+
+
+    Context "Given a multiline string with a line ending with a semicolon" {
+        It "Should get the correct extent of the violation for a single semicolon" {
+            $def = @"
+'this line has no semicolon'
+'test';
+"@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations[0].Extent.StartLineNumber | Should -Be 2
+            $violations[0].Extent.EndLineNumber | Should -Be 2
+            $violations[0].Extent.StartColumnNumber | Should -Be 7
+            $violations[0].Extent.EndColumnNumber | Should -Be 8
+        }
+    }
+
+    Context "Given a multiline string with a line having a semicolon in the middle" {
+        It "Should not find any violations" {
+            $def = @"
+'this line has no semicolon'
+'line with a semicolon; in the middle'
+"@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should -Be 0
+        }
+    }
+
+    Context "Given a multiline string with a line having a semicolon in C# code" {
+        It "Should not find any violations" {
+            $def = @"
+`$calcCode = `@"
+public class Calc{
+    public int Add(int x,int y){
+        return x+y;
+    }
+}
+"`@
+
+Add-Type -TypeDefinition `$calcCode -Language CSharp
+
+`$c = New-Object Calc
+`$c.Add(1,2)
+"@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should -Be 0
+        }
+    }
+
+    Context "Given a multiline string with a line having a semicolon in variable assignment" {
+        It "Should not find any violations" {
+            $def = @"
+`$allowPopupsOption=`@"
+lockPref("dom.disable_open_during_load", false);
+"`@
+    Write `$allowPopupsOption | Out-File -Encoding UTF8 -FilePath `$pathToMozillaCfg -Append
+"@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should -Be 0
+        }
+    }
+
+    Context "Given a line ending with a semicolon" {
+        It "Should remove the semicolon at the end" {
+            $def = "'test';"
+            $expected = "'test'"
+
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
+        }
+    }
+
+    Context "Given a line with a semicolon in the middle and one at the end" {
+        It "Should remove the semicolon at the end" {
+            $def = "'test';'test';"
+            $expected = "'test';'test'"
+
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
+        }
+    }
+
+    Context "Given a multiline string with a line ending with a semicolon" {
+        It "Should remove the semicolon at the end of the line with a semicolon" {
+            $def = @"
+'this line has no semicolon at the end'
+'test';
+"@
+            $expected = @"
+'this line has no semicolon at the end'
+'test'
+"@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
+        }
+    }
+}

--- a/docs/Rules/AvoidSemicolonsAsLineTerminators.md
+++ b/docs/Rules/AvoidSemicolonsAsLineTerminators.md
@@ -1,0 +1,46 @@
+---
+description: Avoid semicolons as line terminators
+ms.custom: PSSA v1.21.0
+ms.date: 06/15/2022
+ms.topic: reference
+title: AvoidSemicolonsAsLineTerminators
+---
+# AvoidSemicolonsAsLineTerminators
+
+**Severity Level: Warning**
+
+## Description
+
+Lines should not end with a semicolon.
+
+**Note**: This rule is not enabled by default. The user needs to enable it through settings.
+
+## Example
+
+### Wrong
+
+```powershell
+Install-Module -Name PSScriptAnalyzer; $a = 1 + $b;
+```
+
+### Correct
+
+```powershell
+Install-Module -Name PSScriptAnalyzer; $a = 1 + $b
+```
+
+## Configuration
+
+```powershell
+Rules = @{
+    PSAvoidSemicolonsAsLineTerminators  = @{
+        Enable     = $true
+    }
+}
+```
+
+### Parameters
+
+#### Enable: bool (Default value is `$false`)
+
+Enable or disable the rule during ScriptAnalyzer invocation.

--- a/docs/Rules/README.md
+++ b/docs/Rules/README.md
@@ -20,6 +20,7 @@ The PSScriptAnalyzer contains the following rule definitions.
 | [AvoidGlobalVars](./AvoidGlobalVars.md)                                                           | Warning     |        Yes         |                 |
 | [AvoidInvokingEmptyMembers](./AvoidInvokingEmptyMembers.md)                                       | Warning     |        Yes         |                 |
 | [AvoidLongLines](./AvoidLongLines.md)                                                             | Warning     |         No         |       Yes       |
+| [AvoidSemicolonsAsLineTerminators](./AvoidSemicolonsAsLineTerminators.md)                         | Warning     |         No         |                 |
 | [AvoidMultipleTypeAttributes<sup>1</sup>](./AvoidMultipleTypeAttributes.md)                       | Warning     |        Yes         |                 |
 | [AvoidNullOrEmptyHelpMessageAttribute](./AvoidNullOrEmptyHelpMessageAttribute.md)                 | Warning     |        Yes         |                 |
 | [AvoidOverwritingBuiltInCmdlets](./AvoidOverwritingBuiltInCmdlets.md)                             | Warning     |        Yes         |       Yes       |


### PR DESCRIPTION
It's a rule to warn about lines ending with a semicolon

## PR Summary

Add the PSAvoidSemicolonsAsLineTerminators rule to warn about lines ending with a semicolon. Covered with tests. The rule is disabled by default as it's more of a styling preference. https://github.com/PowerShell/PSScriptAnalyzer/issues/824

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.