### PR TITLE
AvoidUsingPositionalParameter: Check if command has parameters to avoid having az in default CommandAllowList

### DIFF
--- a/Engine/Helper.cs
+++ b/Engine/Helper.cs
@@ -615,14 +615,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// </summary>
         /// <param name="cmdAst"></param>
         /// <returns></returns>
-        public bool IsKnownCmdletFunctionOrExternalScript(CommandAst cmdAst)
+        public bool IsKnownCmdletFunctionOrExternalScript(CommandAst cmdAst, out CommandInfo commandInfo)
         {
+            commandInfo = null;
             if (cmdAst == null)
             {
                 return false;
             }
 
-            var commandInfo = GetCommandInfo(cmdAst.GetCommandName());
+            commandInfo = GetCommandInfo(cmdAst.GetCommandName());
             if (commandInfo == null)
             {
                 return false;

--- a/Rules/AvoidPositionalParameters.cs
+++ b/Rules/AvoidPositionalParameters.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Management.Automation.Language;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System.Linq;
+using System.Management.Automation;
 #if !CORECLR
 using System.ComponentModel.Composition;
 #endif
@@ -21,7 +22,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 #endif
     public class AvoidPositionalParameters : ConfigurableRule
     {
-        [ConfigurableRuleProperty(defaultValue: new string[] { "az" })]
+        [ConfigurableRuleProperty(defaultValue: new string[] { })]
         public string[] CommandAllowList { get; set; }
 
         public AvoidPositionalParameters()
@@ -61,9 +62,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // MSDN: CommandAst.GetCommandName Method
                 if (cmdAst.GetCommandName() == null) continue;
                 
-                if ((Helper.Instance.IsKnownCmdletFunctionOrExternalScript(cmdAst) || declaredFunctionNames.Contains(cmdAst.GetCommandName())) &&
+                if ((Helper.Instance.IsKnownCmdletFunctionOrExternalScript(cmdAst, out CommandInfo commandInfo) || declaredFunctionNames.Contains(cmdAst.GetCommandName())) &&
                     (Helper.Instance.PositionalParameterUsed(cmdAst, true)))
                 {
+                    if (commandInfo?.Parameters.Count == 0) continue;
                     PipelineAst parent = cmdAst.Parent as PipelineAst;
 
                     string commandName = cmdAst.GetCommandName();

--- a/Rules/UseCmdletCorrectly.cs
+++ b/Rules/UseCmdletCorrectly.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
 
             // Positional parameters could be mandatory, so we assume all is well
-            if (Helper.Instance.PositionalParameterUsed(cmdAst) && Helper.Instance.IsKnownCmdletFunctionOrExternalScript(cmdAst))
+            if (Helper.Instance.PositionalParameterUsed(cmdAst) && Helper.Instance.IsKnownCmdletFunctionOrExternalScript(cmdAst, out _))
             {
                 return true;
             }

--- a/Tests/Rules/AvoidPositionalParameters.tests.ps1
+++ b/Tests/Rules/AvoidPositionalParameters.tests.ps1
@@ -55,6 +55,11 @@ Describe "AvoidPositionalParameters" {
                 Rules        = @{ PSAvoidUsingPositionalParameters = @{ CommandAllowList = 'az', 'Join-Path' } }
             } | Should -BeNullOrEmpty
         }
+
+        It "returns no violations for script with no defined parameters" {
+            Invoke-ScriptAnalyzer -ScriptDefinition 'join-patH a b c'
+            } | Should -BeNullOrEmpty
+        }
     }
 
     Context "Function defined and called in script, which has 3 or more positional parameters triggers rule." {

--- a/docs/Rules/AvoidUsingPositionalParameters.md
+++ b/docs/Rules/AvoidUsingPositionalParameters.md
@@ -25,7 +25,7 @@ supplied. A simple example where the risk of using positional parameters is negl
 ```powershell
 Rules = @{
     AvoidUsingPositionalParameters = @{
-        CommandAllowList = 'az', 'Join-Path'
+        CommandAllowList = 'Join-Path', 'MyCmdletOrScript'
         Enable           = $true
     }
 }
@@ -33,9 +33,9 @@ Rules = @{
 
 ### Parameters
 
-#### AvoidUsingPositionalParameters: string[] (Default value is 'az')
+#### AvoidUsingPositionalParameters: string[] (Default value is @()')
 
-Commands to be excluded from this rule. `az` is excluded by default because starting with version 2.40.0 the entrypoint of the AZ CLI became an `az.ps1` script but this script does not have any named parameters and just passes them on using `$args` as is to the Python process that it starts, therefore it is still a CLI and not a PowerShell command.
+Commands or scripts to be excluded from this rule.
 
 #### Enable: bool (Default value is `$true`)
 


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.