### PR TITLE
CI: Use new Ubuntu 22.04  image and remove deprecated Ubuntu 18.04

### DIFF
--- a/.azure-pipelines-ci/ci.yaml
+++ b/.azure-pipelines-ci/ci.yaml
@@ -22,12 +22,14 @@ stages:
       - job:
         strategy:
           matrix:
-            Ubuntu_18_04:
-              vmImage: ubuntu-18.04
             Ubuntu_20_04:
               vmImage: ubuntu-20.04
-            mac_Latest:
-              vmImage: macOS-latest
+            Ubuntu_22_04:
+              vmImage: ubuntu-22.04
+            macOS_11:
+              vmImage: macOS-11
+            macOS_12:
+              vmImage: macOS-12
             Windows_Server2019_PowerShell_Core:
               vmImage: windows-2019
             Windows_Server2022_PowerShell_Core:

--- a/.azure-pipelines-ci/ci.yaml
+++ b/.azure-pipelines-ci/ci.yaml
@@ -26,10 +26,8 @@ stages:
               vmImage: ubuntu-20.04
             Ubuntu_22_04:
               vmImage: ubuntu-22.04
-            macOS_11:
-              vmImage: macOS-11
-            macOS_12:
-              vmImage: macOS-12
+            mac_Latest:
+              vmImage: macOS-latest
             Windows_Server2019_PowerShell_Core:
               vmImage: windows-2019
             Windows_Server2022_PowerShell_Core:


### PR DESCRIPTION
## PR Summary

See below where Ubuntu 18.04 has been deprecated and will soon be removed. Also there are new Ubuntu 22.04 and macOS 12 images where the latest tag hasn't been updated to point to them. Therefore explicitly adding Ubuntu 22.04, which is better going forward but keep using macos-latest due to their high release frequency.
https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.