### PR TITLE
PSUseConsistentWhitespace: Ignore whitespace between separator and comment

### DIFF
--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -451,6 +451,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 return node.Next != null
                     && node.Next.Value.Kind != TokenKind.NewLine
+                    && node.Next.Value.Kind != TokenKind.Comment
                     && node.Next.Value.Kind != TokenKind.EndOfInput // semicolon can be followed by end of input
                     && !IsPreviousTokenApartByWhitespace(node.Next);
             };

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -514,6 +514,48 @@ if ($true) { Get-Item `
         }
     }
 
+    Context "CheckSeparator" {
+        BeforeAll {
+            $ruleConfiguration.CheckInnerBrace = $false
+            $ruleConfiguration.CheckOpenBrace = $false
+            $ruleConfiguration.CheckOpenParen = $false
+            $ruleConfiguration.CheckOperator = $false
+            $ruleConfiguration.CheckPipe = $false
+            $ruleConfiguration.CheckSeparator = $true
+        }
+
+        It "Should find a violation if there is no space after a comma" {
+            $def = '$Array = @(1,2)'
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -HaveCount 1
+        }
+
+        It "Should not find a violation if there is a space after a comma" {
+            $def = '$Array = @(1, 2)'
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
+        }
+
+        It "Should not find a violation if there is a new-line after a comma" {
+            $def = @'
+$Array = @(
+    1,
+    2
+)
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
+        }
+
+        It "Should not find a violation if there is a comment after the separator" {
+            $def = @'
+$Array = @(
+    'foo',     # Comment Line 1
+    'FizzBuzz' # Comment Line 2
+)
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -BeNullOrEmpty
+        }
+
+    }
+
 
     Context "CheckParameter" {
         BeforeAll {


### PR DESCRIPTION
## PR Summary

When checking for consistent whitespace between separators, using:

```powershell
$Settings = @{
    IncludeRules = @('PSUseConsistentWhitespace')
    Rules        = @{
        PSUseConsistentWhitespace = @{
            Enable                                  = $true
            CheckInnerBrace                         = $false
            CheckOpenBrace                          = $false
            CheckOpenParen                          = $false
            CheckOperator                           = $false
            CheckPipe                               = $false
            CheckPipeForRedundantWhitespace         = $false
            CheckSeparator                          = $true
            CheckParameter                          = $false
            IgnoreAssignmentOperatorInsideHashTable = $false
        }
    }
}
```

Whitespace between a separator and subsequent start of a comment is flagged as a violation. When formatting, it is removed.

So something such as:

```powershell
$Array = @(
    'Foo',     # Comment Line 1
    'FizzBuzz' # Comment Line 2
)
```

Is *fixed* to:

```powershell
$Array = @(
    'Foo', # Comment Line 1
    'FizzBuzz' # Comment Line 2
)
```

This doesn't seem like desirable behaviour.

This PR ignores whitespace between separators and the start of a comment.

There were no tests around the `CheckSeparator` parameter, so I've added some.

Fixes #1842 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.