### PR TITLE
Update SMA version to 7.4.7

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Pluralize.NET" Version="1.0.2" />
     <PackageVersion Include="PowerShellStandard.Library" Version="3.0.0-preview-02" />
-    <PackageVersion Include="System.Management.Automation" Version="7.2.23" />
+    <PackageVersion Include="System.Management.Automation" Version="7.4.7" />
     <PackageVersion Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## PR Summary

Since PowerShell 7.2 is not supported any more, we can upgrade the SMA version. Somehow 7.4.8 is not published, raised issue here: https://github.com/PowerShell/PowerShell/issues/25162

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.