### PR TITLE
Upgrade to .NET 8 since .NET 6 is past EOL

### DIFF
--- a/.pipelines/PSScriptAnalyzer-Official.yml
+++ b/.pipelines/PSScriptAnalyzer-Official.yml
@@ -80,10 +80,7 @@ extends:
             inputs:
               packageType: sdk
               useGlobalJson: true
-          - pwsh: |
-              Register-PSRepository -Name CFS -SourceLocation "https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/nuget/v2" -InstallationPolicy Trusted
-              Install-Module -Repository CFS -Name Microsoft.PowerShell.PSResourceGet
-              ./tools/installPSResources.ps1 -PSRepository CFS
+          - pwsh: ./tools/installPSResources.ps1 -PSRepository CFS
             displayName: Install PSResources
           - pwsh: ./build.ps1 -Configuration Release -All
             displayName: Build

--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>$(ModuleVersion)</VersionPrefix>
-    <TargetFrameworks>net6;net462</TargetFrameworks>
+    <TargetFrameworks>net8;net462</TargetFrameworks>
     <AssemblyName>Microsoft.Windows.PowerShell.ScriptAnalyzer</AssemblyName>
     <AssemblyVersion>$(ModuleVersion)</AssemblyVersion>
     <PackageId>Engine</PackageId>
@@ -18,11 +18,11 @@
     <DebugType>portable</DebugType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net6' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net8' ">
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8' ">
     <Compile Remove="SafeDirectoryCatalog.cs" />
   </ItemGroup>
 
@@ -69,10 +69,10 @@
   </PropertyGroup>
 
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8'">
     <PackageReference Include="System.Management.Automation" />
   </ItemGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8'">
     <DefineConstants>$(DefineConstants);PSV7;CORECLR</DefineConstants>
   </PropertyGroup>
 

--- a/Rules/Rules.csproj
+++ b/Rules/Rules.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>$(ModuleVersion)</VersionPrefix>
-    <TargetFrameworks>net6;net462</TargetFrameworks>
+    <TargetFrameworks>net8;net462</TargetFrameworks>
     <AssemblyName>Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules</AssemblyName>
     <AssemblyVersion>$(ModuleVersion)</AssemblyVersion>
     <PackageId>Rules</PackageId>
@@ -16,7 +16,7 @@
 
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8' ">
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="System.Reflection.TypeExtensions" />
     <PackageReference Include="Microsoft.Management.Infrastructure" />
@@ -61,7 +61,7 @@
     <DefineConstants>$(DefineConstants);PSV3;PSV4</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8'">
     <DefineConstants>$(DefineConstants);PSV7;CORECLR</DefineConstants>
   </PropertyGroup>
 

--- a/build.psm1
+++ b/build.psm1
@@ -144,7 +144,7 @@ function Start-ScriptAnalyzerBuild
 
         $framework = 'net462'
         if ($PSVersion -eq 7) {
-            $framework = 'net6'
+            $framework = 'net8'
         }
 
         # build the appropriate assembly

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.427"
+        "version": "8.0.406",
+        "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
Well this is past due. This will drop support for PowerShell <7.4 (which are all past EOL too).