### PR TITLE
Revert "Fix dependabot issues by upgrading newtonsoft json library to 13.0.1"

### DIFF
--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Microsoft.PowerShell.CrossCompatibility.csproj
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Microsoft.PowerShell.CrossCompatibility.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
 </Project>

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Engine\Engine.csproj" />
     <ProjectReference Include="..\PSCompatibilityCollector\Microsoft.PowerShell.CrossCompatibility\Microsoft.PowerShell.CrossCompatibility.csproj" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">


### PR DESCRIPTION
Reverts PowerShell/PSScriptAnalyzer#1815 because for PowerShell Core we are not shipping it and it could cause issues if we start to reference an API that doesn't ship with the old version of Newtonsoft that still ships in ps 7.0 as patches don't patch newtonsoft. we should revisit bumping the version for windows powershell builds though