### PR TITLE
Make Settings type detection more robust

### DIFF
--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -497,6 +497,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         internal static SettingsMode FindSettingsMode(object settings, string path, out object settingsFound)
         {
             var settingsMode = SettingsMode.None;
+
+            // if the provided settings argument is wrapped in an expressions then PowerShell resolves it but it will be of type PSObject and we have to operate then on the BaseObject
+            if (settings is PSObject)
+            {
+                settings = ((PSObject)settings).BaseObject;
+            }
+
             settingsFound = settings;
             if (settingsFound == null)
             {
@@ -531,11 +538,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
                     if (settingsFound is Hashtable)
                     {
                         settingsMode = SettingsMode.Hashtable;
-                    }
-                    // if the provided argument is wrapped in an expressions then PowerShell resolves it but it will be of type PSObject and we have to operate then on the BaseObject
-                    else if (settingsFound is PSObject settingsFoundPSObject)
-                    {
-                        TryResolveSettingForStringType(settingsFoundPSObject.BaseObject, ref settingsMode, ref settingsFound);
                     }
                 }
             }

--- a/Engine/Settings.cs
+++ b/Engine/Settings.cs
@@ -499,9 +499,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             var settingsMode = SettingsMode.None;
 
             // if the provided settings argument is wrapped in an expressions then PowerShell resolves it but it will be of type PSObject and we have to operate then on the BaseObject
-            if (settings is PSObject)
+            if (settings is PSObject settingsFoundPSObject)
             {
-                settings = ((PSObject)settings).BaseObject;
+                settings = settingsFoundPSObject.BaseObject;
             }
 
             settingsFound = settings;

--- a/Tests/Engine/Settings.tests.ps1
+++ b/Tests/Engine/Settings.tests.ps1
@@ -377,4 +377,34 @@ Describe "Settings Class" {
             @{ Expr = ';)' }
         )
     }
+
+    Context "FindSettingsMode" {
+        BeforeAll {
+            $findSettingsMode = ($settingsTypeName -as [type]).GetMethod(
+                'FindSettingsMode',
+                [System.Reflection.BindingFlags]::NonPublic -bor [System.Reflection.BindingFlags]::Static)
+
+            $outputObject = [System.Object]::new()
+        }
+
+        It "Should detect hashtable" {
+            $settings = @{}
+            $findSettingsMode.Invoke($null, @($settings, $null, [ref]$outputObject)) | Should -Be "Hashtable"
+        }
+
+        It "Should detect hashtable wrapped by a PSObject" {
+            $settings = [PSObject]@{} # Force the settings hashtable to be wrapped
+            $findSettingsMode.Invoke($null, @($settings, $null, [ref]$outputObject)) | Should -Be "Hashtable"
+        }
+
+        It "Should detect string" {
+            $settings = ""
+            $findSettingsMode.Invoke($null, @($settings, $null, [ref]$outputObject)) | Should -Be "File"
+        }
+
+        It "Should detect string wrapped by a PSObject" {
+            $settings = [PSObject]"" # Force the settings string to be wrapped
+            $findSettingsMode.Invoke($null, @($settings, $null, [ref]$outputObject)) | Should -Be "File"
+        }
+    }
 }


### PR DESCRIPTION
## PR Summary
It was unable to parse settings hashtable, when that hashtable has been wrapped as a PSObject. This started happening in PS 7.2, I was using `Import-PowerShellDataFile` to read some settings before passing them on to `Invoke-ScriptAnalyzer`.

There was some code to handle wrapped strings, might as well do that with all parameter types.
<!-- summarize your PR between here and the checklist -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.