### PR TITLE
PSReviewUnusedParameter false positive for ValueFromPipeline

### DIFF
--- a/Rules/ReviewUnusedParameter.cs
+++ b/Rules/ReviewUnusedParameter.cs
@@ -126,7 +126,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     );
                     // If the parameter has the ValueFromPipeline attribute and the scriptblock has a process block with
                     // $_ or $PSItem usage, then the parameter is considered used
-                    if (valueFromPipeline?.GetValue() == true && hasProcessBlockWithPSItemOrUnderscore)
+                    if (valueFromPipeline?.GetValue() && hasProcessBlockWithPSItemOrUnderscore)
+
                     {
                         continue;
                     }

--- a/Rules/ReviewUnusedParameter.cs
+++ b/Rules/ReviewUnusedParameter.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     );
                     // If the parameter has the ValueFromPipeline attribute and the scriptblock has a process block with
                     // $_ or $PSItem usage, then the parameter is considered used
-                    if (valueFromPipeline?.GetValue() && hasProcessBlockWithPSItemOrUnderscore)
+                    if (valueFromPipeline != null && valueFromPipeline.GetValue() && hasProcessBlockWithPSItemOrUnderscore)
 
                     {
                         continue;

--- a/Tests/Rules/ReviewUnusedParameter.tests.ps1
+++ b/Tests/Rules/ReviewUnusedParameter.tests.ps1
@@ -20,6 +20,18 @@ Describe "ReviewUnusedParameter" {
             $Violations.Count | Should -Be 2
         }
 
+        It "has 1 violation - function with 1 parameter with ValueFromPipeline set to false and `$_ usage" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $false)] $Param1) $_}'
+            $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
+            $Violations.Count | Should -Be 1
+        }
+
+        It "has 1 violation - function with 1 parameter with ValueFromPipeline set to false and `$PSItem usage" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $false)] $Param1) $PSItem}'
+            $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
+            $Violations.Count | Should -Be 1
+        }
+
         It "has 1 violation - scriptblock with 1 unused parameter" {
             $ScriptDefinition = '{ param ($Param1) }'
             $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
@@ -55,6 +67,30 @@ Describe "ReviewUnusedParameter" {
 
         It "has no violations - function with splatting" {
             $ScriptDefinition = 'function GoodFunc1 { param ($Param1) $Splat = @{InputObject = $Param1}}'
+            $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
+            $Violations.Count | Should -Be 0
+        }
+
+        It "has no violation - function with 1 parameter with ValueFromPipeline explictly set to true and `$_ usage" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $true)] $Param1) $_}'
+            $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
+            $Violations.Count | Should -Be 0
+        }
+
+        It "has no violation - function with 1 parameter with ValueFromPipeline explictly set to true and `$PSItem usage" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $true)] $Param1) $PSItem}'
+            $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
+            $Violations.Count | Should -Be 0
+        }
+
+        It "has no violation - function with 1 parameter with ValueFromPipeline implicitly set to true and `$_ usage" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline)] $Param1) $_}'
+            $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
+            $Violations.Count | Should -Be 0
+        }
+
+        It "has no violation - function with 1 parameter with ValueFromPipeline implicitly set to true and `$PSItem usage" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline)] $Param1) $PSItem}'
             $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
             $Violations.Count | Should -Be 0
         }

--- a/Tests/Rules/ReviewUnusedParameter.tests.ps1
+++ b/Tests/Rules/ReviewUnusedParameter.tests.ps1
@@ -20,14 +20,26 @@ Describe "ReviewUnusedParameter" {
             $Violations.Count | Should -Be 2
         }
 
-        It "has 1 violation - function with 1 parameter with ValueFromPipeline set to false and `$_ usage" {
-            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $false)] $Param1) $_}'
+        It "has 1 violation - function with 1 parameter with ValueFromPipeline set to false and `$_ usage inside process block" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $false)] $Param1) process {$_}}'
             $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
             $Violations.Count | Should -Be 1
         }
 
-        It "has 1 violation - function with 1 parameter with ValueFromPipeline set to false and `$PSItem usage" {
-            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $false)] $Param1) $PSItem}'
+        It "has 1 violation - function with 1 parameter with ValueFromPipeline set to false and `$PSItem usage inside process block" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $false)] $Param1) process {$PSItem}}'
+            $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
+            $Violations.Count | Should -Be 1
+        }
+
+        It "has 1 violation - function with 1 parameter with ValueFromPipeline set to true and `$_ usage outside process block" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $true)] $Param1) $_}'
+            $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
+            $Violations.Count | Should -Be 1
+        }
+
+        It "has 1 violation - function with 1 parameter with ValueFromPipeline set to true and `$PSItem usage outside process block" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $true)] $Param1) $PSItem}'
             $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
             $Violations.Count | Should -Be 1
         }
@@ -71,26 +83,26 @@ Describe "ReviewUnusedParameter" {
             $Violations.Count | Should -Be 0
         }
 
-        It "has no violation - function with 1 parameter with ValueFromPipeline explictly set to true and `$_ usage" {
-            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $true)] $Param1) $_}'
+        It "has no violation - function with 1 parameter with ValueFromPipeline explictly set to true and `$_ usage inside process block" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $true)] $Param1) process {$_}}'
             $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
             $Violations.Count | Should -Be 0
         }
 
-        It "has no violation - function with 1 parameter with ValueFromPipeline explictly set to true and `$PSItem usage" {
-            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $true)] $Param1) $PSItem}'
+        It "has no violation - function with 1 parameter with ValueFromPipeline explictly set to true and `$PSItem usage inside process block" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline = $true)] $Param1) process {$PSItem}}'
             $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
             $Violations.Count | Should -Be 0
         }
 
-        It "has no violation - function with 1 parameter with ValueFromPipeline implicitly set to true and `$_ usage" {
-            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline)] $Param1) $_}'
+        It "has no violation - function with 1 parameter with ValueFromPipeline implicitly set to true and `$_ usage inside process block" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline)] $Param1) process{$_}}'
             $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
             $Violations.Count | Should -Be 0
         }
 
-        It "has no violation - function with 1 parameter with ValueFromPipeline implicitly set to true and `$PSItem usage" {
-            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline)] $Param1) $PSItem}'
+        It "has no violation - function with 1 parameter with ValueFromPipeline implicitly set to true and `$PSItem usage inside process block" {
+            $ScriptDefinition = 'function BadFunc1 { param ([Parameter(ValueFromPipeline)] $Param1) process{$PSItem}}'
             $Violations = Invoke-ScriptAnalyzer -ScriptDefinition $ScriptDefinition -IncludeRule $RuleName
             $Violations.Count | Should -Be 0
         }


### PR DESCRIPTION
## PR Summary

Whether good practice or not, a parameter defined with `ValueFromPipeline` is flagged as unused when referred to by `$_` or `$PSItem` within the process block of a function.

This PR checks for `ValueFromPipeline` when the parameter's usage is inspected. If set, `$_` and `$PSItem` count towards it's usage when seen in a process block.

Fixes #1840 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.