### PR TITLE
Allow suppression of  PSUseSingularNouns for specific function

### DIFF
--- a/Rules/UseSingularNouns.cs
+++ b/Rules/UseSingularNouns.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         GetName(),
                         DiagnosticSeverity.Warning,
                         fileName,
+                        funcAst.Name,
                         suggestedCorrections: new CorrectionExtent[] { GetCorrection(pluralizer, extent, funcAst.Name, noun) });
                 }
             }

--- a/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
+++ b/Tests/Rules/UseSingularNounsReservedVerbs.tests.ps1
@@ -86,6 +86,18 @@ Write-Output "Adding some data"
             $diagnostics.SuggestedCorrections.Text | Should -BeExactly $Correction
         }
     }
+    Context 'Suppression' {
+        It 'Can be suppressed by RuleSuppressionId' {
+            $scriptDef = @"
+function Get-Elements {
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('$nounViolationName', 'Get-Elements')]
+    param()
+}
+"@
+            $warnings = @(Invoke-ScriptAnalyzer -ScriptDefinition $scriptDef)
+            $warnings.Count | Should -Be 0
+        }
+    }
 }
 
 Describe "UseApprovedVerbs" {

--- a/docs/Rules/UseSingularNouns.md
+++ b/docs/Rules/UseSingularNouns.md
@@ -17,7 +17,7 @@ Suppression allows to suppress just specific function names, for example
 
 ```
 function Get-Elements {
-    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', 'Get-Element')]
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', 'Get-Elements')]
     Param()
 }
 ```

--- a/docs/Rules/UseSingularNouns.md
+++ b/docs/Rules/UseSingularNouns.md
@@ -13,6 +13,15 @@ title: UseSingularNouns
 
 PowerShell team best practices state cmdlets should use singular nouns and not plurals.
 
+Suppression allows to suppress just specific function names, for example
+
+```
+function Get-Elements {
+    [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', 'Get-Element')]
+    Param()
+}
+```
+
 ## How
 
 Change plurals to singular.


### PR DESCRIPTION
## PR Summary

Enables suppression of PSUseSingularNouns for specific function.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.