### PR TITLE
Fix for PSUseConsistantWhiteSpace when using statement is present

### DIFF
--- a/Engine/FindAstPositionVisitor.cs
+++ b/Engine/FindAstPositionVisitor.cs
@@ -333,7 +333,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer
 
          public override AstVisitAction VisitUsingStatement(UsingStatementAst usingStatementAst)
          {
-             return Visit(usingStatementAst);
+             return AstVisitAction.Continue;
          }
 #endif
 

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -212,9 +212,10 @@ $ht = @{
             $ruleConfiguration.CheckSeparator = $false
             $ruleConfiguration.IgnoreAssignmentOperatorInsideHashTable = $true
         }
+
         It "Should not find violation if assignment operator is in multi-line hash table and a using statement is present" {
             $def = @'
-using system
+using namespace System.IO
 
 $ht = @{
     variable = 3
@@ -223,7 +224,6 @@ $ht = @{
 '@
             Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
         }
-
 
         It "Should not find violation if assignment operator is in multi-line hash table" {
             $def = @'

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -212,6 +212,19 @@ $ht = @{
             $ruleConfiguration.CheckSeparator = $false
             $ruleConfiguration.IgnoreAssignmentOperatorInsideHashTable = $true
         }
+        It "Should not find violation if assignment operator is in multi-line hash table and a using statement is present" {
+            $def = @'
+using system
+
+$ht = @{
+    variable = 3
+    other    = 4
+}
+'@
+            Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings | Should -Be $null
+        }
+
+
         It "Should not find violation if assignment operator is in multi-line hash table" {
             $def = @'
 $ht = @{
@@ -628,11 +641,11 @@ bar -h i `
         }
 
         It "Should fix script when a parameter value is a script block spanning multiple lines" {
-            $def = {foo { 
+            $def = {foo {
     bar
 }     -baz}
 
-            $expected = {foo { 
+            $expected = {foo {
     bar
 } -baz}
             Invoke-Formatter -ScriptDefinition "$def" -Settings $settings |


### PR DESCRIPTION
## PR Summary

The addition of an using statement can cause the PSUseConsistant white space to fail due to how the InternalVisit of the UsingStatementAst is implemented in a slightly different way than other ASTs. See [issue 2089](https://github.com/PowerShell/PSScriptAnalyzer/issues/2089) for more details.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.