### PR TITLE
PSUseConsistentWhitespace: Correctly fix whitespace between command parameters when parameter value spans multiple lines 

### DIFF
--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -421,8 +421,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     {
                         int numberOfRedundantWhiteSpaces = rightExtent.StartColumnNumber - expectedStartColumnNumberOfRightExtent;
                         var correction = new CorrectionExtent(
-                            startLineNumber: leftExtent.StartLineNumber,
-                            endLineNumber: leftExtent.EndLineNumber,
+                            startLineNumber: leftExtent.EndLineNumber,
+                            endLineNumber: rightExtent.StartLineNumber,
                             startColumnNumber: leftExtent.EndColumnNumber + 1,
                             endColumnNumber: leftExtent.EndColumnNumber + 1 + numberOfRedundantWhiteSpaces,
                             text: string.Empty,

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -585,6 +585,42 @@ bar -h i `
                 Should -Be "$expected"
         }
 
+        It "Should fix script when a parameter value is a script block spanning multiple lines" {
+            $def = {foo { 
+    bar
+}     -baz}
+
+            $expected = {foo { 
+    bar
+} -baz}
+            Invoke-Formatter -ScriptDefinition "$def" -Settings $settings |
+                Should -Be "$expected"
+        }
+
+        It "Should fix script when a parameter value is a hashtable spanning multiple lines" {
+            $def = {foo @{
+    a = 1
+}     -baz}
+
+            $expected = {foo @{
+    a = 1
+} -baz}
+            Invoke-Formatter -ScriptDefinition "$def" -Settings $settings |
+                Should -Be "$expected"
+        }
+
+        It "Should fix script when a parameter value is an array spanning multiple lines" {
+            $def = {foo @(
+    1
+)     -baz}
+
+            $expected = {foo @(
+    1
+) -baz}
+            Invoke-Formatter -ScriptDefinition "$def" -Settings $settings |
+                Should -Be "$expected"
+        }
+
         It "Should fix script when redirects are involved and whitespace is not consistent" {
             # Related to Issue #2000
             $def = 'foo   3>&1  1>$null   2>&1'

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -535,7 +535,7 @@ bar -h i `
             Invoke-ScriptAnalyzer -ScriptDefinition "$def" -Settings $settings | Should -Be $null
         }
 
-        It "Should not find no violation if there is always 1 space between parameters except when using colon syntax" {
+        It "Should not find a violation if there is always 1 space between parameters except when using colon syntax" {
             $def = 'foo -bar $baz @splattedVariable -bat -parameterName:$parameterValue'
             Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }


### PR DESCRIPTION
## PR Summary

Changes the suggested correction extent of `PSUseConsistentWhitespace`'s parameter spacing violations.

When enabled, the `CheckParameter` setting of this rule checks the spacing between parameters of a command. 

An erroneous correction extent was being generated when parameter values spanned multiple lines (such as for arrays, scriptblocks, and hashtables.

For instance, using the below settings to isolate only the `CheckParameter` part of the rule:

```powershell
$Settings = @{
    IncludeRules = @('PSUseConsistentWhitespace')
    Rules        = @{
        PSUseConsistentWhitespace = @{
            Enable                                  = $true
            CheckInnerBrace                         = $false
            CheckOpenBrace                          = $false
            CheckOpenParen                          = $false
            CheckOperator                           = $false
            CheckPipe                               = $false
            CheckPipeForRedundantWhitespace         = $false
            CheckSeparator                          = $false
            CheckParameter                          = $true
            IgnoreAssignmentOperatorInsideHashTable = $false
        }
    }
}
```

Running the formatter against:

```powershell
foo { 
    bar
}  -baz

foo @{ 
    1 = 1
}  -baz

foo @(
    1
)  -baz
```

> **Note:** There are multiple spaces before each of the `-baz` parameters

Resulted in:

```powershell
fo-baz

fo-baz

fo-baz
```

Fixes #2060

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.