### PR TITLE
Exclude automatic variable FormatEnumerationLimit from analysis by PSAvoidGlobalVars and PSUseDeclaredVarsMoreThanAssignments

### DIFF
--- a/Engine/SpecialVars.cs
+++ b/Engine/SpecialVars.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         internal const string Matches = "Matches";
         internal const string PSVersionTable = "PSVersionTable";
         internal const string OFS = "OFS";
+        internal const string FormatEnumerationLimit = "FormatEnumerationLimit";
 
         internal static readonly string[] InitializedVariables;
 
@@ -59,8 +60,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                                                                    PSCommandPath,
                                                                    ExecutionContext,
                                                                    Matches,
-                                                                   PSVersionTable,
-                                                                   OFS
+                                                                   PSVersionTable,                                                                   
+                                                                   OFS,
+                                                                   FormatEnumerationLimit,
                                                                };
         internal static readonly Type[] AutomaticVariableTypes = new Type[]  
                                                                  {  
@@ -76,7 +78,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                                                                    /* ExecutionContext */  typeof(EngineIntrinsics),
                                                                    /* Matches */           typeof(System.Collections.Hashtable),
                                                                    /* PSVersionTable */    typeof(System.Collections.Hashtable),
-                                                                   /* OFS */               typeof(object)
+                                                                   /* OFS */               typeof(object),
+                                                                   /* FormatEnumerationLimit */ typeof(int)
                                                                  };
 
 


### PR DESCRIPTION
## PR Summary

Fixes #1756 by adding `1756` to the list of automatic variables that are excluded by `PSAvoidGlobalVars` and `PSUseDeclaredVarsMoreThanAssignments`. I don't think this warrants adding a test but I did a quick manual test though that `Invoke-ScriptAnalyzer -ScriptDefinition '$FormatEnumerationLimit = 2'` and `Invoke-ScriptAnalyzer -ScriptDefinition '$global:FormatEnumerationLimit = 2'` do not return a warning. Not urgently needed for 1.21.0 so could wait.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.