### PR TITLE
#1744 Add a rule to alert catch [RuntimeException] { ... }Initial branch

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/PSScriptAnalyzer.iml
+++ b/.idea/PSScriptAnalyzer.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/PSScriptAnalyzer.iml" filepath="$PROJECT_DIR$/.idea/PSScriptAnalyzer.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/Rules/AvoidGeneralCatch.cs
+++ b/Rules/AvoidGeneralCatch.cs
@@ -37,10 +37,24 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 if (catchAst.CatchTypes.Count == 0) 
                 {
-                    yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchError),
+                    yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchErrorEmpty),
                         catchAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
                 }
                 else
+                {
+
+                    foreach (TypeConstraintAst caughtAst in catchAst.CatchTypes) {
+                        if (string.Equals(caughtAst.TypeName.FullName, "RuntimeException", StringComparison.CurrentCultureIgnoreCase) || string.Equals(caughtAst.TypeName.FullName, "System.Management.Automation.RuntimeException", StringComparison.CurrentCultureIgnoreCase)) {
+                        
+                        yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchError),
+                            caughtAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
+
+                        }
+                    }
+                }
+
+/**
+                if (catchAst.CatchTypes.Count != 0)
                 {
 
                     foreach (TypeConstraintAst caughtAst in catchAst.CatchTypes) {
@@ -52,6 +66,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         }
                     }
                 }
+                **/
             }
         }
 

--- a/Rules/AvoidGeneralCatch.cs
+++ b/Rules/AvoidGeneralCatch.cs
@@ -43,13 +43,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
                 else{
 
-                    print("successful compile");
+                    //print("successful compile");
 
-                    foreach (CatchClauseAst catchAst in Catch.CatchTypes) {
-                        if (catchAst.type == RuntimeException) {
+                    foreach (TypeConstraintAst caughtAst in catchAst.CatchTypes) {
+                        if (caughtAst.TypeName.FullName.Equals("runtimeexception")) {
                         
                         yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchError),
-                            catchAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
+                            caughtAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
 
                         }
                     }
@@ -81,7 +81,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// <returns>The description of this rule</returns>
         public string GetDescription()
         {
-            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingGeneralCatchDescription);
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchDescription);
         }
 
         /// <summary>

--- a/Rules/AvoidGeneralCatch.cs
+++ b/Rules/AvoidGeneralCatch.cs
@@ -35,18 +35,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 CatchClauseAst catchAst = (CatchClauseAst)foundAst;
 
-                //CatchClauseAst catchAst = (CatchClauseAst)foundAst;
-                if (catchAst.CatchTypes.Count == 0) {
+                if (catchAst.CatchTypes.Count == 0) 
+                {
                     yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchError),
                         catchAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
                 }
-
-                else{
-
-                    //print("successful compile");
+                else
+                {
 
                     foreach (TypeConstraintAst caughtAst in catchAst.CatchTypes) {
-                        if (caughtAst.TypeName.FullName.Equals("runtimeexception")) {
+                        if (string.Equals(caughtAst.TypeName.FullName, "RuntimeException", StringComparison.CurrentCultureIgnoreCase) | string.Equals(caughtAst.TypeName.FullName, "System.Management.Automation.RuntimeException", StringComparison.CurrentCultureIgnoreCase)); {
                         
                         yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchError),
                             caughtAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);

--- a/Rules/AvoidGeneralCatch.cs
+++ b/Rules/AvoidGeneralCatch.cs
@@ -13,7 +13,7 @@ using System.Globalization;
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
     /// <summary>
-    /// AvoidGeneralCatch: Check if any empty catch block is used.
+    /// AvoidGeneralCatch: Check if catch clause type is RuntimeException and caution against using it  
     /// </summary>
 #if !CORECLR
 [Export(typeof(IScriptRule))]
@@ -35,18 +35,25 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 CatchClauseAst catchAst = (CatchClauseAst)foundAst;
 
-//code goes here
-               /* if (catchAst.Body.Statements.Count == 0)
-               no need for statement check?
-
-                {
-                 #   yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchError),
-                  #      catchAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
-                  if getName == RuntimeExcewption>
-                  is getName catch clause?
-                
+                //CatchClauseAst catchAst = (CatchClauseAst)foundAst;
+                if (catchAst.CatchTypes.Count == 0) {
+                    yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchError),
+                        catchAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
                 }
-                */
+
+                else{
+
+                    print("successful compile");
+
+                    foreach (CatchClauseAst catchAst in Catch.CatchTypes) {
+                        if (catchAst.type == RuntimeException) {
+                        
+                        yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchError),
+                            catchAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
+
+                        }
+                    }
+                }
             }
         }
 
@@ -101,9 +108,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
         }
-
     }
 }
+
+    
 
 
 

--- a/Rules/AvoidGeneralCatch.cs
+++ b/Rules/AvoidGeneralCatch.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Management.Automation.Language;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+#if !CORECLR
+using System.ComponentModel.Composition;
+#endif
+using System.Globalization;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
+{
+    /// <summary>
+    /// AvoidGeneralCatch: Check if any empty catch block is used.
+    /// </summary>
+#if !CORECLR
+[Export(typeof(IScriptRule))]
+#endif
+    public class AvoidGeneralCatch : IScriptRule
+    {
+        /// <summary>
+        /// AnalyzeScript: Analyze the script to check if any empty catch block is used.
+        /// </summary>
+        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
+            if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
+
+            // Finds all CommandAsts.
+            IEnumerable<Ast> foundAsts = ast.FindAll(testAst => testAst is CatchClauseAst, true);
+
+            // Iterates all CatchClauseAst and check the statements count.
+            foreach (Ast foundAst in foundAsts)
+            {
+                CatchClauseAst catchAst = (CatchClauseAst)foundAst;
+
+//code goes here
+               /* if (catchAst.Body.Statements.Count == 0)
+               no need for statement check?
+
+                {
+                 #   yield return new DiagnosticRecord(string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchError),
+                  #      catchAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
+                  if getName == RuntimeExcewption>
+                  is getName catch clause?
+                
+                }
+                */
+            }
+        }
+
+        /// <summary>
+        /// GetName: Retrieves the name of this rule.
+        /// </summary>
+        /// <returns>The name of this rule</returns>
+        public string GetName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.AvoidGeneralCatchName);
+        }
+
+        /// <summary>
+        /// GetCommonName: Retrieves the common name of this rule.
+        /// </summary>
+        /// <returns>The common name of this rule</returns>
+        public string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidGeneralCatchCommonName);
+        }
+
+        /// <summary>
+        /// GetDescription: Retrieves the description of this rule.
+        /// </summary>
+        /// <returns>The description of this rule</returns>
+        public string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingGeneralCatchDescription);
+        }
+
+        /// <summary>
+        /// Method: Retrieves the type of the rule: builtin, managed or module.
+        /// </summary>
+        public SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity: Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns></returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
+
+        /// <summary>
+        /// Method: Retrieves the module/assembly name the rule is from.
+        /// </summary>
+        public string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+
+    }
+}
+
+
+
+

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -290,7 +290,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         /// </summary>
         internal static string AvoidGeneralCatchError {
             get {
-                return ResourceManager.GetString("AvoidLongGeneralCatchError", resourceCulture);
+                return ResourceManager.GetString("AvoidGeneralCatchError", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string when no specific exception is caught.
+        /// </summary>
+        internal static string AvoidGeneralCatchErrorEmpty {
+            get {
+                return ResourceManager.GetString("AvoidGeneralCatchErrorEmpty", resourceCulture);
             }
         }
         

--- a/Rules/Strings.Designer.cs
+++ b/Rules/Strings.Designer.cs
@@ -284,6 +284,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
                 return ResourceManager.GetString("AvoidEmptyCatchBlockError", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to General catch block is used.
+        /// </summary>
+        internal static string AvoidGeneralCatchError {
+            get {
+                return ResourceManager.GetString("AvoidLongGeneralCatchError", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Avoid global aliases..
@@ -1013,6 +1022,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
                 return ResourceManager.GetString("AvoidUsingEmptyCatchBlockCommonName", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Avoid Using catch block of type RuntimeException.
+        /// </summary>
+        internal static string AvoidGeneralCatchCommonName {
+            get {
+                return ResourceManager.GetString("AvoidGeneralCatchCommonName", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Empty catch blocks are considered poor design decisions because if an error occurs in the try block, this error is simply swallowed and not acted upon. While this does not inherently lead to bad things. It can and this should be avoided if possible. To fix a violation of this rule, using Write-Error or throw statements in catch blocks..
@@ -1022,6 +1040,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
                 return ResourceManager.GetString("AvoidUsingEmptyCatchBlockDescription", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Empty catch blocks are considered poor design decisions because if an error occurs in the try block, this error is simply swallowed and not acted upon. While this does not inherently lead to bad things. It can and this should be avoided if possible. To fix a violation of this rule, using Write-Error or throw statements in catch blocks..
+        /// </summary>
+        internal static string AvoidGeneralCatchDescription {
+            get {
+                return ResourceManager.GetString("AvoidGeneralCatchDescription", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to AvoidUsingEmptyCatchBlock.
@@ -1029,6 +1056,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer {
         internal static string AvoidUsingEmptyCatchBlockName {
             get {
                 return ResourceManager.GetString("AvoidUsingEmptyCatchBlockName", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AvoidGeneralCatchBlock.
+        /// </summary>
+        internal static string AvoidGeneralCatchName {
+            get {
+                return ResourceManager.GetString("AvoidUsingEmptyCatchName", resourceCulture);
             }
         }
         

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -126,7 +126,7 @@
   <data name="AvoidUsingEmptyCatchBlockDescription" xml:space="preserve">
     <value>Empty catch blocks are considered poor design decisions because if an error occurs in the try block, this error is simply swallowed and not acted upon. While this does not inherently lead to bad things. It can and this should be avoided if possible. To fix a violation of this rule, using Write-Error or throw statements in catch blocks.</value>
   </data>
-  <data name="AvoidUsingGeneralCatchDescription" xml:space="preserve">
+  <data name="AvoidGeneralCatchDescription" xml:space="preserve">
     <value>A catch block with the type system.management.automation.runtimeexception should not be used in a catch block as it will incorrectly catch all exceptions </value>
   </data>
   <data name="AvoidUsingEmptyCatchBlockCommonName" xml:space="preserve">
@@ -383,6 +383,9 @@
   </data>
   <data name="AvoidUsingEmptyCatchBlockName" xml:space="preserve">
     <value>AvoidUsingEmptyCatchBlock</value>
+  </data>
+  <data name="AvoidGeneralCatchName" xml:space="preserve">
+    <value>AvoidGeneralCatch</value>
   </data>
   <data name="AvoidUsingInvokeExpressionRuleName" xml:space="preserve">
     <value>AvoidUsingInvokeExpression</value>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -525,6 +525,9 @@
   <data name="AvoidGeneralCatchError" xml:space="preserve">
     <value>Runtime Exception is used in catch block. Avoid using this as it will catch all exceptions.</value>
   </data>
+  <data name="AvoidGeneralCatchErrorEmpty" xml:space="preserve">
+    <value>No specific exception is being caught.</value>
+  </data>
   <data name="AvoidUsingCmdletAliasesError" xml:space="preserve">
     <value>'{0}' is an alias of '{1}'. Alias can introduce possible problems and make scripts hard to maintain. Please consider changing alias to its full content.</value>
   </data>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -126,8 +126,14 @@
   <data name="AvoidUsingEmptyCatchBlockDescription" xml:space="preserve">
     <value>Empty catch blocks are considered poor design decisions because if an error occurs in the try block, this error is simply swallowed and not acted upon. While this does not inherently lead to bad things. It can and this should be avoided if possible. To fix a violation of this rule, using Write-Error or throw statements in catch blocks.</value>
   </data>
+  <data name="AvoidUsingGeneralCatchDescription" xml:space="preserve">
+    <value>A catch block with the type system.management.automation.runtimeexception should not be used in a catch block as it will incorrectly catch all exceptions </value>
+  </data>
   <data name="AvoidUsingEmptyCatchBlockCommonName" xml:space="preserve">
     <value>Avoid Using Empty Catch Block</value>
+  </data>
+  <data name="AvoidGeneralCatchCommonName" xml:space="preserve">
+    <value>Avoid using General Catch type</value>
   </data>
   <data name="AvoidUsingInvokeExpressionRuleDescription" xml:space="preserve">
     <value>The Invoke-Expression cmdlet evaluates or runs a specified string as a command and returns the results of the expression or command. It can be extraordinarily powerful so it is not that you want to never use it but you need to be very careful about using it.  In particular, you are probably on safe ground if the data only comes from the program itself.  If you include any data provided from the user - you need to protect yourself from Code Injection. To fix a violation of this rule, please remove Invoke-Expression from script and find other options instead.</value>
@@ -512,6 +518,9 @@
   </data>
   <data name="AvoidEmptyCatchBlockError" xml:space="preserve">
     <value>Empty catch block is used. Please use Write-Error or throw statements in catch blocks.</value>
+  </data>
+  <data name="AvoidGeneralCatchError" xml:space="preserve">
+    <value>Runtime Exception is used in catch block. Avoid using this as it will catch all exceptions.</value>
   </data>
   <data name="AvoidUsingCmdletAliasesError" xml:space="preserve">
     <value>'{0}' is an alias of '{1}'. Alias can introduce possible problems and make scripts hard to maintain. Please consider changing alias to its full content.</value>

--- a/Tests/Rules/AvoidGeneralCatch.ps1
+++ b/Tests/Rules/AvoidGeneralCatch.ps1
@@ -2,11 +2,19 @@ try
 {
     1/0
 }
+catch [DivideByZeroException]
+{
+    "catch divide by zero exception"
+}
 catch [System.Management.Automation.RuntimeException]
 {
-
+    "catch RuntimeException"
+}
+catch
+{
+    "No exception"
 }
 finally
 {
-    Write-Host "cleaning up ..."
+    "cleaning up ..."
 }

--- a/Tests/Rules/AvoidGeneralCatch.ps1
+++ b/Tests/Rules/AvoidGeneralCatch.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 try
 {
     1/0

--- a/Tests/Rules/AvoidGeneralCatch.ps1
+++ b/Tests/Rules/AvoidGeneralCatch.ps1
@@ -1,0 +1,12 @@
+try
+{
+    1/0
+}
+catch [System.Management.Automation.RuntimeException]
+{
+
+}
+finally
+{
+    Write-Host "cleaning up ..."
+}

--- a/Tests/Rules/AvoidGeneralCatch.tests.ps1
+++ b/Tests/Rules/AvoidGeneralCatch.tests.ps1
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+BeforeAll {
+    $violationMessage = "Runtime Exception as catch block type is used. Please use Write-Error or throw statements in catch blocks."
+    $violationName = "PSAvoidGeneralCatch"
+    $violations = Invoke-ScriptAnalyzer $PSScriptRoot\AvoidGeneralCatch.ps1 | Where-Object {$_.RuleName -eq $violationName}
+    #$noViolations = Invoke-ScriptAnalyzer $PSScriptRoot\AvoidEmptyCatchBlockNoViolations.ps1 | Where-Object {$_.RuleName -eq $violationName}
+}
+
+Describe "UseDeclaredVarsMoreThanAssignments" {
+    Context "When there are violations" {
+        It "has 2 avoid using empty Catch block violations" {
+            $violations.Count | Should -Be 2
+        }
+
+        It "has the correct description message" {
+            $violations[0].Message | Should -Match $violationMessage
+        }
+
+    }
+
+    Context "When there are no violations" {
+        It "returns no violations" {
+            $noViolations.Count | Should -Be 0
+        }
+    }
+}

--- a/Tests/Rules/AvoidGeneralCatch.tests.ps1
+++ b/Tests/Rules/AvoidGeneralCatch.tests.ps1
@@ -5,24 +5,14 @@ BeforeAll {
     $violationMessage = "Runtime Exception as catch block type is used. Please use Write-Error or throw statements in catch blocks."
     $violationName = "PSAvoidGeneralCatch"
     $violations = Invoke-ScriptAnalyzer $PSScriptRoot\AvoidGeneralCatch.ps1 | Where-Object {$_.RuleName -eq $violationName}
-    #$noViolations = Invoke-ScriptAnalyzer $PSScriptRoot\AvoidEmptyCatchBlockNoViolations.ps1 | Where-Object {$_.RuleName -eq $violationName}
 }
 
 Describe "UseDeclaredVarsMoreThanAssignments" {
-    Context "When there are violations" {
-        It "has 2 avoid using empty Catch block violations" {
-            $violations.Count | Should -Be 2
-        }
-
-        It "has the correct description message" {
-            $violations[0].Message | Should -Match $violationMessage
-        }
-
+    It "has 2 violations satisfying AvoidGeneralCatch rule" {
+        $violations.Count | Should -Be 2
     }
 
-    Context "When there are no violations" {
-        It "returns no violations" {
-            $noViolations.Count | Should -Be 0
-        }
+    It "has the correct description message" {
+        $violations[0].Message | Should -Match $violationMessage
     }
 }


### PR DESCRIPTION
## PR Summary

Addition of rule to advise users against using catch blocks with type RuntimeException.

Reason for rule is catch blocks with type RuntimeException catch any type of exception behaving the same as an unqualified catchblock. Tests for rule ensure situations with catch block of type RuntimeException and catchblocks without a specified exception type are caught

## PR Checklist

- [ X ] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [ X ] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ X ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [ X ] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ X ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ X ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.