### PR TITLE
Add tests for #1504 PSUseUsingScopeModifierInNewRunspaces

### DIFF
--- a/Tests/Rules/UseUsingScopeModifierInNewRunspaces.tests.ps1
+++ b/Tests/Rules/UseUsingScopeModifierInNewRunspaces.tests.ps1
@@ -278,20 +278,27 @@ Describe "UseUsingScopeModifierInNewRunspaces" {
             # Issue 1492: https://github.com/PowerShell/PSScriptAnalyzer/issues/1492
             @{
                 Description = 'Does not throw when the same variable name is used in two different sessions'
-                ScriptBlock = @'
-function Get-One{
-    Invoke-Command -Session $sourceRemoteSession {
-        $a = $sccmModule
-        foo $a
-    }
-}
-function Get-Two{
-    Invoke-Command -Session $sourceRemoteSession {
-        $a = $sccmModule
-        foo $a
-    }
-}
-'@
+                ScriptBlock = '{
+                    function Get-One {
+                        Invoke-Command -Session -ScriptBlock $sourceRemoteSession {
+                            $a = $sccmModule
+                            foo $a
+                        }
+                    }
+                    function Get-Two {
+                        Invoke-Command -Session -ScriptBlock $sourceRemoteSession {
+                            $a = $sccmModule
+                            foo $a
+                        }
+                    }
+                }'
+            }
+            # Script block with variables in params(), issue #1504: https://github.com/PowerShell/PSScriptAnalyzer/issues/1504
+            @{
+                Description = 'Does not throw when variable is defined inside params()'
+                ScriptBlock = '{
+
+                }'
             }
         )
     }

--- a/Tests/Rules/UseUsingScopeModifierInNewRunspaces.tests.ps1
+++ b/Tests/Rules/UseUsingScopeModifierInNewRunspaces.tests.ps1
@@ -146,7 +146,6 @@ Describe "UseUsingScopeModifierInNewRunspaces" {
     }
 
     Context "Should not detect anything" {
-
         It "should not emit anything for: <Description>" {
             [System.Array] $warnings = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptBlock -Settings $settings
             $warnings.Count | Should -Be 0
@@ -293,11 +292,25 @@ Describe "UseUsingScopeModifierInNewRunspaces" {
                     }
                 }'
             }
-            # Script block with variables in params(), issue #1504: https://github.com/PowerShell/PSScriptAnalyzer/issues/1504
+            # ScriptBlock with variables in params(), issue #1504: https://github.com/PowerShell/PSScriptAnalyzer/issues/1504
+            ## Microsoft.PowerShell.Core \ Start-Job
             @{
-                Description = 'Does not throw when variable is defined inside params()'
+                Description = 'Does not throw when variable is defined inside params() - Start-Job'
                 ScriptBlock = '{
-
+                    Start-Job -ScriptBlock {
+                        Param($Foo)
+                        $Foo
+                    } -ArgumentList "Bar" | Receive-Job -Wait -AutoRemoveJob
+                }'
+            }
+            ## Microsoft.PowerShell.ThreadJob \ Start-ThreadJob
+            @{
+                Description = 'Does not throw when variable is defined inside params() - Start-Job'
+                ScriptBlock = '{
+                    Start-ThreadJob -ScriptBlock {
+                        Param($Foo)
+                        $Foo
+                    } -ArgumentList "Bar" | Receive-Job -Wait -AutoRemoveJob
                 }'
             }
         )

--- a/Tests/Rules/UseUsingScopeModifierInNewRunspaces.tests.ps1
+++ b/Tests/Rules/UseUsingScopeModifierInNewRunspaces.tests.ps1
@@ -295,7 +295,7 @@ Describe "UseUsingScopeModifierInNewRunspaces" {
             # ScriptBlock with variables in params(), issue #1504: https://github.com/PowerShell/PSScriptAnalyzer/issues/1504
             ## Microsoft.PowerShell.Core \ Start-Job
             @{
-                Description = 'Does not throw when variable is defined inside params() - Start-Job'
+                Description = 'Does not warn when variable is defined inside params() - Start-Job'
                 ScriptBlock = '{
                     Start-Job -ScriptBlock {
                         Param($Foo)
@@ -305,7 +305,7 @@ Describe "UseUsingScopeModifierInNewRunspaces" {
             }
             ## Microsoft.PowerShell.ThreadJob \ Start-ThreadJob
             @{
-                Description = 'Does not throw when variable is defined inside params() - Start-Job'
+                Description = 'Does not warn when variable is defined inside params() - Start-Job'
                 ScriptBlock = '{
                     Start-ThreadJob -ScriptBlock {
                         Param($Foo)


### PR DESCRIPTION
## PR Summary

Wrote two tests for issue #1504. The issue is not fixed yet, but I had two scenarios that could easily be added to the relevant test file.

Repro to wrongfully trigger `PSUseUsingScopeModifierInNewRunspaces`, which I added to test:

```powershell
# Microsoft.PowerShell.Core \ Start-Job
Start-Job -ScriptBlock {
    Param($Foo)
    $Foo
} -ArgumentList 'Bar' | Receive-Job -Wait -AutoRemoveJob

# Microsoft.PowerShell.ThreadJob
Start-ThreadJob -ScriptBlock {
    Param($Foo)
    $Foo
} -ArgumentList 'Bar' | Receive-Job -Wait -AutoRemoveJob
```

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.