### PR TITLE
Fix 'Accept pipeline input' properties in documentation of Invoke-Formatter

### DIFF
--- a/Tests/Engine/ModuleHelp.Tests.ps1
+++ b/Tests/Engine/ModuleHelp.Tests.ps1
@@ -234,6 +234,25 @@ Describe 'Cmdlet parameter help' {
 			# To avoid calling Trim method on a null object.
 			$helpType = if ($parameterHelp.parameterValue) { $parameterHelp.parameterValue.Trim() }
 			$helpType | Should -Be $codeType -Because "help for $commandName has correct parameter type for $parameterName"
+
+			foreach($parameterAttribute in $parameter.Attributes) {
+				if ($parameterAttribute.ValueFromPipeline -eq $null) { continue }
+
+				$parameterHelpPipelineInput = if ($parameterHelp.pipelineInput -eq 'True (ByPropertyName, ByValue)') {
+					$true
+				}
+				else {
+					[System.Boolean]::Parse($parameterHelp.pipelineInput)
+				}
+
+				$parameterHelpPipelineInput | Should -Be $parameterAttribute.ValueFromPipelineByPropertyName `
+					-Because "Parameter $parameterName of command $CommandName and parameter set $($parameterAttribute.ParameterSetName) has correct ValueFromPipelineByPropertyName attribute"
+
+				if ($parameterHelp.pipelineInput -eq 'True (ByPropertyName, ByValue)') {
+					$parameterAttribute.ValueFromPipeline | Should -BeTrue `
+						-Because "Parameter $parameterName of command $CommandName and parameter set $($parameterAttribute.ParameterSetName) has correct ValueFromPipeline attribute"
+				}
+			}
 		}
 
 		foreach ($helpParam in $HelpParameterNames) {

--- a/docs/Cmdlets/Invoke-Formatter.md
+++ b/docs/Cmdlets/Invoke-Formatter.md
@@ -104,7 +104,7 @@ Aliases:
 Required: False
 Position: 3
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True
 Accept wildcard characters: False
 ```
 
@@ -121,7 +121,7 @@ Aliases:
 Required: True
 Position: 1
 Default value: None
-Accept pipeline input: False
+Accept pipeline input: True (ByPropertyName, ByValue)
 Accept wildcard characters: False
 ```
 
@@ -137,7 +137,7 @@ Aliases:
 Required: False
 Position: 2
 Default value: CodeFormatting
-Accept pipeline input: False
+Accept pipeline input: True
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
## PR Summary

PR #1763 made `Invoke-Formatter` accept pipeline input but tests didn't catch that cmdlet docs weren't updated. This fixes the docs and adds tests for pipeline input. Since that pull request hasn't been released yet, no need to update Microsoft docs.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.