### PR TITLE
Document new optional parameters added to UseCorrectCasing in #1704

### DIFF
--- a/docs/Rules/UseCorrectCasing.md
+++ b/docs/Rules/UseCorrectCasing.md
@@ -16,6 +16,35 @@ This rule nonetheless ensures consistent casing for clarity and readability.
 Using lowercase keywords helps distinguish them from commands.
 Using lowercase operators helps distinguish them from parameters.
 
+## Configuration
+
+```powershell
+Rules = @{
+    PS UseCorrectCasing = @{
+        Enable        = $true
+        CheckCommands = $true
+        CheckKeyword  = $true
+        CheckOperator = $true
+    }
+}
+```
+
+### Enable: bool (Default value is `$false`)
+
+Enable or disable the rule during ScriptAnalyzer invocation.
+
+### CheckCommands: bool (Default value is `$true`)
+
+If true, require the case of all operators to be lowercase.
+
+### CheckKeyword: bool (Default value is `$true`)
+
+If true, require the case of all keywords to be lowercase.
+
+### CheckOperator: bool (Default value is `$true`)
+
+If true, require the case of all commands to match their actual casing.
+
 ## How
 
 Use exact casing for type names.


### PR DESCRIPTION
## PR Summary

Document new optional parameters added in #1704

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.