### PR TITLE
Documentation corrections for AvoidUsingPositionalParameters

### DIFF
--- a/docs/Rules/AvoidUsingPositionalParameters.md
+++ b/docs/Rules/AvoidUsingPositionalParameters.md
@@ -24,7 +24,7 @@ supplied. A simple example where the risk of using positional parameters is negl
 
 ```powershell
 Rules = @{
-    AvoidUsingPositionalParameters = @{
+    PSAvoidUsingPositionalParameters = @{
         CommandAllowList = 'az', 'Join-Path'
         Enable           = $true
     }
@@ -33,7 +33,7 @@ Rules = @{
 
 ### Parameters
 
-#### AvoidUsingPositionalParameters: string[] (Default value is 'az')
+#### CommandAllowList: string[] (Default value is 'az')
 
 Commands to be excluded from this rule. `az` is excluded by default because starting with version 2.40.0 the entrypoint of the AZ CLI became an `az.ps1` script but this script does not have any named parameters and just passes them on using `$args` as is to the Python process that it starts, therefore it is still a CLI and not a PowerShell command.
 


### PR DESCRIPTION
This is just a minor PR for fixing a couple of typos in the documentation.

```diff
Rules = @{
-    AvoidUsingPositionalParameters = @{
+    PSAvoidUsingPositionalParameters = @{
        CommandAllowList = 'az', 'Join-Path'
        Enable           = $true
    }
}
```

```diff
- #### AvoidUsingPositionalParameters: string[] (Default value is 'az')
+ #### CommandAllowList: string[] (Default value is 'az')
```