### PR TITLE
Enable suppression of PSAvoidAssignmentToAutomaticVariable for specific variable or parameter

### DIFF
--- a/Rules/AvoidAssignmentToAutomaticVariable.cs
+++ b/Rules/AvoidAssignmentToAutomaticVariable.cs
@@ -62,20 +62,20 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 if (_readOnlyAutomaticVariables.Contains(variableName, StringComparer.OrdinalIgnoreCase))
                 {
                     yield return new DiagnosticRecord(DiagnosticRecordHelper.FormatError(Strings.AvoidAssignmentToReadOnlyAutomaticVariableError, variableName),
-                                                      variableExpressionAst.Extent, GetName(), DiagnosticSeverity.Error, fileName);
+                                                      variableExpressionAst.Extent, GetName(), DiagnosticSeverity.Error, fileName, variableName);
                 }
 
                 if (_readOnlyAutomaticVariablesIntroducedInVersion6_0.Contains(variableName, StringComparer.OrdinalIgnoreCase))
                 {
                     var severity = IsPowerShellVersion6OrGreater() ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning;
                     yield return new DiagnosticRecord(DiagnosticRecordHelper.FormatError(Strings.AvoidAssignmentToReadOnlyAutomaticVariableIntroducedInPowerShell6_0Error, variableName),
-                                                      variableExpressionAst.Extent, GetName(), severity, fileName);
+                                                      variableExpressionAst.Extent, GetName(), severity, fileName, variableName);
                 }
 
                 if (_writableAutomaticVariables.Contains(variableName, StringComparer.OrdinalIgnoreCase))
                 {
                     yield return new DiagnosticRecord(DiagnosticRecordHelper.FormatError(Strings.AvoidAssignmentToWritableAutomaticVariableError, variableName),
-                                                      variableExpressionAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
+                                                      variableExpressionAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName, variableName);
                 }
             }
 
@@ -93,20 +93,20 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 if (_readOnlyAutomaticVariables.Contains(variableName, StringComparer.OrdinalIgnoreCase))
                 {
                     yield return new DiagnosticRecord(DiagnosticRecordHelper.FormatError(Strings.AvoidAssignmentToReadOnlyAutomaticVariableError, variableName),
-                                                      variableExpressionAst.Extent, GetName(), DiagnosticSeverity.Error, fileName);
+                                                      variableExpressionAst.Extent, GetName(), DiagnosticSeverity.Error, fileName, variableName);
                 }
 
                 if (_readOnlyAutomaticVariablesIntroducedInVersion6_0.Contains(variableName, StringComparer.OrdinalIgnoreCase))
                 {
                     var severity = IsPowerShellVersion6OrGreater() ? DiagnosticSeverity.Error : DiagnosticSeverity.Warning;
                     yield return new DiagnosticRecord(DiagnosticRecordHelper.FormatError(Strings.AvoidAssignmentToReadOnlyAutomaticVariableIntroducedInPowerShell6_0Error, variableName),
-                                                      variableExpressionAst.Extent, GetName(), severity, fileName);
+                                                      variableExpressionAst.Extent, GetName(), severity, fileName, variableName);
                 }
 
                 if (_writableAutomaticVariables.Contains(variableName, StringComparer.OrdinalIgnoreCase))
                 {
                     yield return new DiagnosticRecord(DiagnosticRecordHelper.FormatError(Strings.AvoidAssignmentToWritableAutomaticVariableError, variableName),
-                                                      variableExpressionAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName);
+                                                      variableExpressionAst.Extent, GetName(), DiagnosticSeverity.Warning, fileName, variableName);
                 }
             }
         }

--- a/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
+++ b/Tests/Rules/AvoidAssignmentToAutomaticVariable.tests.ps1
@@ -7,59 +7,60 @@ BeforeAll {
 
 Describe "AvoidAssignmentToAutomaticVariables" {
     Context "ReadOnly Variables" {
+        BeforeDiscovery {
+            $excpectedSeverityForAutomaticVariablesInPowerShell6 = 'Warning'
+            if ($PSVersionTable.PSVersion.Major -ge 6)
+            {
+                $excpectedSeverityForAutomaticVariablesInPowerShell6 = 'Error'
+            }
 
-        $excpectedSeverityForAutomaticVariablesInPowerShell6 = 'Warning'
-        if ($PSVersionTable.PSVersion.Major -ge 6)
-        {
-            $excpectedSeverityForAutomaticVariablesInPowerShell6 = 'Error'
+            $testCases_AutomaticVariables = @(
+                @{ VariableName = '?'; ExpectedSeverity = 'Error'; IsReadOnly = $true }
+                @{ VariableName = 'Error' ; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'ExecutionContext'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'false'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'Home'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'Host'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'PID'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'PSCulture'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'PSEdition'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'PSHome'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'PSUICulture'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'PSVersionTable'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'ShellId'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                @{ VariableName = 'true'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
+                # Variables introduced only in PowerShell 6+ have a Severity of Warning only
+                @{ VariableName = 'IsCoreCLR'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
+                @{ VariableName = 'IsLinux'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
+                @{ VariableName = 'IsMacOS'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
+                @{ VariableName = 'IsWindows'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
+                @{ VariableName = '_'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'AllNodes'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'Args'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'ConsoleFilename'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'Event'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'EventArgs'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'EventSubscriber'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'ForEach'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'Input'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'Matches'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'MyInvocation'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'NestedPromptLevel'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'Profile'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'PSBoundParameters'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'PsCmdlet'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'PSCommandPath'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'ReportErrorShowExceptionClass'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'ReportErrorShowInnerException'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'ReportErrorShowSource'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'ReportErrorShowStackTrace'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'Sender'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'StackTrace'; ExpectedSeverity = 'Warning' }
+                @{ VariableName = 'This'; ExpectedSeverity = 'Warning' }
+            )
+
+            $testCases_ReadOnlyAutomaticVariables = $testCases_AutomaticVariables | Where-Object { $_.IsReadonly }
         }
-
-        $testCases_AutomaticVariables = @(
-            @{ VariableName = '?'; ExpectedSeverity = 'Error'; IsReadOnly = $true }
-            @{ VariableName = 'Error' ; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'ExecutionContext'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'false'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'Home'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'Host'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'PID'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'PSCulture'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'PSEdition'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'PSHome'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'PSUICulture'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'PSVersionTable'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'ShellId'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            @{ VariableName = 'true'; ExpectedSeverity = 'Error';  IsReadOnly = $true }
-            # Variables introduced only in PowerShell 6+ have a Severity of Warning only
-            @{ VariableName = 'IsCoreCLR'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
-            @{ VariableName = 'IsLinux'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
-            @{ VariableName = 'IsMacOS'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
-            @{ VariableName = 'IsWindows'; ExpectedSeverity = $excpectedSeverityForAutomaticVariablesInPowerShell6; OnlyPresentInCoreClr = $true }
-            @{ VariableName = '_'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'AllNodes'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'Args'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'ConsoleFilename'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'Event'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'EventArgs'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'EventSubscriber'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'ForEach'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'Input'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'Matches'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'MyInvocation'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'NestedPromptLevel'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'Profile'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'PSBoundParameters'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'PsCmdlet'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'PSCommandPath'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'ReportErrorShowExceptionClass'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'ReportErrorShowInnerException'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'ReportErrorShowSource'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'ReportErrorShowStackTrace'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'Sender'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'StackTrace'; ExpectedSeverity = 'Warning' }
-            @{ VariableName = 'This'; ExpectedSeverity = 'Warning' }
-        )
-
-        $testCases_ReadOnlyAutomaticVariables = $testCases_AutomaticVariables | Where-Object { $_.IsReadonly }
 
         It "Variable <VariableName> produces warning of Severity <ExpectedSeverity>" -TestCases $testCases_AutomaticVariables {
             param ($VariableName, $ExpectedSeverity)
@@ -133,6 +134,29 @@ Describe "AvoidAssignmentToAutomaticVariables" {
                 }
             }
         }
+    }
 
+    Context 'Suppression' {
+        BeforeDiscovery {
+            $testCases_RuleSuppression = @(
+                @{ VariableName = 'true'; Type = 'ReadOnlyAutomaticVariableError' }
+                @{ VariableName = 'IsWindows'; Type = 'ReadOnlyAutomaticVariableIntroducedInPowerShell6_0Error' }
+                @{ VariableName = 'ForEach'; Type = 'WritableAutomaticVariableError' }
+            )
+        }
+
+        It 'Variable <VariableName> of type <Type> can be suppressed by RuleSuppressionId' -TestCases $testCases_RuleSuppression {
+            $scriptDef = @"
+function suppressionTest {
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('$ruleName', '$VariableName')]
+    param(
+        `$$VariableName
+    )
+}
+"@
+
+            $warnings = @(Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef -ExcludeRule PSReviewUnusedParameter)
+            $warnings.Count | Should -Be 0
+        }
     }
 }


### PR DESCRIPTION
## PR Summary

Enables suppression for specific variable/parameter with rule PSAvoidAssignmentToAutomaticVariable.
Fix #1589

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.