### PR TITLE
PSUseConsistentWhitespace: Handle redirect operators which are not in stream order

### DIFF
--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -396,8 +396,17 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     testAst => testAst is CommandAst, true);
             foreach (CommandAst commandAst in commandAsts)
             {
+                /// When finding all the command parameter elements, there is no guarantee that
+                /// we will read them from the AST in the order they appear in the script (in token
+                /// order). So we first sort the tokens by their starting line number, followed by
+                /// their starting column number.
                 List<Ast> commandParameterAstElements = commandAst.FindAll(
-                    testAst => testAst.Parent == commandAst, searchNestedScriptBlocks: false).ToList();
+                        testAst => testAst.Parent == commandAst, searchNestedScriptBlocks: false
+                    ).OrderBy(
+                        e => e.Extent.StartLineNumber
+                    ).ThenBy(
+                        e => e.Extent.StartColumnNumber
+                    ).ToList();
                 for (int i = 0; i < commandParameterAstElements.Count - 1; i++)
                 {
                     IScriptExtent leftExtent = commandParameterAstElements[i].Extent;

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -540,6 +540,12 @@ bar -h i `
             Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
 
+        It "Should not find a violation when redirect operators, spearated by 1 space, are used and not in stream order" {
+            # Related to Issue #2000
+            $def = 'foo 3>&1 1>$null 2>&1'
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
+        }
+
         It "Should find 1 violation if there is 1 space too much before a parameter" {
             $def = 'foo  -bar'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
@@ -577,6 +583,14 @@ bar -h i `
 -switch}
             Invoke-Formatter -ScriptDefinition "$def" -Settings $settings |
                 Should -Be "$expected"
+        }
+
+        It "Should fix script when redirects are involved and whitespace is not consistent" {
+            # Related to Issue #2000
+            $def = 'foo   3>&1  1>$null   2>&1'
+            $expected = 'foo 3>&1 1>$null 2>&1'
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings |
+                Should -Be $expected
         }
     }
 }


### PR DESCRIPTION
## PR Summary

When `CheckParameter` is `$true` for the rule `PSUseConsistentWhitespace`, it checks whitespace between parameters by inspecting the AST. It gets all direct children of each `CommandAst` and checks, in order, that each's extent is separated by exactly 1 character. 

This relies on the implicit assumption that the AST returns the children in something resembling token order.

In the case of redirect operators, this is not always the case (they anecdotally appear to be returned in the order of the stream they're redirecting). See [the issue here](https://github.com/PowerShell/PSScriptAnalyzer/issues/2000#issuecomment-2108321027) for more detailed breakdown.

This PR adds sorting of the children before subsequently performing the same checks on the tokens extents.

Running the below across PS5.1 and PS7.4 with and without the PR change applied shows the performance impact of the change to be minimal.

```powershell
Measure-Command {
    foreach ($i in 1..10000) {
        Invoke-Formatter -ScriptDefinition "Invoke-Foo $i 3>&1 2>&1 1>`$null" -Settings @{
            Rules = @{
                PSUseConsistentWhitespace = @{
                    Enable         = $true
                    CheckParameter = $true
                }
            }
        }
    }
}
```

|                           | PS5.1 Pre-PR | PS5.1 Post-PR | PS7.4.2 Pre-PR | PS7.4.2 Post-PR |
|---------------------------|--------------|---------------|----------------|-----------------|
| **`Invoke-Formatter`**      | 231.3535187  | 156.0559906   | 16.8896873     | 13.4352551      |
| **`Invoke-ScriptAnalyzer`** | 253.1291937  | 250.9393157   | 21.8151956     | 19.8125177      |

> The 'speedup' is presumably that we're no longer emitting a diagnostic record

Fixes #2000 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.