### PR TITLE
PSAvoidUsingPositionalParameters: Do not warn on AZ CLI

### DIFF
--- a/Rules/AvoidPositionalParameters.cs
+++ b/Rules/AvoidPositionalParameters.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Management.Automation.Language;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+using System.Linq;
 #if !CORECLR
 using System.ComponentModel.Composition;
 #endif
@@ -18,12 +19,20 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 #if !CORECLR
 [Export(typeof(IScriptRule))]
 #endif
-    public class AvoidPositionalParameters : IScriptRule
+    public class AvoidPositionalParameters : ConfigurableRule
     {
+        [ConfigurableRuleProperty(defaultValue: new string[] { "az" })]
+        public string[] CommandAllowList { get; set; }
+
+        public AvoidPositionalParameters()
+        {
+            Enable = true; // keep it enabled by default, user can still override this with settings
+        }
+
         /// <summary>
         /// AnalyzeScript: Analyze the ast to check that positional parameters are not used.
         /// </summary>
-        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        public override IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
         {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
@@ -57,21 +66,21 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     PipelineAst parent = cmdAst.Parent as PipelineAst;
 
+                    string commandName = cmdAst.GetCommandName();
                     if (parent != null && parent.PipelineElements.Count > 1)
                     {
                         // raise if it's the first element in pipeline. otherwise no.
-                        if (parent.PipelineElements[0] == cmdAst)
+                        if (parent.PipelineElements[0] == cmdAst && !CommandAllowList.Contains(commandName, StringComparer.OrdinalIgnoreCase))
                         {
-                            yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPositionalParametersError, cmdAst.GetCommandName()),
-                                cmdAst.Extent, GetName(), DiagnosticSeverity.Information, fileName, cmdAst.GetCommandName());
+                            yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPositionalParametersError, commandName),
+                                cmdAst.Extent, GetName(), DiagnosticSeverity.Information, fileName, commandName);
                         }
                     }
                     // not in pipeline so just raise it normally
                     else
                     {
-                        string commandName = cmdAst.GetCommandName();
-                        // AZ CLI entrypoint became an az.ps1 script in 2.40.0 so do not raise for it since it is still a CLI https://github.com/PowerShell/PSScriptAnalyzer/issues/1845
-                        if (commandName != "az") {
+                        if (!CommandAllowList.Contains(commandName, StringComparer.OrdinalIgnoreCase))
+                        {
                             yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPositionalParametersError, commandName),
                                 cmdAst.Extent, GetName(), DiagnosticSeverity.Information, fileName, commandName);
                         }
@@ -84,7 +93,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// GetName: Retrieves the name of this rule.
         /// </summary>
         /// <returns>The name of this rule</returns>
-        public string GetName()
+        public override string GetName()
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.AvoidUsingPositionalParametersName);
         }
@@ -93,7 +102,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// GetCommonName: Retrieves the common name of this rule.
         /// </summary>
         /// <returns>The common name of this rule</returns>
-        public string GetCommonName()
+        public override string GetCommonName()
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPositionalParametersCommonName);
         }
@@ -102,7 +111,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// GetDescription: Retrieves the description of this rule.
         /// </summary>
         /// <returns>The description of this rule</returns>
-        public string GetDescription()
+        public override string GetDescription()
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPositionalParametersDescription);
         }
@@ -110,7 +119,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// Method: Retrieves the type of the rule: builtin, managed or module.
         /// </summary>
-        public SourceType GetSourceType()
+        public override SourceType GetSourceType()
         {
             return SourceType.Builtin;
         }
@@ -119,7 +128,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
         /// </summary>
         /// <returns></returns>
-        public RuleSeverity GetSeverity()
+        public override RuleSeverity GetSeverity()
         {
             return RuleSeverity.Information;
         }
@@ -127,7 +136,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <summary>
         /// Method: Retrieves the module/assembly name the rule is from.
         /// </summary>
-        public string GetSourceName()
+        public override string GetSourceName()
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
         }

--- a/Rules/AvoidPositionalParameters.cs
+++ b/Rules/AvoidPositionalParameters.cs
@@ -69,8 +69,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     // not in pipeline so just raise it normally
                     else
                     {
-                        yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPositionalParametersError, cmdAst.GetCommandName()),
-                            cmdAst.Extent, GetName(), DiagnosticSeverity.Information, fileName, cmdAst.GetCommandName());
+                        string commandName = cmdAst.GetCommandName();
+                        // AZ CLI entrypoint became an az.ps1 script in 2.40.0 so do not raise for it since it is still a CLI https://github.com/PowerShell/PSScriptAnalyzer/issues/1845
+                        if (commandName != "az") {
+                            yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingPositionalParametersError, commandName),
+                                cmdAst.Extent, GetName(), DiagnosticSeverity.Information, fileName, commandName);
+                        }
                     }
                 }
             }

--- a/Tests/Rules/AvoidPositionalParameters.tests.ps1
+++ b/Tests/Rules/AvoidPositionalParameters.tests.ps1
@@ -36,6 +36,10 @@ Describe "AvoidPositionalParameters" {
         It "returns no violations for DSC configuration" {
             $noViolationsDSC.Count | Should -Be 0
         }
+
+        It "returns no violations for AZ CLI" {
+            Invoke-ScriptAnalyzer -ScriptDefinition 'az group deployment list' | Should -BeNullOrEmpty
+        }
     }
 
     Context "Function defined and called in script, which has 3 or more positional parameters triggers rule." {

--- a/Tests/Rules/AvoidPositionalParameters.tests.ps1
+++ b/Tests/Rules/AvoidPositionalParameters.tests.ps1
@@ -27,11 +27,11 @@ Describe "AvoidPositionalParameters" {
         }
 
         It "returns violations for command that is not in allow list of settings" {
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'az group deployment list' -Settings @{
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition 'Join-Path a b c d' -Settings @{
                 IncludeRules = @('PSAvoidUsingPositionalParameters')
-                Rules        = @{ PSAvoidUsingPositionalParameters = @{ CommandAllowList = 'Join-Path' } }
+                Rules        = @{ PSAvoidUsingPositionalParameters = @{ CommandAllowList = 'Test-Path' } }
             }
-            $violations.Count | Should -Be 1 # ensure that defaults get removed if setting is supplied
+            $violations.Count | Should -Be 1
             $violations.RuleName | Should -Be 'PSAvoidUsingPositionalParameters'
         }
     }

--- a/docs/Rules/AvoidUsingPositionalParameters.md
+++ b/docs/Rules/AvoidUsingPositionalParameters.md
@@ -20,6 +20,27 @@ rule from being too noisy, this rule gets only triggered when there are 3 or mor
 supplied. A simple example where the risk of using positional parameters is negligible, is
 `Test-Path $Path`.
 
+## Configuration
+
+```powershell
+Rules = @{
+    AvoidUsingPositionalParameters = @{
+        CommandAllowList = 'az', 'Join-Path'
+        Enable           = $true
+    }
+}
+```
+
+### Parameters
+
+#### AvoidUsingPositionalParameters: string[] (Default value is 'az')
+
+Commands to be excluded from this rule. `az` is excluded by default because starting with version 2.40.0 the entrypoint of the AZ CLI became an `az.ps1` script but this script does not have any named parameters and just passes them on using `$args` as is to the Python process that it starts, therefore it is still a CLI and not a PowerShell command.
+
+#### Enable: bool (Default value is `$true`)
+
+Enable or disable the rule during ScriptAnalyzer invocation.
+
 ## How
 
 Use full parameter names when calling commands.


### PR DESCRIPTION
## PR Summary

Fixes  #1845 
AZ CLI entrypoint recently changed from a batch file to an az.ps1 'script' in latest version 2.40.0, which just passed $args arguments as-is to python so it is still a CLI and not a script with parameters.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.