### PR TITLE
PSUseConsistentIndentation: Check indentation of lines where first token is a LParen not followed by comment or new line

### DIFF
--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         break;
 
                     case TokenKind.LParen:
+                        AddViolation(token, indentationLevel, diagnosticRecords, ref onNewLine);
                         // When a line starts with a parenthesis and it is not the last non-comment token of that line,
                         // then indentation does not need to be increased.
                         if ((tokenIndex == 0 || tokens[tokenIndex - 1].Kind == TokenKind.NewLine) &&
@@ -173,7 +174,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                             break;
                         }
                         lParenSkippedIndentation.Push(false);
-                        AddViolation(token, indentationLevel++, diagnosticRecords, ref onNewLine);
+                        indentationLevel++;
                         break;
 
                     case TokenKind.Pipe:

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -177,6 +177,18 @@ function test {
 '@
         Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition | Should -Be $idempotentScriptDefinition
     }
+
+    It 'Should find violation in script when LParen is first token on a line and is not followed by Newline' {
+        $ScriptDefinition = @'
+     (foo)
+     (bar)
+'@
+        $ExpectedScriptDefinition = @'
+(foo)
+(bar)
+'@
+    Invoke-FormatterAssertion $ScriptDefinition $ExpectedScriptDefinition 2 $settings
+    }
 }
 
     Context "When a sub-expression is provided" {

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -11,7 +11,7 @@ Describe "UseConsistentIndentation" {
         function Invoke-FormatterAssertion {
             param(
                 [string] $ScriptDefinition,
-                [string] $ExcpectedScriptDefinition,
+                [string] $ExpectedScriptDefinition,
                 [int] $NumberOfExpectedWarnings,
                 [hashtable] $Settings
             )
@@ -19,9 +19,9 @@ Describe "UseConsistentIndentation" {
             # Unit test just using this rule only
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $settings
             $violations.Count | Should -Be $NumberOfExpectedWarnings -Because $ScriptDefinition
-            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be $expected -Because $ScriptDefinition
+            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be $ExpectedScriptDefinition -Because $ScriptDefinition
             # Integration test with all default formatting rules
-            Invoke-Formatter -ScriptDefinition $scriptDefinition | Should -Be $expected -Because $ScriptDefinition
+            Invoke-Formatter -ScriptDefinition $scriptDefinition | Should -Be $ExpectedScriptDefinition -Because $ScriptDefinition
         }
     }
     BeforeEach {


### PR DESCRIPTION
## PR Summary

Currently if an LParen `(` is the first token on a line and the next token is not a comment or new line, then the line's indentation is not checked.

This is due to this if-check:

https://github.com/PowerShell/PSScriptAnalyzer/blob/a754b950467aa9e78a1eba1a3423bbd055ed8772/Rules/UseConsistentIndentation.cs#L165-L177

`AddViolation()`, which subsequently checks the lines indentation against the expected indentation, is not called if the conditional evaluates to `true`.

This PR changes the logic to always call `AddViolation()`, so the indentation is checked, but to only increase the indentation level when the conditional evaluates to `false`.

Fixes #1994 

I've run this rule recursively over some large code-bases, including the `PSScriptAnalyzer` repo. 

- In the current `1.22.0` we find `2,927` violations.
- With this PR applied, we find `2,931` violations.
- I believe the settings I used (*below*) means the rule defaults to `spaces` and many of the files were using `tabs` - hence the large number of violations.
  ```powershell
  $Settings = @{
      IncludeRules = @('PSUseConsistentIndentation')
      Rules        = @{
          PSUseConsistentIndentation = @{
              Enable = $true
          }
      }
  }
  ```
- All previously found violations were still found.
- There were 4 newly found violations:
    - `\Tests\Engine\ModuleHelp.Tests.ps1\ModuleHelp.Tests.ps1` line 48
      https://github.com/PowerShell/PSScriptAnalyzer/blob/a754b950467aa9e78a1eba1a3423bbd055ed8772/Tests/Engine/ModuleHelp.Tests.ps1#L47-L54

      This becomes:

      ![image](https://github.com/PowerShell/PSScriptAnalyzer/assets/6566675/6f3a0177-57df-4e8c-8b17-db8f461d2fcc)

      Which is a little dubious 🤔

      > **Edit:** This is because the previous line has `6` opening LParens, and `3` closing RParens. So the `indentation` level is `3` greater than the previous line

    - `\Tests\Engine\ModuleHelp.Tests.ps1\ModuleHelp.Tests.ps1` line 116
      https://github.com/PowerShell/PSScriptAnalyzer/blob/a754b950467aa9e78a1eba1a3423bbd055ed8772/Tests/Engine/ModuleHelp.Tests.ps1#L115-L117

      This line wasn't previously being checked. It's using tabs, and as mentioned above the settings is defaulting to spaces.

    - `\Tests\Engine\CommunityAnalyzerRules\CommunityAnalyzerRules.psm1\CommunityAnalyzerRules.psm1` line 518
      https://github.com/PowerShell/PSScriptAnalyzer/blob/a754b950467aa9e78a1eba1a3423bbd055ed8772/Tests/Engine/CommunityAnalyzerRules/CommunityAnalyzerRules.psm1#L515-L521

      This is changed to:

      ![image](https://github.com/PowerShell/PSScriptAnalyzer/assets/6566675/5d2d4b1b-9a14-41e3-a9f9-b3481eb2a340)

    - `\Tests\Rules\UseToExportFieldsInManifest.tests.ps1\UseToExportFieldsInManifest.tests.ps1` line 73

      This is a line that randomly uses tabs

      ![image](https://github.com/PowerShell/PSScriptAnalyzer/assets/6566675/f8a01328-be4a-429f-9425-aa9636e6334b)

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.