### PR TITLE
Drop v3 and v4 support from build

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,14 +3,12 @@
     <!-- Newtonsoft.Json brings in an old version of CSharp. So, we are forcing a newer version. -->
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Management.Infrastructure" Version="3.0.0" />
-    <PackageVersion Include="Microsoft.PowerShell.3.ReferenceAssemblies" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.PowerShell.4.ReferenceAssemblies" Version="1.0.0" />
     <PackageVersion Include="Microsoft.PowerShell.5.ReferenceAssemblies" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <!--  The version of Newtonsoft.Json needs to be newer than the version in the oldest supported version of PowerShell 7: https://github.com/PowerShell/PowerShell/blob/v7.2.17/src/System.Management.Automation/System.Management.Automation.csproj#L15 -->
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Pluralize.NET" Version="1.0.2" />
-    <PackageVersion Include="PowerShellStandard.Library" Version="3.0.0-preview-02" />
+    <PackageVersion Include="PowerShellStandard.Library" Version="5.1.1" />
     <PackageVersion Include="System.Management.Automation" Version="7.4.7" />
     <PackageVersion Include="System.Reflection.TypeExtensions" Version="4.7.0" />
   </ItemGroup>

--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -75,33 +75,9 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net8'">
     <DefineConstants>$(DefineConstants);PSV7;CORECLR</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' AND '$(Configuration)' == 'PSV3Release' AND '$(Configuration)' != 'PSV4Release'">
-    <PackageReference Include="Microsoft.PowerShell.3.ReferenceAssemblies" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' AND '$(Configuration)' == 'PSV4Release'">
-    <PackageReference Include="Microsoft.PowerShell.4.ReferenceAssemblies" />
-  </ItemGroup>
    
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' AND '$(Configuration)' != 'PSV3Release'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" />
   </ItemGroup>
-   
-  <PropertyGroup Condition=" '$(Configuration)' == 'PSV3Release' ">
-    <DefineConstants>$(DefineConstants);PSV3</DefineConstants>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(Configuration)' == 'PSV4Release' ">
-    <DefineConstants>$(DefineConstants);PSV3;PSV4</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(Configuration)' == 'PSV3Debug' ">
-    <DefineConstants>$(DefineConstants);PSV3</DefineConstants>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(Configuration)' == 'PSV4Debug' ">
-    <DefineConstants>$(DefineConstants);PSV3;PSV4</DefineConstants>
-  </PropertyGroup>
 
 </Project>

--- a/Engine/PSScriptAnalyzer.psd1
+++ b/Engine/PSScriptAnalyzer.psd1
@@ -20,13 +20,13 @@ GUID = 'd6245802-193d-4068-a631-8863a4342a18'
 CompanyName = 'Microsoft Corporation'
 
 # Copyright statement for this module
-Copyright = '(c) Microsoft Corporation 2016. All rights reserved.'
+Copyright = '(c) Microsoft Corporation 2025. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'PSScriptAnalyzer provides script analysis and checks for potential code defects in the scripts by applying a group of built-in or customized rules on the scripts being analyzed.'
 
 # Minimum version of the Windows PowerShell engine required by this module
-PowerShellVersion = '3.0'
+PowerShellVersion = '5.1'
 
 # Name of the Windows PowerShell host required by this module
 # PowerShellHostName = ''

--- a/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Microsoft.PowerShell.CrossCompatibility.csproj
+++ b/PSCompatibilityCollector/Microsoft.PowerShell.CrossCompatibility/Microsoft.PowerShell.CrossCompatibility.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
     <PackageReference Include="Newtonsoft.Json" />
-    <PackageReference Include="Microsoft.PowerShell.3.ReferenceAssemblies" />
+    <PackageReference Include="Microsoft.PowerShell.5.ReferenceAssemblies" />
     <PackageReference Include="Microsoft.Management.Infrastructure" VersionOverride="1.0.0" />
   </ItemGroup>
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ To install **PSScriptAnalyzer** from source code:
 ### Requirements
 
 - [Latest .NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
-* If building for Windows PowerShell versions, then the .NET Framework 4.6.2 [targeting pack](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net462) (also referred to as developer/targeting pack) need to be installed. This is only possible on Windows.
-* Optionally but recommended for development: [Visual Studio 2017/2019](https://www.visualstudio.com/downloads)
+- If building for Windows PowerShell versions, then the .NET Framework 4.6.2 [targeting pack](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net462) (also referred to as developer/targeting pack) need to be installed. This is only possible on Windows.
+- Optional but recommended for development: [Visual Studio 2022](https://www.visualstudio.com/downloads)
+- Or [Visual Studio Code](https://code.visualstudio.com/download)
 - [Pester v5 PowerShell module, available on PowerShell Gallery](https://github.com/pester/Pester)
 - [PlatyPS PowerShell module, available on PowerShell Gallery](https://github.com/PowerShell/platyPS/releases)
-- Optionally but recommended for development: [Visual Studio](https://www.visualstudio.com/downloads)
 
 ### Steps
 
@@ -110,18 +110,6 @@ To install **PSScriptAnalyzer** from source code:
     .\build.ps1 -PSVersion 5
     ```
 
-  - Windows PowerShell version 4.0
-
-    ```powershell
-    .\build.ps1 -PSVersion 4
-    ```
-
-  - Windows PowerShell version 3.0
-
-    ```powershell
-    .\build.ps1 -PSVersion 3
-    ```
-
   - PowerShell 7
 
     ```powershell
@@ -134,7 +122,7 @@ To install **PSScriptAnalyzer** from source code:
   .\build.ps1 -Documentation
   ```
 
-- Build all versions (PowerShell v3, v4, v5, and v6) and documentation
+- Build all versions (PowerShell v5 and v7) and documentation
 
   ```powershell
   .\build.ps1 -All

--- a/build.ps1
+++ b/build.ps1
@@ -7,7 +7,7 @@ param(
     [switch]$All,
 
     [Parameter(ParameterSetName="BuildOne")]
-    [ValidateSet(3, 4, 5, 7)]
+    [ValidateSet(5, 7)]
     [int]$PSVersion = $PSVersionTable.PSVersion.Major,
 
     [Parameter(ParameterSetName="BuildOne")]

--- a/build.psm1
+++ b/build.psm1
@@ -88,7 +88,7 @@ function Start-ScriptAnalyzerBuild
     param (
         [switch]$All,
 
-        [ValidateSet(3, 4, 5, 7)]
+        [ValidateSet(5, 7)]
         [int]$PSVersion = $PSVersionTable.PSVersion.Major,
 
         [ValidateSet("Debug", "Release")]
@@ -124,7 +124,7 @@ function Start-ScriptAnalyzerBuild
         if ( $All )
         {
             # Build all the versions of the analyzer
-            foreach ($psVersion in 3, 4, 5, 7) {
+            foreach ($psVersion in 5, 7) {
                 Write-Verbose -Verbose -Message "Configuration: $Configuration PSVersion: $psVersion"
                 Start-ScriptAnalyzerBuild -Configuration $Configuration -PSVersion $psVersion -Verbose:$verboseWanted
             }
@@ -145,12 +145,6 @@ function Start-ScriptAnalyzerBuild
         $framework = 'net462'
         if ($PSVersion -eq 7) {
             $framework = 'net8'
-        }
-
-        # build the appropriate assembly
-        if ($PSVersion -match "[34]" -and $Framework -ne "net462")
-        {
-            throw ("ScriptAnalyzer for PS version '{0}' is not applicable to {1} framework" -f $PSVersion,$Framework)
         }
 
         Push-Location -Path $projectRoot
@@ -176,14 +170,6 @@ function Start-ScriptAnalyzerBuild
 
         switch ($PSVersion)
         {
-            3
-            {
-                $destinationDirBinaries = "$script:destinationDir\PSv3"
-            }
-            4
-            {
-                $destinationDirBinaries = "$script:destinationDir\PSv4"
-            }
             5
             {
                 $destinationDirBinaries = "$script:destinationDir"
@@ -199,7 +185,7 @@ function Start-ScriptAnalyzerBuild
         }
 
         $buildConfiguration = $Configuration
-        if ((3, 4, 7) -contains $PSVersion) {
+        if ($PSVersion -eq 7) {
             $buildConfiguration = "PSV${PSVersion}${Configuration}"
         }
 


### PR DESCRIPTION
This leaves all the guarded v3 and v4 implementation and test code, but starts the removal of support by dropping it from the build and updating the manifest.