### PR TITLE
Improve Pester bootstrap logic for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,7 @@ built-in rules.
 
 Pester-based ScriptAnalyzer Tests are located in `path/to/PSScriptAnalyzer/Tests` folder.
 
-- Ensure [Pester 4.3.1](https://www.powershellgallery.com/packages/Pester/4.3.1) or higher is
-  installed
+- Ensure [Pester](https://www.powershellgallery.com/packages/Pester) of at least version 5.3 is installed
 - In the root folder of your local repository, run:
 
 ```powershell

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -4,8 +4,8 @@
 $ErrorActionPreference = 'Stop'
 
 function Install-Pester {
-    $requiredPesterVersion = '5.2.2'
-    $pester = Get-Module Pester -ListAvailable | Where-Object { $_.Version -eq $requiredPesterVersion }
+    $requiredPesterVersion = '5.3'
+    $pester = Get-Module Pester -ListAvailable | Where-Object { $_.Version -ge $requiredPesterVersion }
     if ($null -eq $pester) {
         if ($null -eq (Get-Module -ListAvailable PowershellGet)) {
             # WMF 4 image build


### PR DESCRIPTION
## PR Summary

This will improve CI times as it won't bootstrap a specific Pester version any more as long as a version >5.3 is there, which is always already the case in the Microsoft hosted agents.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.