### PR TITLE
UseApprovedVerbs.md: Backport minor change of PR 104 in PowerShell-Docs-Modules

### DIFF
--- a/docs/Rules/UseApprovedVerbs.md
+++ b/docs/Rules/UseApprovedVerbs.md
@@ -15,7 +15,7 @@ All cmdlets must used approved verbs.
 
 Approved verbs can be found by running the command `Get-Verb`.
 
-Additional documentation on approved verbs can be found in the microsoft docs page
+Additional documentation on approved verbs can be found at
 [Approved Verbs for PowerShell Commands](https://learn.microsoft.com/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands).
 Some unapproved verbs are documented on the approved verbs page and point to approved alternatives.
 Try searching for the verb you used to find its approved form. For example, searching for `Read`,


### PR DESCRIPTION
## PR Summary

Add missing backport the change to `UseApprovedVerbs.md` of PR 104 in `PowerShell-Docs-Modules`: https://github.com/MicrosoftDocs/PowerShell-Docs-Modules/pull/104/files#diff-7f36cb7cb779ee3d32ec0749bba06c5a5fbd5398106c748acf80fee400ce7115

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.