### PR TITLE
Adding ToString() methods to [CorrectionExtent] and [DiagnosticRecord]

### DIFF
--- a/Engine/Generic/CorrectionExtent.cs
+++ b/Engine/Generic/CorrectionExtent.cs
@@ -104,5 +104,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
         {
 
         }
+
+        /// <summary>
+        /// Outputs a CorrectionExtent as a string.
+        /// </summary>
+        /// <returns>Returns the text in a CorrectionExtent.</returns>
+        public override string ToString() {
+            return this.Text;
+        }
     }
 }

--- a/Engine/Generic/DiagnosticRecord.cs
+++ b/Engine/Generic/DiagnosticRecord.cs
@@ -127,6 +127,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic
             RuleSuppressionID = ruleId;
             this.suggestedCorrections = suggestedCorrections;
         }
+
+        /// <summary>
+        /// Outputs a DiagnosticRecord as a string.
+        /// </summary>
+        /// <returns>Returns the message in a DiagnosticRecord.</returns>
+        public override string ToString() {
+            return this.Message;
+        }
     }
 
 


### PR DESCRIPTION
## PR Summary

Adding ToString() methods to `[CorrectionExtent]` and `[DiagnosticRecord]`

Fixes #1945 
Fixes #1944 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.