### PR TITLE
PSAlignAssignmentStatement: Ignore hashtables with a single key-value pair

### DIFF
--- a/Rules/AlignAssignmentStatement.cs
+++ b/Rules/AlignAssignmentStatement.cs
@@ -314,6 +314,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         private bool HasPropertiesOnSeparateLines(IEnumerable<Tuple<IScriptExtent, IScriptExtent>> tuples)
         {
+            if (tuples.Count() == 1)
+            {
+                // If the hashtable has just a single key-value pair, it does not have properties on separate lines
+                return false;
+            }
             var lines = new HashSet<int>();
             foreach (var kvp in tuples)
             {

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -75,6 +75,33 @@ $x = @{ }
             Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Get-Count | Should -Be 0
 
         }
+
+        It "Should ignore if a hashtable has a single key-value pair on a single line" {
+            $def = @'
+$x = @{ 'key'="value" }
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Get-Count | Should -Be 0
+
+        }
+
+        It "Should ignore if a hashtable has a single key-value pair across multiple lines" {
+            $def = @'
+$x = @{ 
+    'key'="value" 
+}
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Get-Count | Should -Be 0
+
+        }
+
+        It "Should ignore if a hashtable has multiple key-value pairs on a single line" {
+            $def = @'
+$x = @{ 'key'="value"; 'key2'="value2"; 'key3WithLongerName'="value3" }
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Get-Count | Should -Be 0
+
+        }
+
     }
 
     Context "When assignment statements are in DSC Configuration" {


### PR DESCRIPTION
## PR Summary

Hashtables with a single key-value pair should be ignored by `PSAlignAssignmentStatement` as there is nothing to align. 

There are other rules that handle whitespace around operators etc which can handle formatting according to the users preference.

Currently:

```powershell
Invoke-Formatter -ScriptDefinition "@{'Key'='Value'}" -Settings @{
    Rules = @{
        PSAlignAssignmentStatement = @{
            Enable = $true
            CheckHashtable = $true
        }
    }
}
```

Results in:

```powershell
@{'Key' ='Value'}
```
*Note the space added after the hashtable key*

Resolves #1979 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.