### PR TITLE
Update default type definition of `RuleInfo`

### DIFF
--- a/Engine/ScriptAnalyzer.types.ps1xml
+++ b/Engine/ScriptAnalyzer.types.ps1xml
@@ -79,7 +79,7 @@
           <PropertySet>
             <Name>DefaultDisplayPropertySet</Name>
             <ReferencedProperties>
-              <Name>Name</Name>
+              <Name>RuleName</Name>
               <Name>Severity</Name>
               <Name>Description</Name>
               <Name>SourceName</Name>


### PR DESCRIPTION
## PR Summary

The default type definition of `[Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic.RuleInfo]` declares a property called `Name` - which is not a member of the type.

PR updates this to `RuleName`.

Resolves #2010 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.