### PR TITLE
Fix edge case of UseConsistentIndentation where child pipeline is on the same line as hashtable

### DIFF
--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -133,7 +133,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             var currentIndenationLevelIncreaseDueToPipelines = 0;
             var onNewLine = true;
             var pipelineAsts = ast.FindAll(testAst => testAst is PipelineAst && (testAst as PipelineAst).PipelineElements.Count > 1, true).ToList();
-            int minimumPipelineAstIndex = 0;
             /*
                 When an LParen and LBrace are on the same line, it can lead to too much de-indentation.
                 In order to prevent the RParen code from de-indenting too much, we keep a stack of when we skipped the indentation
@@ -273,7 +272,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 if (pipelineIndentationStyle == PipelineIndentationStyle.None) { continue; }
 
                 // Check if the current token matches the end of a PipelineAst
-                PipelineAst matchingPipeLineAstEnd = MatchingPipelineAstEnd(pipelineAsts, ref minimumPipelineAstIndex, token);
+                PipelineAst matchingPipeLineAstEnd = MatchingPipelineAstEnd(pipelineAsts, token);
                 if (matchingPipeLineAstEnd == null)
                 {
                     continue;
@@ -412,10 +411,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             return lastPipeOnFirstLineWithPipeUsage;
         }
 
-        private static PipelineAst MatchingPipelineAstEnd(List<Ast> pipelineAsts, ref int minimumPipelineAstIndex, Token token)
+        private static PipelineAst MatchingPipelineAstEnd(List<Ast> pipelineAsts, Token token)
         {
             PipelineAst matchingPipeLineAstEnd = null;
-            for (int i = minimumPipelineAstIndex; i < pipelineAsts.Count; i++)
+            for (int i = 0; i < pipelineAsts.Count; i++)
             {
                 if (pipelineAsts[i].Extent.EndScriptPosition.LineNumber > token.Extent.EndScriptPosition.LineNumber)
                 {
@@ -425,7 +424,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 if (PositionIsEqual(pipelineAsts[i].Extent.EndScriptPosition, token.Extent.EndScriptPosition))
                 {
                     matchingPipeLineAstEnd = pipelineAsts[i] as PipelineAst;
-                    minimumPipelineAstIndex = i;
                     break;
                 }
             }

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -396,6 +396,12 @@ foo |
 foo |
     bar -Parameter1
 '@
+            },
+            @{ IdempotentScriptDefinition = @'
+Get-TransportRule |
+Select-Object @{ E = $SenderDomainIs | Sort-Object }
+baz
+'@
             }
             ) {
         param ($IdempotentScriptDefinition)
@@ -403,6 +409,20 @@ foo |
         $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = 'None'
         Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
     }
+
+        It 'Should preserve script when using PipelineIndentation IncreaseIndentationAfterEveryPipeline' -TestCases @(
+            @{ PipelineIndentation = 'IncreaseIndentationForFirstPipeline' }
+            @{ PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline' }
+            ) {
+        param ($PipelineIndentation)
+            $IdempotentScriptDefinition = @'
+Get-TransportRule |
+    Select-Object @{ Key = $SenderDomainIs | Sort-Object }
+baz
+'@
+            $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+            Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
+        }
 
         It "Should preserve script when using PipelineIndentation <PipelineIndentation>" -TestCases @(
                 @{ PipelineIndentation = 'IncreaseIndentationForFirstPipeline' }
@@ -496,7 +516,6 @@ foo |
             }
             Test-CorrectionExtentFromContent @params
         }
-
 
         It "Should indent properly after line continuation (backtick) character with pipeline" {
             $def = @'

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -399,8 +399,9 @@ foo |
             },
             @{ IdempotentScriptDefinition = @'
 Get-TransportRule |
+Where-Object @{ $_.name -match "a"} |
 Select-Object @{ E = $SenderDomainIs | Sort-Object }
-baz
+Foreach-Object { $_.FullName }
 '@
             }
             ) {


### PR DESCRIPTION
## PR Summary

Fixes #1832

During debugging I found that the root cause of the issue was that in `MatchingPipelineAstEnd` function, the wrong pipeline was being matched (it was the child and not parent pipeline), which lead to de-indentation to be skipped and ending up with one indentation level too much. Therefore removing this `ref` counter, which is a premature optimisation I have to admit to avoid looping over all pipeline asts every time and can be removed.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.