### PR TITLE
Set MaxDepth in JsonSerializerSettings for more secure handling of exceptional conditions in Newtonsoft.Json

### DIFF
--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Retrieval/JsonProfileSerializer.cs
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Retrieval/JsonProfileSerializer.cs
@@ -84,6 +84,7 @@ namespace Microsoft.PowerShell.CrossCompatibility.Retrieval
                 Converters = GetFormatConverters(),
                 MissingMemberHandling = MissingMemberHandling.Ignore,
                 DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate,
+                MaxDepth = 128,
             };
 
             var serializer = JsonSerializer.Create(settings);


### PR DESCRIPTION
## PR Summary

This is an alternative resolution over bumping the version of Newtonsoft.Json in #1810 (which we cannot do for PowerShell Core)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.