### PR TITLE
AvoidLongLines: Make internal function DiagnosticSeverity private

### DIFF
--- a/Rules/AvoidLongLines.cs
+++ b/Rules/AvoidLongLines.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// Gets the severity of the returned diagnostic record: error, warning, or information.
         /// </summary>
         /// <returns></returns>
-        public DiagnosticSeverity GetDiagnosticSeverity()
+        private DiagnosticSeverity GetDiagnosticSeverity()
         {
             return DiagnosticSeverity.Warning;
         }


### PR DESCRIPTION
## PR Summary

Code analysis showed that this function is only used by the rule itself, therefore it shouldn't have been public. No change of behavior. Technically breaking but this method was never intended to be public and other rules do not have public methods to return the DiagnosticSeverity they will emit, in fact depending on the analysis they might be different.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.