### PR TITLE
Fix `AvoidUsingDoubleQuotesForConstantString` information in overview README

### DIFF
--- a/docs/Rules/README.md
+++ b/docs/Rules/README.md
@@ -31,7 +31,7 @@ The PSScriptAnalyzer contains the following rule definitions.
 | [AvoidUsingComputerNameHardcoded](./AvoidUsingComputerNameHardcoded.md)                           | Error       |        Yes         |                 |
 | [AvoidUsingConvertToSecureStringWithPlainText](./AvoidUsingConvertToSecureStringWithPlainText.md) | Error       |        Yes         |                 |
 | [AvoidUsingDeprecatedManifestFields](./AvoidUsingDeprecatedManifestFields.md)                     | Warning     |        Yes         |                 |
-| [AvoidUsingDoubleQuotesForConstantString](./AvoidUsingDoubleQuotesForConstantString.md)           | Warning     |         No         |       Yes       |
+| [AvoidUsingDoubleQuotesForConstantString](./AvoidUsingDoubleQuotesForConstantString.md)           | Information |         No         |                 |
 | [AvoidUsingEmptyCatchBlock](./AvoidUsingEmptyCatchBlock.md)                                       | Warning     |        Yes         |                 |
 | [AvoidUsingInvokeExpression](./AvoidUsingInvokeExpression.md)                                     | Warning     |        Yes         |                 |
 | [AvoidUsingPlainTextForPassword](./AvoidUsingPlainTextForPassword.md)                             | Warning     |        Yes         |                 |


### PR DESCRIPTION
## PR Summary

As identified[^1] by @BenedekFarkas, the line in the rules overview readme for `AvoidUsingDoubleQuotesForConstantString` incorrectly lists the severity as `Warning` and that the rule is configurable when the severity is `Information`[^2] and there aren't any configurable options.

This change copies the fix @BenedekFarkas kindly submitted to the docs site to ensure the documentation stays up-to-date.

[^1]: For more information, see:

      - MicrosoftDocs/PowerShell-Docs-Modules#128

[^2]: Source code:

      https://github.com/PowerShell/PSScriptAnalyzer/blob/9a6ce978d870909e688d9da0d101d3fc00b504f0/Rules/AvoidUsingDoubleQuotesForConstantString.cs#L142

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.