### PR TITLE
Minor test fix for UseCorrectCasing rule

### DIFF
--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -11,7 +11,7 @@ Describe "UseCorrectCasing" {
     }
 
     It "corrects case of of cmdlet inside interpolated string" {
-        Invoke-Formatter '"$(get-childitem)"' | Should -Be '"$(get-childitem)"'
+        Invoke-Formatter '"$(get-childitem)"' | Should -Be '"$(Get-ChildItem)"'
     }
 
     It "Corrects alias correctly" {


### PR DESCRIPTION
This test seems to have been wrong, so have corrected it
## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.