### PR TITLE
Make messages of UseCorrectCasing more detailed

### DIFF
--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -466,42 +466,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Avoid semicolons as line terminators.
-        /// </summary>
-        internal static string AvoidSemicolonsAsLineTerminatorsCommonName {
-            get {
-                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsCommonName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Line should not end with a semicolon.
-        /// </summary>
-        internal static string AvoidSemicolonsAsLineTerminatorsDescription {
-            get {
-                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Line ends with a semicolon.
-        /// </summary>
-        internal static string AvoidSemicolonsAsLineTerminatorsError {
-            get {
-                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsError", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to AvoidSemicolonsAsLineTerminators.
-        /// </summary>
-        internal static string AvoidSemicolonsAsLineTerminatorsName {
-            get {
-                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsName", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to Avoid multiple type specifiers on parameters.
         /// </summary>
         internal static string AvoidMultipleTypeAttributesCommonName {
@@ -606,6 +570,42 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         internal static string AvoidOverwritingBuiltInCmdletsName {
             get {
                 return ResourceManager.GetString("AvoidOverwritingBuiltInCmdletsName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Avoid semicolons as line terminators.
+        /// </summary>
+        internal static string AvoidSemicolonsAsLineTerminatorsCommonName {
+            get {
+                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsCommonName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Line should not end with a semicolon.
+        /// </summary>
+        internal static string AvoidSemicolonsAsLineTerminatorsDescription {
+            get {
+                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Line ends with a semicolon.
+        /// </summary>
+        internal static string AvoidSemicolonsAsLineTerminatorsError {
+            get {
+                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidSemicolonsAsLineTerminators.
+        /// </summary>
+        internal static string AvoidSemicolonsAsLineTerminatorsName {
+            get {
+                return ResourceManager.GetString("AvoidSemicolonsAsLineTerminatorsName", resourceCulture);
             }
         }
         
@@ -2644,7 +2644,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cmdlet/Function/Parameter does not match its exact casing &apos;{0}&apos;..
+        ///   Looks up a localized string similar to Function/Cmdlet &apos;{0}&apos; does not match its exact casing &apos;{1}&apos;..
         /// </summary>
         internal static string UseCorrectCasingError {
             get {
@@ -2658,6 +2658,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         internal static string UseCorrectCasingName {
             get {
                 return ResourceManager.GetString("UseCorrectCasingName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter &apos;{0}&apos; of function/cmdlet &apos;{1}&apos; does not match its exact casing &apos;{2}&apos;..
+        /// </summary>
+        internal static string UseCorrectCasingParameterError {
+            get {
+                return ResourceManager.GetString("UseCorrectCasingParameterError", resourceCulture);
             }
         }
         

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1099,7 +1099,7 @@
     <value>For better readability and consistency, use the exact casing of the cmdlet/function/parameter.</value>
   </data>
   <data name="UseCorrectCasingError" xml:space="preserve">
-    <value>Cmdlet/Function/Parameter does not match its exact casing '{0}'.</value>
+    <value>Function/Cmdlet '{0}' does not match its exact casing '{1}'.</value>
   </data>
   <data name="UseCorrectCasingName" xml:space="preserve">
     <value>UseCorrectCasing</value>
@@ -1187,5 +1187,8 @@
   </data>
   <data name="AvoidUsingBrokenHashAlgorithmsName" xml:space="preserve">
     <value>AvoidUsingBrokenHashAlgorithms</value>
+  </data>
+  <data name="UseCorrectCasingParameterError" xml:space="preserve">
+    <value>Parameter '{0}' of function/cmdlet '{1}' does not match its exact casing '{2}'.</value>
   </data>
 </root>

--- a/Rules/UseCorrectCasing.cs
+++ b/Rules/UseCorrectCasing.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 if (!commandName.Equals(correctlyCasedCommandName, StringComparison.Ordinal))
                 {
                     yield return new DiagnosticRecord(
-                        string.Format(CultureInfo.CurrentCulture, Strings.UseCorrectCasingError, commandName, shortName),
+                        string.Format(CultureInfo.CurrentCulture, Strings.UseCorrectCasingError, commandName, correctlyCasedCommandName),
                         GetCommandExtent(commandAst),
                         GetName(),
                         DiagnosticSeverity.Warning,
@@ -91,7 +91,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         if (!parameterName.Equals(correctlyCasedParameterName, StringComparison.Ordinal))
                         {
                             yield return new DiagnosticRecord(
-                                string.Format(CultureInfo.CurrentCulture, Strings.UseCorrectCasingError, commandName, parameterName),
+                                string.Format(CultureInfo.CurrentCulture, Strings.UseCorrectCasingParameterError, parameterName, commandName, correctlyCasedParameterName),
                                 GetCommandExtent(commandAst),
                                 GetName(),
                                 DiagnosticSeverity.Warning,


### PR DESCRIPTION
## PR Summary

Fixes #1841 by having different error message for parameter casing mismatch and including more info.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.