### PR TITLE
Change severity of UseCorrectCasing to be Information

### DIFF
--- a/Rules/UseCorrectCasing.cs
+++ b/Rules/UseCorrectCasing.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 string.Format(CultureInfo.CurrentCulture, message, extent.Text, correction),
                 extent,
                 GetName(),
-                DiagnosticSeverity.Warning,
+                DiagnosticSeverity.Information,
                 fileName,
                 correction,
                 suggestedCorrections: GetCorrectionExtent(ast, extent, correction));
@@ -217,7 +217,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 string.Format(CultureInfo.CurrentCulture, message, extent.Text, correction),
                 extent,
                 GetName(),
-                DiagnosticSeverity.Warning,
+                DiagnosticSeverity.Information,
                 fileName,
                 correction,
                 suggestedCorrections: GetCorrectionExtent(ast, extent, correction));


### PR DESCRIPTION
## PR Summary

Fixes #2036
Ironically documentation was already stating Information as severity so nothing to fix there 😅

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.