### PR TITLE
Set exit code of `Invoke-ScriptAnalyzer -EnableExit` to total number of diagnostics (#2054)

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 
         #region Private variables
         List<string> processedPaths;
+        private int totalDiagnosticCount = 0;
         #endregion // Private variables
 
         #region Parameters
@@ -412,6 +413,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
         {
             ScriptAnalyzer.Instance.CleanUp();
             base.EndProcessing();
+
+            if (EnableExit) {
+                this.Host.SetShouldExit(totalDiagnosticCount);
+            }
         }
 
         protected override void StopProcessing()
@@ -426,10 +431,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
 
         private void ProcessInput()
         {
-            WriteToOutput(RunAnalysis());
+            var diagnosticRecords = RunAnalysis();
+            WriteToOutput(diagnosticRecords);
+            totalDiagnosticCount += diagnosticRecords.Count;
         }
 
-        private IEnumerable<DiagnosticRecord> RunAnalysis()
+        private List<DiagnosticRecord> RunAnalysis()
         {
             if (!IsFileParameterSet())
             {
@@ -454,7 +461,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
             return diagnostics;
         }
 
-        private void WriteToOutput(IEnumerable<DiagnosticRecord> diagnosticRecords)
+        private void WriteToOutput(List<DiagnosticRecord> diagnosticRecords)
         {
             foreach (ILogger logger in ScriptAnalyzer.Instance.Loggers)
             {
@@ -506,11 +513,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                         }
                     }
                 }
-            }
-
-            if (EnableExit.IsPresent)
-            {
-                this.Host.SetShouldExit(diagnosticRecords.Count());
             }
         }
 

--- a/Engine/ScriptAnalyzer.cs
+++ b/Engine/ScriptAnalyzer.cs
@@ -1488,7 +1488,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
         /// <param name="scriptTokens">Parsed tokens of <paramref name="scriptDefinition"/.></param>
         /// <param name="skipVariableAnalysis">Whether variable analysis can be skipped (applicable if rules do not use variable analysis APIs).</param>
         /// <returns></returns>
-        public IEnumerable<DiagnosticRecord> AnalyzeScriptDefinition(string scriptDefinition, out ScriptBlockAst scriptAst, out Token[] scriptTokens, bool skipVariableAnalysis = false)
+        public List<DiagnosticRecord> AnalyzeScriptDefinition(string scriptDefinition, out ScriptBlockAst scriptAst, out Token[] scriptTokens, bool skipVariableAnalysis = false)
         {
             scriptAst = null;
             scriptTokens = null;
@@ -1503,7 +1503,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             catch (Exception e)
             {
                 this.outputWriter.WriteWarning(e.ToString());
-                return null;
+                return new();
             }
 
             var relevantParseErrors = RemoveTypeNotFoundParseErrors(errors, out List<DiagnosticRecord> diagnosticRecords);
@@ -1528,7 +1528,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
             }
 
             // now, analyze the script definition
-            return diagnosticRecords.Concat(this.AnalyzeSyntaxTree(scriptAst, scriptTokens, String.Empty, skipVariableAnalysis));
+            diagnosticRecords.AddRange(this.AnalyzeSyntaxTree(scriptAst, scriptTokens, null, skipVariableAnalysis));
+            return diagnosticRecords;
         }
 
         /// <summary>

--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -561,9 +561,29 @@ Describe "Test -EnableExit Switch" {
 
         $pssaPath = (Get-Module PSScriptAnalyzer).Path
 
-        & $pwshExe -Command "Import-Module '$pssaPath'; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit"
+        & $pwshExe -NoProfile -Command "Import-Module '$pssaPath'; Invoke-ScriptAnalyzer -ScriptDefinition gci -EnableExit"
 
-        $LASTEXITCODE  | Should -Be 1
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Returns exit code equivalent to number of warnings for multiple piped files" {
+        if ($IsCoreCLR)
+        {
+            $pwshExe = (Get-Process -Id $PID).Path
+        }
+        else
+        {
+            $pwshExe = 'powershell'
+        }
+
+        $pssaPath = (Get-Module PSScriptAnalyzer).Path
+
+        & $pwshExe -NoProfile {
+            Import-Module $Args[0]
+            Get-ChildItem $Args[1] | Invoke-ScriptAnalyzer -EnableExit
+        } -Args $pssaPath, "$PSScriptRoot\RecursionDirectoryTest"
+
+        $LASTEXITCODE | Should -Be 2
     }
 
     Describe "-ReportSummary switch" {


### PR DESCRIPTION
## PR Summary

Fixes #2054 by setting the exit to the total number of emitted diagnostics instead of just the last processed file from the pipeline.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.