### PR TITLE
Use -NoProfile when invoking pwsh in Pester tests

### DIFF
--- a/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
+++ b/Tests/Engine/InvokeScriptAnalyzer.tests.ps1
@@ -604,7 +604,7 @@ Describe "-ReportSummary switch" {
     }
 
     It "prints the correct report summary using the -NoReportSummary switch" {
-        $result = & $pwshExe -Command "Import-Module '$pssaPath'; Invoke-ScriptAnalyzer -ScriptDefinition gci -ReportSummary"
+        $result = & $pwshExe -NoProfile -Command "Import-Module '$pssaPath'; Invoke-ScriptAnalyzer -ScriptDefinition gci -ReportSummary"
 
         "$result" | Should -BeLike $reportSummaryFor1Warning
     }

--- a/build.psm1
+++ b/build.psm1
@@ -351,7 +351,7 @@ function Test-ScriptAnalyzer
             }
             else {
                 $powershell = (Get-Process -id $PID).MainModule.FileName
-                & ${powershell} -Command $scriptBlock
+                & ${powershell} -NoProfile -Command $scriptBlock
             }
         }
         finally {


### PR DESCRIPTION
## PR Summary

Fixes Pester tests for users who print a custom banner (or any other output on startup) in their `$PROFILE`. Also makes the tests finish faster.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.