### PR TITLE
Set Invoke-ScriptAnalyzer Path default value

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -42,12 +42,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         /// </summary>
         [Parameter(Position = 0,
             ParameterSetName = ParameterSet_Path_IncludeSuppressed,
-            Mandatory = true,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         [Parameter(Position = 0,
             ParameterSetName = ParameterSet_Path_SuppressedOnly,
-            Mandatory = true,
             ValueFromPipeline = true,
             ValueFromPipelineByPropertyName = true)]
         [ValidateNotNull]
@@ -57,7 +55,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             get { return path; }
             set { path = value; }
         }
-        private string path;
+        private string path = ".";
 
         /// <summary>
         /// ScriptDefinition: a script definition in the form of a string to run rules on.


### PR DESCRIPTION
## PR Summary

Removes `Path` as a mandatory parameter and sets the default to the current working directory.

Resolves #1887

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.