### PR TITLE
Make Invoke-Formatter test case assertion fail in case of incorrect casing

### DIFF
--- a/Tests/Rules/UseCorrectCasing.tests.ps1
+++ b/Tests/Rules/UseCorrectCasing.tests.ps1
@@ -11,7 +11,7 @@ Describe "UseCorrectCasing" {
     }
 
     It "corrects case of of cmdlet inside interpolated string" {
-        Invoke-Formatter '"$(get-childitem)"' | Should -Be '"$(Get-ChildItem)"'
+        Invoke-Formatter '"$(get-childitem)"' | Should -BeExactly '"$(Get-ChildItem)"'
     }
 
     It "Corrects alias correctly" {


### PR DESCRIPTION
## PR Summary

This PR fixes the test `"corrects case of of cmdlet inside interpolated string"` for `Invoke-Formatter`. It follows #1885 which didn't fully fixed the test.

## Additional Info

The idea is to use `-BeExactly` for case-sensitive strings comparison.
With changes in the PR the test fails when the expected string is `'"$(get-childItem)"'`:

```
[-] UseCorrectCasing.corrects case of of cmdlet inside interpolated string 19ms (17ms|1ms)
 Expected strings to be the same, but they were different.
 String lengths are both 18.
 Strings differ at index 3.
 Expected: '"$(get-childItem)"'
 But was:  '"$(Get-ChildItem)"'
            ---^
 at Invoke-Formatter '"$(get-childitem)"' | Should -BeExactly '"$(get-childItem)"', /Users/redko.o/src/github.com/PowerShell/PSScriptAnalyzer/Tests/Rules/UseCorrectCasing.tests.ps1:14
 at <ScriptBlock>, /Users/redko.o/src/github.com/PowerShell/PSScriptAnalyzer/Tests/Rules/UseCorrectCasing.tests.ps1:14
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.