### PR TITLE
Change double quotes to single where possible

### DIFF
--- a/docs/Rules/AlignAssignmentStatement.md
+++ b/docs/Rules/AlignAssignmentStatement.md
@@ -19,8 +19,8 @@ are aligned or not. Consider the following example in which the key value pairs 
 
 ```powershell
 $hashtable = @{
-    property1 = "value"
-    anotherProperty = "another value"
+    property1 = 'value'
+    anotherProperty = 'another value'
 }
 ```
 
@@ -28,8 +28,8 @@ Alignment in this case would look like the following.
 
 ```powershell
 $hashtable = @{
-    property1       = "value"
-    anotherProperty = "another value"
+    property1       = 'value'
+    anotherProperty = 'another value'
 }
 ```
 

--- a/docs/Rules/AvoidGlobalAliases.md
+++ b/docs/Rules/AvoidGlobalAliases.md
@@ -28,7 +28,7 @@ Use other scope modifiers for new aliases.
 ### Wrong
 
 ```powershell
-New-Alias -Name Name -Value Value -Scope "Global"
+New-Alias -Name Name -Value Value -Scope Global
 ```
 
 ### Correct

--- a/docs/Rules/AvoidInvokingEmptyMembers.md
+++ b/docs/Rules/AvoidInvokingEmptyMembers.md
@@ -23,13 +23,13 @@ Provide the requested members for a given type or class.
 ### Wrong
 
 ```powershell
-$MyString = "abc"
+$MyString = 'abc'
 $MyString.('len'+'gth')
 ```
 
 ### Correct
 
 ```powershell
-$MyString = "abc"
+$MyString = 'abc'
 $MyString.('length')
 ```

--- a/docs/Rules/AvoidOverwritingBuiltInCmdlets.md
+++ b/docs/Rules/AvoidOverwritingBuiltInCmdlets.md
@@ -26,7 +26,7 @@ following your settings file.
 @{
     'Rules' = @{
         'PSAvoidOverwritingBuiltInCmdlets' = @{
-            'PowerShellVersion' = @("core-6.1.0-windows")
+            'PowerShellVersion' = @('core-6.1.0-windows')
         }
     }
 }
@@ -38,8 +38,8 @@ following your settings file.
 
 The parameter `PowerShellVersion` is a list of allowlists that ship with PSScriptAnalyzer.
 
-**Note**: The default value for `PowerShellVersion` is `"core-6.1.0-windows"` if PowerShell 6 or
-later is installed, and `"desktop-5.1.14393.206-windows"` if it is not.
+**Note**: The default value for `PowerShellVersion` is `core-6.1.0-windows` if PowerShell 6 or
+later is installed, and `desktop-5.1.14393.206-windows` if it is not.
 
 Usually, patched versions of PowerShell have the same cmdlet data, therefore only settings of major
 and minor versions of PowerShell are supplied. One can also create a custom settings file as well

--- a/docs/Rules/AvoidShouldContinueWithoutForce.md
+++ b/docs/Rules/AvoidShouldContinueWithoutForce.md
@@ -33,7 +33,7 @@ Function Test-ShouldContinue
         $MyString = 'blah'
     )
 
-    if ($PsCmdlet.ShouldContinue("ShouldContinue Query", "ShouldContinue Caption"))
+    if ($PsCmdlet.ShouldContinue('ShouldContinue Query', 'ShouldContinue Caption'))
     {
         ...
     }
@@ -52,7 +52,7 @@ Function Test-ShouldContinue
         [Switch]$Force
     )
 
-    if ($Force -or $PsCmdlet.ShouldContinue("ShouldContinue Query", "ShouldContinue Caption"))
+    if ($Force -or $PsCmdlet.ShouldContinue('ShouldContinue Query', 'ShouldContinue Caption'))
     {
         ...
     }

--- a/docs/Rules/AvoidUsingComputerNameHardcoded.md
+++ b/docs/Rules/AvoidUsingComputerNameHardcoded.md
@@ -25,7 +25,7 @@ Remove hard coded computer names.
 ```powershell
 Function Invoke-MyRemoteCommand ()
 {
-    Invoke-Command -Port 343 -ComputerName "hardcoderemotehostname"
+    Invoke-Command -Port 343 -ComputerName hardcoderemotehostname
 }
 ```
 
@@ -45,7 +45,7 @@ Function Invoke-MyCommand ($ComputerName)
 ```powershell
 Function Invoke-MyLocalCommand ()
 {
-    Invoke-Command -Port 343 -ComputerName "hardcodelocalhostname"
+    Invoke-Command -Port 343 -ComputerName 'hardcodelocalhostname'
 }
 ```
 

--- a/docs/Rules/AvoidUsingConvertToSecureStringWithPlainText.md
+++ b/docs/Rules/AvoidUsingConvertToSecureStringWithPlainText.md
@@ -30,14 +30,14 @@ module from the PowerShell Gallery.
 ### Wrong
 
 ```powershell
-$UserInput = Read-Host "Please enter your secure code"
+$UserInput = Read-Host 'Please enter your secure code'
 $EncryptedInput = ConvertTo-SecureString -String $UserInput -AsPlainText -Force
 ```
 
 ### Correct
 
 ```powershell
-$SecureUserInput = Read-Host "Please enter your secure code" -AsSecureString
+$SecureUserInput = Read-Host 'Please enter your secure code' -AsSecureString
 $EncryptedInput = ConvertFrom-SecureString -String $SecureUserInput
 $SecureString = ConvertTo-SecureString -String $EncryptedInput
 ```

--- a/docs/Rules/AvoidUsingEmptyCatchBlock.md
+++ b/docs/Rules/AvoidUsingEmptyCatchBlock.md
@@ -41,7 +41,7 @@ try
 }
 catch [DivideByZeroException]
 {
-    Write-Error "DivideByZeroException"
+    Write-Error 'DivideByZeroException'
 }
 
 try
@@ -50,6 +50,6 @@ try
 }
 catch [DivideByZeroException]
 {
-    throw "DivideByZeroException"
+    throw 'DivideByZeroException'
 }
 ```

--- a/docs/Rules/AvoidUsingInvokeExpression.md
+++ b/docs/Rules/AvoidUsingInvokeExpression.md
@@ -26,7 +26,7 @@ Remove the use of `Invoke-Expression`.
 ### Wrong
 
 ```powershell
-Invoke-Expression "Get-Process"
+Invoke-Expression 'Get-Process'
 ```
 
 ### Correct

--- a/docs/Rules/AvoidUsingWMICmdlet.md
+++ b/docs/Rules/AvoidUsingWMICmdlet.md
@@ -48,12 +48,12 @@ Change to the equivalent CIM based cmdlet.
 
 ```powershell
 Get-WmiObject -Query 'Select * from Win32_Process where name LIKE "myprocess%"' | Remove-WmiObject
-Invoke-WmiMethod -Class Win32_Process -Name "Create" -ArgumentList @{ CommandLine = "notepad.exe" }
+Invoke-WmiMethod -Class Win32_Process -Name 'Create' -ArgumentList @{ CommandLine = 'notepad.exe' }
 ```
 
 ### Correct
 
 ```powershell
 Get-CimInstance -Query 'Select * from Win32_Process where name LIKE "myprocess%"' | Remove-CIMInstance
-Invoke-CimMethod -ClassName Win32_Process -MethodName "Create" -Arguments @{ CommandLine = "notepad.exe" }
+Invoke-CimMethod -ClassName Win32_Process -MethodName 'Create' -Arguments @{ CommandLine = 'notepad.exe' }
 ```

--- a/docs/Rules/AvoidUsingWriteHost.md
+++ b/docs/Rules/AvoidUsingWriteHost.md
@@ -12,7 +12,7 @@ title: AvoidUsingWriteHost
 ## Description
 
 The use of `Write-Host` is greatly discouraged unless in the use of commands with the `Show` verb.
-The `Show` verb explicitly means "show on the screen, with no other possibilities".
+The `Show` verb explicitly means 'show on the screen, with no other possibilities'.
 
 Commands with the `Show` verb do not have this check applied.
 
@@ -29,7 +29,7 @@ logging or returning one or more objects.
 function Get-MeaningOfLife
 {
     ...
-    Write-Host "Computing the answer to the ultimate question of life, the universe and everything"
+    Write-Host 'Computing the answer to the ultimate question of life, the universe and everything'
     ...
     Write-Host 42
 }
@@ -42,13 +42,13 @@ function Get-MeaningOfLife
 {
     [CmdletBinding()]Param() # to make it possible to set the VerbosePreference when calling the function
     ...
-    Write-Verbose "Computing the answer to the ultimate question of life, the universe and everything"
+    Write-Verbose 'Computing the answer to the ultimate question of life, the universe and everything'
     ...
     Write-Output 42
 }
 
 function Show-Something
 {
-    Write-Host "show something on screen";
+    Write-Host 'show something on screen'
 }
 ```

--- a/docs/Rules/DSCUseVerboseMessageInDSCResource.md
+++ b/docs/Rules/DSCUseVerboseMessageInDSCResource.md
@@ -38,7 +38,7 @@ Function Test-Function
 {
     [CmdletBinding()]
     Param()
-    Write-Verbose "Verbose output"
+    Write-Verbose 'Verbose output'
     ...
 }
 ```

--- a/docs/Rules/PlaceCloseBrace.md
+++ b/docs/Rules/PlaceCloseBrace.md
@@ -42,7 +42,7 @@ Create violation if there is an empty line before a close brace.
 #### IgnoreOneLineBlock: bool (Default value is `$true`)
 
 Indicates if closed brace pairs in a one line block should be ignored or not. For example,
-`$x = if ($true) { "blah" } else { "blah blah" }`, if the property is set to true then the rule
+`$x = if ($true) { 'blah' } else { 'blah blah' }`, if the property is set to true then the rule
 doesn't fire a violation.
 
 #### NewLineAfter: bool (Default value is `$true`)

--- a/docs/Rules/PlaceOpenBrace.md
+++ b/docs/Rules/PlaceOpenBrace.md
@@ -46,5 +46,5 @@ Enforce a new line character after an open brace. The default value is true.
 #### IgnoreOneLineBlock: bool (Default value is `$true`)
 
 Indicates if open braces in a one line block should be ignored or not. For example,
-` $x = if ($true) { "blah" } else { "blah blah" }`, if the property is set to true then the rule
+` $x = if ($true) { 'blah' } else { 'blah blah' }`, if the property is set to true then the rule
 doesn't fire a violation.

--- a/docs/Rules/ProvideCommentHelp.md
+++ b/docs/Rules/ProvideCommentHelp.md
@@ -30,7 +30,7 @@ Rules = @{
         ExportedOnly = $false
         BlockComment = $true
         VSCodeSnippetCorrection = $false
-        Placement = "before"
+        Placement = 'before'
     }
 }
 ```

--- a/docs/Rules/ShouldProcess.md
+++ b/docs/Rules/ShouldProcess.md
@@ -42,7 +42,7 @@ function Set-File
         [Parameter(Mandatory=$true)]
         $Path
     )
-    "String" | Out-File -FilePath $Path
+    'String' | Out-File -FilePath $Path
 }
 ```
 
@@ -62,7 +62,7 @@ function Set-File
         [string]$Content
     )
 
-    if ($PSCmdlet.ShouldProcess($Path, ("Setting content to '{0}'" -f $Content)))
+    if ($PSCmdlet.ShouldProcess($Path, ('Setting content to '{0}'' -f $Content)))
     {
         $Content | Out-File -FilePath $Path
     }

--- a/docs/Rules/UseCompatibleCmdlets.md
+++ b/docs/Rules/UseCompatibleCmdlets.md
@@ -23,7 +23,7 @@ the following your settings file:
 @{
     'Rules' = @{
         'PSUseCompatibleCmdlets' = @{
-            'compatibility' = @("core-6.1.0-windows")
+            'compatibility' = @('core-6.1.0-windows')
         }
     }
 }

--- a/docs/Rules/UseCompatibleCommands.md
+++ b/docs/Rules/UseCompatibleCommands.md
@@ -82,7 +82,7 @@ The default profile directory is under the PSScriptAnalzyer module at
 `$PSScriptRoot/compatibility_profiles` (where `$PSScriptRoot` here refers to the directory
 containing `PSScriptAnalyzer.psd1`).
 
-The compatibility analysis compares a command used to both a target profile and a "union" profile
+The compatibility analysis compares a command used to both a target profile and a 'union' profile
 (containing all commands available in *any* profile in the profile dir). If a command is not present
 in the union profile, it is assumed to be locally created and ignored. Otherwise, if a command is
 present in the union profile but not present in a target, it is deemed to be incompatible with that
@@ -126,17 +126,17 @@ Command compatibility diagnostics can be suppressed with an attribute on the `pa
 scriptblock as with other rules.
 
 ```powershell
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseCompatibleCommands", "")]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', '')]
 ```
 
 The rule can also be suppressed only for particular commands:
 
 ```powershell
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseCompatibleCommands", "Start-Service")]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', 'Start-Service')]
 ```
 
 And also suppressed only for parameters:
 
 ```powershell
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseCompatibleCommands", "Import-Module/FullyQualifiedName")]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', 'Import-Module/FullyQualifiedName')]
 ```

--- a/docs/Rules/UseCompatibleSyntax.md
+++ b/docs/Rules/UseCompatibleSyntax.md
@@ -22,9 +22,9 @@ PowerShell versions because they aren't able to parse the incompatible syntaxes.
         PSUseCompatibleSyntax = @{
             Enable = $true
             TargetVersions = @(
-                "6.0",
-                "5.1",
-                "4.0"
+                '6.0',
+                '5.1',
+                '4.0'
             )
         }
     }

--- a/docs/Rules/UseCompatibleTypes.md
+++ b/docs/Rules/UseCompatibleTypes.md
@@ -83,8 +83,8 @@ The default profile directory is under the PSScriptAnalzyer module at
 `$PSScriptRoot/PSCompatibilityCollector/profiles` (where `$PSScriptRoot` here refers to the
 directory containing `PSScriptAnalyzer.psd1`).
 
-The compatibility analysis compares a type used to both a target profile and a "union" profile
-(containing all types available in *any* profile in the profile dir). If a type is not present in
+The compatibility analysis compares a type used to both a target profile and a 'union' profile
+(containing all types available in _any_ profile in the profile dir). If a type is not present in
 the union profile, it is assumed to be locally created and ignored. Otherwise, if a type is present
 in the union profile but not present in a target, it is deemed to be incompatible with that target.
 
@@ -127,11 +127,11 @@ PS> $settings = @{
       Rules = @{
         PSUseCompatibleTypes = @{
           Enable = $true
-          TargetProfiles = @("win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework")
+          TargetProfiles = @('win-48_x64_10.0.17763.0_5.1.17763.316_x64_4.0.30319.42000_framework')
         }
       }
 }
-PS> Invoke-ScriptAnalyzer -Settings $settings -ScriptDefinition '[System.Management.Automation.SemanticVersion]"1.18.0-rc1"'
+PS> Invoke-ScriptAnalyzer -Settings $settings -ScriptDefinition '[System.Management.Automation.SemanticVersion]'1.18.0-rc1''
 
 RuleName                Severity     ScriptName Line  Message
 --------                --------     ---------- ----  -------
@@ -146,17 +146,17 @@ Command compatibility diagnostics can be suppressed with an attribute on the `pa
 scriptblock as with other rules.
 
 ```powershell
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseCompatibleTypes", "")]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleTypes', '')]
 ```
 
 The rule can also be suppressed only for particular types:
 
 ```powershell
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseCompatibleTypes", "System.Management.Automation.Security.SystemPolicy")]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleTypes', 'System.Management.Automation.Security.SystemPolicy')]
 ```
 
 And also suppressed only for type members:
 
 ```powershell
-[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseCompatibleCommands", "System.Management.Automation.LanguagePrimitives/ConvertTypeNameToPSTypeName")]
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseCompatibleCommands', 'System.Management.Automation.LanguagePrimitives/ConvertTypeNameToPSTypeName')]
 ```

--- a/docs/Rules/UseDeclaredVarsMoreThanAssignments.md
+++ b/docs/Rules/UseDeclaredVarsMoreThanAssignments.md
@@ -15,7 +15,7 @@ Variables that are assigned but not used are not needed.
 
 > [!NOTE]
 > For this rule, the variable must be used within the same scriptblock that it was declared or it
-> won't be considered to be "used".
+> won't be considered to be 'used'.
 
 ## How
 
@@ -28,8 +28,8 @@ Remove the variables that are declared but not used.
 ```powershell
 function Test
 {
-    $declaredVar = "Declared just for fun"
-    $declaredVar2 = "Not used"
+    $declaredVar = 'Declared just for fun'
+    $declaredVar2 = 'Not used'
     Write-Output $declaredVar
 }
 ```
@@ -39,7 +39,7 @@ function Test
 ```powershell
 function Test
 {
-    $declaredVar = "Declared just for fun"
+    $declaredVar = 'Declared just for fun'
     Write-Output $declaredVar
 }
 ```

--- a/docs/Rules/UseOutputTypeCorrectly.md
+++ b/docs/Rules/UseOutputTypeCorrectly.md
@@ -45,6 +45,6 @@ function Get-Foo
         Param(
         )
 
-        return "four"
+        return 'four'
 }
 ```

--- a/docs/Rules/UseUsingScopeModifierInNewRunspaces.md
+++ b/docs/Rules/UseUsingScopeModifierInNewRunspaces.md
@@ -32,40 +32,40 @@ Within the ScriptBlock, instead of just using a variable from the parent scope, 
 ### Wrong
 
 ```powershell
-$var = "foo"
+$var = 'foo'
 1..2 | ForEach-Object -Parallel { $var }
 ```
 
 ### Correct
 
 ```powershell
-$var = "foo"
+$var = 'foo'
 1..2 | ForEach-Object -Parallel { $using:var }
 ```
 
 ## More correct examples
 
 ```powershell
-$bar = "bar"
-Invoke-Command -ComputerName "foo" -ScriptBlock { $using:bar }
+$bar = 'bar'
+Invoke-Command -ComputerName 'foo' -ScriptBlock { $using:bar }
 ```
 
 ```powershell
-$bar = "bar"
-$s = New-PSSession -ComputerName "foo"
+$bar = 'bar'
+$s = New-PSSession -ComputerName 'foo'
 Invoke-Command -Session $s -ScriptBlock { $using:bar }
 ```
 
 ```powershell
 # Remark: Workflow is supported on Windows PowerShell only
 Workflow {
-    $foo = "foo"
+    $foo = 'foo'
     InlineScript { $using:foo }
 }
 ```
 
 ```powershell
-$foo = "foo"
+$foo = 'foo'
 Start-ThreadJob -ScriptBlock { $using:foo }
 Start-Job -ScriptBlock {$using:foo }
 ```


### PR DESCRIPTION
Change double quotes to single where possible.

Related to change in MicrosoftDocs/PowerShell-Docs-Modules#147.

Once merged, these changes need to be copied back to docs repo.

