### PR TITLE
Add ErrorView to SpecialVars.cs

### DIFF
--- a/Engine/SpecialVars.cs
+++ b/Engine/SpecialVars.cs
@@ -91,6 +91,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         internal const string ConfirmPreference = "ConfirmPreference";
         internal const string ProgressPreference = "ProgressPreference";
         internal const string InformationPreference = "InformationPreference";
+        internal const string ErrorView = "ErrorView";
 
         internal static readonly string[] PreferenceVariables = new string[]
                                                                 {
@@ -101,7 +102,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                                                                     WarningPreference,
                                                                     ConfirmPreference,
                                                                     ProgressPreference,
-                                                                    InformationPreference
+                                                                    InformationPreference,
+                                                                    ErrorView
                                                                 };
 
         internal static readonly Type[] PreferenceVariableTypes = new Type[]
@@ -114,6 +116,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                                                                     /* ConfirmPreference */ typeof(ConfirmImpact),
                                                                     /* ProgressPreference */ typeof(Enum),
                                                                     /* InformationPreference */ typeof(ActionPreference),
+                                                                    /* ErrorView */         typeof(ErrorView),
                                                                 };
 
         internal enum AutomaticVariable

--- a/Engine/SpecialVars.cs
+++ b/Engine/SpecialVars.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                                                                     /* ConfirmPreference */ typeof(ConfirmImpact),
                                                                     /* ProgressPreference */ typeof(Enum),
                                                                     /* InformationPreference */ typeof(ActionPreference),
-                                                                    /* ErrorView */         typeof(ErrorView),
+                                                                    /* ErrorView */         typeof(Enum), //ErrorView type not available on PS3
                                                                 };
 
         internal enum AutomaticVariable

--- a/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
+++ b/Tests/Rules/UseDeclaredVarsMoreThanAssignments.tests.ps1
@@ -72,6 +72,11 @@ function MyFunc2() {
     }
 
     Context "When there are no violations" {
+        It "No warning is issued for assignment without use of preference variable ErrorView" {
+            $results = Invoke-ScriptAnalyzer -ScriptDefinition '$ErrorView = NormalView'
+            $results.Count | Should -Be 0
+        }
+
         It "returns no violations" {
             $noViolations.Count | Should -Be 0
         }


### PR DESCRIPTION
## PR Summary

Fixes #1749 
No warning is issued for `Errorview` by rule `PSUseDeclaredVarsMoreThanAssignment`

- Added `ErrorView` to `SpecialVars.cs`
- Added test for warning mentioned in issue

## Additional Notes

I could not use the correct type for `ErrorView` as the type ErrorView is not available in PS3 and instead declared it's type as an `Enum`.
However I found that inside `SpecialVars.cs` the array of types : `Type[] PreferenceVariableTypes` , is not used anywhere, so is there a reason for it to exist?
https://github.com/PowerShell/PSScriptAnalyzer/blob/77f65007e3e336624b747ace39952f59f5517afa/Engine/SpecialVars.cs#L107


## PR Context

When we try to assign a new state to a Preference Variable like `ErrorView` it should not be flagged as a warning by the rule `PSUseDeclaredVarsMoreThanAssignment`. In order to prevent the rule from showing this warning there is a check for built in variables: https://github.com/PowerShell/PSScriptAnalyzer/blob/77f65007e3e336624b747ace39952f59f5517afa/Rules/UseDeclaredVarsMoreThanAssignments.cs#L203

This checks for the presence of the Preference Variable's declaration inside the `SpecialVars.cs` file. If it's in that file `PSUseDeclaredVarsMoreThanAssignment` stops throwing the warning.


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.