### PR TITLE
Add PSAvoidUsingNewObject Rule

### DIFF
--- a/Engine/Commands/InvokeScriptAnalyzerCommand.cs
+++ b/Engine/Commands/InvokeScriptAnalyzerCommand.cs
@@ -340,11 +340,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.Commands
                         settingsObj?.CustomRulePath?.ToArray(),
                         this.SessionState,
                         combRecurseCustomRulePath);
-                    combRulePaths = rulePaths == null
-                                                ? settingsCustomRulePath
-                                                : settingsCustomRulePath == null
-                                                    ? rulePaths
-                                                    : rulePaths.Concat(settingsCustomRulePath).ToArray();
+                combRulePaths = rulePaths == null
+                                            ? settingsCustomRulePath
+                                            : settingsCustomRulePath == null
+                                                ? rulePaths
+                                                : rulePaths.Concat(settingsCustomRulePath).ToArray();
             }
             catch (Exception exception)
             {

--- a/Engine/Settings/PSGallery.psd1
+++ b/Engine/Settings/PSGallery.psd1
@@ -16,6 +16,7 @@
                    'PSAvoidGlobalVars',
                    'PSUseDeclaredVarsMoreThanAssignments',
                    'PSAvoidUsingInvokeExpression',
+                   'PSAvoidUsingNewObject',
                    'PSAvoidUsingPlainTextForPassword',
                    'PSAvoidUsingComputerNameHardcoded',
                    'PSUsePSCredentialType',

--- a/Engine/Settings/ScriptFunctions.psd1
+++ b/Engine/Settings/ScriptFunctions.psd1
@@ -7,5 +7,6 @@
                    'PSAvoidUsingPositionalParameters',
                    'PSAvoidGlobalVars',
                    'PSUseDeclaredVarsMoreThanAssignments',
-                   'PSAvoidUsingInvokeExpression')
+                   'PSAvoidUsingInvokeExpression',
+                   'PSAvoidUsingNewObject')
 }

--- a/Rules/AvoidUsingNewObject.cs
+++ b/Rules/AvoidUsingNewObject.cs
@@ -4,9 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using System.Management.Automation.Language;
-using System.Text.RegularExpressions;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 
 #if !CORECLR
@@ -16,194 +14,159 @@ using System.ComponentModel.Composition;
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
     /// <summary>
-    /// AvoidUsingNewObject: Check to make sure that New-Object is not used.
+    /// Flags New-Object usage except when creating COM objects via -ComObject parameter.
+    /// Supports parameter abbreviation, splatting, variable resolution, and expandable strings.
     /// </summary>
 #if !CORECLR
     [Export(typeof(IScriptRule))]
 #endif
     public class AvoidUsingNewObject : IScriptRule
     {
-        #region Singleton members
-        private const string _cmdletName = "New-Object";
+        #region Constants
 
-        // We only want to check for the first letter to allow for parameter appreviations.
-        // For Example: -ComObject, -Com, -C.
-        private static Regex _comObjectParameterRegex = new Regex(
-            "^C",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase,
-            TimeSpan.FromSeconds(1)
-        );
-
-        // We only want to check for the first letter to allow for parameter appreviations.
-        // For Example: -TypeName, -Type, -T.
-        private static Regex _typeNameParameterRegex = new Regex(
-            "^T",
-            RegexOptions.Compiled | RegexOptions.IgnoreCase,
-            TimeSpan.FromSeconds(1)
-        );
+        private const string CmdletName = "New-Object";
+        private const string ComObjectParameterName = "ComObject";
+        private const string TypeNameParameterName = "TypeName";
 
         #endregion
 
-        #region Private members
-
-        // Required to query New-Object Parameter Splats / Variable reassignments
-        private Ast _rootAst;
-
-        #endregion
-
-        #region Public methods
+        #region Fields
 
         /// <summary>
-        /// AnalyzeScript: Analyzes the given Ast and returns DiagnosticRecords based on the analysis.
+        /// Root AST for variable assignment tracking.
         /// </summary>
-        /// <param name="ast">The script's ast</param>
-        /// <param name="fileName">The name of the script file being analyzed</param>
-        /// <returns>The results of the analysis</returns>
+        private Ast _rootAst;
+
+        /// <summary>
+        /// Lazy-loaded cache mapping variable names to their assignment statements.
+        /// Only initialized when splatted variables are encountered.
+        /// </summary>
+        private Lazy<Dictionary<string, List<AssignmentStatementAst>>> _assignmentCache;
+
+        #endregion
+
+        #region Public Methods
+
+        /// <summary>
+        /// Analyzes PowerShell AST for New-Object usage that should be replaced with type literals.
+        /// </summary>
+        /// <param name="ast">The root AST to analyze</param>
+        /// <param name="fileName">Source file name for diagnostic reporting</param>
+        /// <returns>Enumerable of diagnostic records for non-COM New-Object usage</returns>
+        /// <exception cref="ArgumentNullException">Thrown when ast parameter is null</exception>
         public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
         {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
             _rootAst = ast;
 
-            IEnumerable<Ast> commandAsts = ast.FindAll(testAst => testAst is CommandAst, true);
-
-            foreach (CommandAst cmdAst in commandAsts)
+            // Direct enumeration without intermediate collection
+            foreach (var node in ast.FindAll(testAst => testAst is CommandAst cmdAst &&
+                string.Equals(cmdAst.GetCommandName(), CmdletName, StringComparison.OrdinalIgnoreCase), true))
             {
-                if (cmdAst.GetCommandName() == null) continue;
+                var cmdAst = (CommandAst)node;
 
-                if (!string.Equals(cmdAst.GetCommandName(), _cmdletName, StringComparison.OrdinalIgnoreCase))
+                if (!IsComObject(cmdAst))
                 {
-                    continue;
-                }
-
-                if (IsComObject(cmdAst))
-                {
-                    continue;
-                }
-
-                yield return new DiagnosticRecord(
-                        GetError(),
+                    yield return new DiagnosticRecord(
+                        string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingNewObjectError),
                         cmdAst.Extent,
                         GetName(),
-                        GetDiagnosticSeverity(),
+                        DiagnosticSeverity.Warning,
                         fileName,
-                        cmdAst.GetCommandName());
+                        CmdletName);
+                }
             }
         }
 
         #endregion
 
-        #region Private methods
+        #region Private Instance Methods - Core Logic
 
         /// <summary>
-        /// GetError: Retrieves the error message
+        /// Determines if a New-Object command creates a COM object.
         /// </summary>
-        /// <returns>The error message</returns>
-        public string GetError()
+        /// <param name="commandAst">The New-Object command AST to analyze</param>
+        /// <returns>True if command creates COM object via -ComObject parameter; false otherwise</returns>
+        private bool IsComObject(CommandAst commandAst)
         {
-            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingNewObjectError);
-        }
-
-        /// <summary>
-        /// GetName: Retrieves the name of this rule.
-        /// </summary>
-        /// <returns>The name of this rule</returns>
-        public string GetName()
-        {
-            return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.AvoidUsingNewObjectName);
-        }
-
-        /// <summary>
-        /// GetCommonName: Retrieves the common name of this rule.
-        /// </summary>
-        /// <returns>The common name of this rule</returns>
-        public string GetCommonName()
-        {
-            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingNewObjectCommonName);
-        }
-
-        /// <summary>
-        /// GetDescription: Retrieves the description of this rule.
-        /// </summary>
-        /// <returns>The description of this rule</returns>
-        public string GetDescription()
-        {
-            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingNewObjectDescription);
-        }
-
-        /// <summary>
-        /// Method: Retrieves the type of the rule: builtin, managed or module.
-        /// </summary>
-        public SourceType GetSourceType()
-        {
-            return SourceType.Builtin;
-        }
-
-        /// <summary>
-        /// GetSeverity:Retrieves the severity of the rule: error, warning of information.
-        /// </summary>
-        /// <returns>The severity of the rule</returns>
-        public RuleSeverity GetSeverity()
-        {
-            return RuleSeverity.Warning;
-        }
-
-        /// <summary>
-        /// DiagnosticSeverity: Retrieves the severity of the rule of type DiagnosticSeverity: error, warning or information.
-        /// </summary>
-        /// <returns>The diagnostic severity of the rule</returns>
-        public DiagnosticSeverity GetDiagnosticSeverity()
-        {
-            return DiagnosticSeverity.Warning;
-        }
-
-        /// <summary>
-        /// Method: Retrieves the module/assembly name the rule is from.
-        /// </summary>
-        public string GetSourceName()
-        {
-            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
-        }
-
-        /// <summary>
-        /// Determines if the New-Object command is creating a COM object.
-        /// </summary>
-        /// <param name="cmdAst">The CommandAst representing the New-Object command</param>
-        /// <returns>True if the command is creating a COM object, false otherwise</returns>
-        private bool IsComObject(CommandAst cmdAst)
-        {
-            foreach (var element in cmdAst.CommandElements)
+            // Quick check for positional TypeName (non-splat expressions after New-Object)
+            if (commandAst.CommandElements.Count >= 2)
             {
-                if (element is CommandParameterAst cmdParameterAst)
+                var firstArg = commandAst.CommandElements[1];
+
+                // Non-splat variable provided for first positional parameter.
+                if (firstArg is VariableExpressionAst varAst && !varAst.Splatted)
                 {
-                    var paramName = cmdParameterAst.ParameterName;
-                    if (string.IsNullOrEmpty(paramName))
-                        continue;
+                    return false;
+                }
 
-                    if (_comObjectParameterRegex.IsMatch(paramName))
-                        return true;
+                // Non-splat using expression provided for first positional parameter (e.g., $using:var)
+                if (firstArg is UsingExpressionAst usingAst && !(usingAst.SubExpression is VariableExpressionAst usingVar && usingVar.Splatted))
+                {
+                    return false;
+                }
+            }
 
-                    if (_typeNameParameterRegex.IsMatch(paramName))
-                        return false;
+            // Parse named parameters with early TypeName exit
+            return HasComObjectParameter(commandAst);
+        }
 
+        /// <summary>
+        /// Parses command parameters to detect COM object usage with minimal allocations.
+        /// Implements early exit optimization for TypeName parameter detection.
+        /// </summary>
+        /// <param name="commandAst">The command AST to analyze for parameters</param>
+        /// <returns>True if ComObject parameter is found; false if TypeName parameter is found or neither</returns>
+        private bool HasComObjectParameter(CommandAst commandAst)
+        {
+            var waitingForParamValue = false;
+            var elements = commandAst.CommandElements;
+            var elementCount = elements.Count;
+
+            // Fast path: insufficient elements
+            if (elementCount <= 1) return false;
+
+            for (int i = 1; i < elementCount; i++)
+            {
+                var element = elements[i];
+
+                if (waitingForParamValue)
+                {
+                    waitingForParamValue = false;
                     continue;
                 }
 
-                if (element is VariableExpressionAst splattedVarAst && splattedVarAst.Splatted)
-                    return ProcessVariableExpression(splattedVarAst);
-
-                if (element is ExpandableStringExpressionAst expandableStringAst)
-                    return ProcessExpandableExpression(expandableStringAst);
-
-                if (element is UsingExpressionAst usingExprAst)
+                switch (element)
                 {
-                    if (!(usingExprAst.SubExpression is VariableExpressionAst usingVarAst))
-                        continue;
+                    case CommandParameterAst paramAst:
+                        var paramName = paramAst.ParameterName;
 
-                    if (!usingVarAst.Splatted)
-                        continue;
+                        // Early exit: TypeName parameter means not COM
+                        if (TypeNameParameterName.StartsWith(paramName, StringComparison.OrdinalIgnoreCase))
+                            return false;
 
-                    return ProcessVariableExpression(usingVarAst);
+                        // Found ComObject parameter
+                        if (ComObjectParameterName.StartsWith(paramName, StringComparison.OrdinalIgnoreCase))
+                            return true;
+
+                        waitingForParamValue = true;
+                        break;
+
+                    case ExpandableStringExpressionAst expandableAst:
+                        if (ProcessExpandableString(expandableAst, ref waitingForParamValue, out bool result))
+                            return result;
+                        break;
+
+                    case VariableExpressionAst varAst when varAst.Splatted:
+                        if (IsSplattedVariableComObject(varAst))
+                            return true;
+                        break;
+
+                    case UsingExpressionAst usingAst when usingAst.SubExpression is VariableExpressionAst usingVar && usingVar.Splatted:
+                        if (IsSplattedVariableComObject((VariableExpressionAst)usingAst.SubExpression))
+                            return true;
+                        break;
                 }
             }
 
@@ -211,175 +174,159 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         }
 
         /// <summary>
-        /// Recursively processes variable assignments to trace back to the original hashtable definition.
+        /// Processes expandable strings with minimal allocations.
         /// </summary>
-        /// <param name="variableName">The name of the variable to process</param>
-        /// <param name="visitedVariables">Set of already visited variables to prevent infinite recursion</param>
-        /// <returns>True if the variable chain leads to a COM object parameter, false otherwise</returns>
-        private bool ProcessVariable(string variableName, HashSet<string> visitedVariables)
+        private bool ProcessExpandableString(
+            ExpandableStringExpressionAst expandableAst,
+            ref bool waitingForParamValue,
+            out bool foundResult)
         {
-            if (visitedVariables.Contains(variableName))
+            foundResult = false;
+            var expandedValues = Helper.Instance.GetStringsFromExpressionAst(expandableAst);
+
+            if (expandedValues is IList<string> list && list.Count == 0 && expandableAst.NestedExpressions != null)
+            {
+                // Defer cache initialization until actually needed
+                var resolvedText = TryResolveExpandableString(expandableAst);
+                if (resolvedText != null)
+                {
+                    expandedValues = new[] { resolvedText };
+                }
+            }
+
+            foreach (var expandedValue in expandedValues)
+            {
+                if (expandedValue.Length > 1 && expandedValue[0] == '-')
+                {
+                    // Avoid substring allocation by using span slicing
+                    var paramName = GetParameterNameFromExpandedValue(expandedValue);
+
+                    if (TypeNameParameterName.StartsWith(paramName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        foundResult = true;
+                        return true; // TypeName found, not COM
+                    }
+
+                    if (ComObjectParameterName.StartsWith(paramName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        foundResult = true;
+                        return true; // ComObject found
+                    }
+
+                    waitingForParamValue = true;
+                }
+            }
+
+            return false;
+        }
+
+        #endregion
+
+        #region Private Instance Methods - Variable Resolution
+
+        /// <summary>
+        /// Lazy resolution of expandable strings - only initialize cache when needed.
+        /// </summary>
+        private string TryResolveExpandableString(ExpandableStringExpressionAst expandableAst)
+        {
+            if (expandableAst.NestedExpressions?.Count != 1)
+                return null;
+
+            var nestedExpr = expandableAst.NestedExpressions[0];
+
+            if (!(nestedExpr is VariableExpressionAst varAst))
+                return null;
+
+            // Now we actually need the cache
+            EnsureAssignmentCacheInitialized();
+
+            var varName = GetVariableNameWithoutScope(varAst);
+            var varValues = ResolveVariableValues(varName);
+
+            if (varValues is IList<string> list && list.Count > 0)
+            {
+                var resolvedText = expandableAst.Extent.Text;
+                var userPath = varAst.VariablePath.UserPath;
+
+                // Optimize string replacement
+                var varPattern = string.Concat("${", userPath, "}");
+                var index = resolvedText.IndexOf(varPattern, StringComparison.Ordinal);
+
+                if (index >= 0)
+                {
+                    return string.Concat(
+                        resolvedText.Substring(0, index),
+                        list[0],
+                        resolvedText.Substring(index + varPattern.Length)
+                    );
+                }
+
+                // Try without braces
+                varPattern = "$" + userPath;
+                index = resolvedText.IndexOf(varPattern, StringComparison.Ordinal);
+
+                if (index >= 0)
+                {
+                    return string.Concat(
+                        resolvedText.Substring(0, index),
+                        list[0],
+                        resolvedText.Substring(index + varPattern.Length)
+                    );
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Analyzes splatted variable for COM object parameters by examining hashtable assignments.
+        /// Supports string literals, expandable strings, and variable key resolution.
+        /// </summary>
+        /// <param name="splattedVar">Splatted variable expression to analyze</param>
+        /// <returns>True if hashtable contains ComObject key or abbreviation</returns>
+        private bool IsSplattedVariableComObject(VariableExpressionAst splattedVar)
+        {
+            EnsureAssignmentCacheInitialized();
+
+            var variableName = GetVariableNameWithoutScope(splattedVar);
+
+            return IsSplattedVariableComObjectRecursive(variableName, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        }
+
+        private bool IsSplattedVariableComObjectRecursive(string variableName, HashSet<string> visited)
+        {
+            if (visited.Contains(variableName))
+            {
                 return false;
+            }
 
-            visitedVariables.Add(variableName);
+            visited.Add(variableName);
 
-            var assignments = FindAssignmentStatements(variableName);
+            var assignments = FindHashtableAssignments(variableName);
 
             foreach (var assignment in assignments)
             {
-                var hashtableAst = GetHashtableFromAssignment(assignment);
-                if (hashtableAst != null)
-                    return ContainsComObjectKey(hashtableAst);
-
-                var sourceVariable = GetVariableFromAssignment(assignment);
-                if (sourceVariable != null)
+                if (assignment.Right is CommandExpressionAst cmdExpr)
                 {
-                    if (ProcessVariable(sourceVariable, visitedVariables))
-                        return true;
+                    if (cmdExpr.Expression is HashtableAst hashtableAst)
+                    {
+                        var hasComKey = HasComObjectKey(hashtableAst);
 
-                    continue;
-                }
+                        if (hasComKey)
+                        {
+                            return true;
+                        }
+                    }
+                    else if (cmdExpr.Expression is VariableExpressionAst referencedVar)
+                    {
+                        // Follow variable chain: $params2 = $script:params
+                        var referencedName = GetVariableNameWithoutScope(referencedVar);
 
-                var stringConstant = GetStringConstantFromAssignment(assignment);
-                if (stringConstant != null)
-                {
-                    if (_comObjectParameterRegex.IsMatch(stringConstant))
-                        return true;
-
-                    if (_typeNameParameterRegex.IsMatch(stringConstant))
-                        return false;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Extracts a string constant from an assignment statement's right-hand side.
-        /// </summary>
-        /// <param name="assignmentAst">The AssignmentStatementAst to analyze</param>
-        /// <returns>The string constant value if found, null otherwise</returns>
-        private static string GetStringConstantFromAssignment(AssignmentStatementAst assignmentAst)
-        {
-            var rightHandSide = assignmentAst.Right;
-
-            if (rightHandSide is PipelineAst pipelineAst)
-            {
-                if (pipelineAst.PipelineElements.Count != 1)
-                    return null;
-
-                if (!(pipelineAst.PipelineElements[0] is CommandExpressionAst cmdExpr))
-                    return null;
-
-                if (!(cmdExpr.Expression is StringConstantExpressionAst stringExpr))
-                    return null;
-
-                return stringExpr.Value;
-            }
-
-            // Handle direct CommandExpressionAst -> StringConstantExpressionAst
-            if (rightHandSide is CommandExpressionAst commandExpr)
-            {
-                if (!(commandExpr.Expression is StringConstantExpressionAst directStringExpr))
-                    return null;
-
-                return directStringExpr.Value;
-            }
-
-            return null;
-        }
-
-        /// <summary>
-        /// Processes VariableExpressionAst to determine if the variable potentially matches 'ComObject' parameter.
-        /// </summary>
-        /// <param name="variableAst">The VariableExpressionAst to process</param>
-        /// <returns>True if the variable contains COM object parameter, false otherwise</returns>
-        private bool ProcessVariableExpression(VariableExpressionAst variableAst)
-        {
-            var variableName = GetVariableNameWithoutScope(variableAst);
-            var visitedVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            return ProcessVariable(variableName, visitedVariables);
-        }
-
-        /// <summary>
-        /// Attempts to resolve expandable strings to its variable value.
-        /// </summary>
-        /// <param name="expandableAst">The ExpandableStringExpressionAst to resolve</param>
-        /// <returns>The resolved string value, or null if it cannot be determined</returns>
-        private bool ProcessExpandableExpression(ExpandableStringExpressionAst expandableAst)
-        {
-            if (expandableAst.NestedExpressions.Count == 0)
-                return false;
-
-            if (!(expandableAst.NestedExpressions[0] is VariableExpressionAst singleVar))
-                return false;
-
-            return ProcessVariableExpression(singleVar);
-        }
-
-        /// <summary>
-        /// Finds all assignment statements in the current scope that assign to the specified variable.
-        /// </summary>
-        /// <param name="variableName">The name of the variable to search for</param>
-        /// <returns>A list of AssignmentStatementAst objects that assign to the variable</returns>
-        private List<AssignmentStatementAst> FindAssignmentStatements(string variableName)
-        {
-            var assignments = new List<AssignmentStatementAst>();
-            var allAssignments = _rootAst.FindAll(ast => ast is AssignmentStatementAst, true);
-
-            foreach (var assignment in allAssignments.Cast<AssignmentStatementAst>())
-            {
-                VariableExpressionAst leftVarAst = GetLeftVariableFromAssignment(assignment);
-                if (leftVarAst == null)
-                    continue;
-
-                var leftVarName = GetVariableNameWithoutScope(leftVarAst);
-                if (!string.Equals(leftVarName, variableName, StringComparison.OrdinalIgnoreCase))
-                    continue;
-
-                assignments.Add(assignment);
-            }
-
-            return assignments;
-        }
-
-        /// <summary>
-        /// Checks if a hashtable contains a ComObject key or TypeName key to determine if it's for COM object creation.
-        /// </summary>
-        /// <param name="hashtableAst">The HashtableAst to examine</param>
-        /// <returns>True if the hashtable contains a ComObject key, false if it contains TypeName or neither</returns>
-        private bool ContainsComObjectKey(HashtableAst hashtableAst)
-        {
-            foreach (var keyValuePair in hashtableAst.KeyValuePairs)
-            {
-                if (keyValuePair.Item1 is StringConstantExpressionAst stringKey)
-                {
-                    string paramName = stringKey.Value;
-                    if (string.IsNullOrEmpty(paramName))
-                        continue;
-
-                    if (_comObjectParameterRegex.IsMatch(paramName))
-                        return true;
-
-                    if (_typeNameParameterRegex.IsMatch(paramName))
-                        return false;
-
-                    continue;
-                }
-
-                if (keyValuePair.Item1 is VariableExpressionAst varKey)
-                {
-                    if (ProcessVariableExpression(varKey))
-                        return true;
-
-                    continue;
-                }
-
-                if (keyValuePair.Item1 is ExpandableStringExpressionAst expandableKey)
-                {
-                    if (ProcessExpandableExpression(expandableKey))
-                        return true;
+                        if (IsSplattedVariableComObjectRecursive(referencedName, visited))
+                        {
+                            return true;
+                        }
+                    }
                 }
             }
 
@@ -388,107 +335,209 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         #endregion
 
-        #region Static methods
+        #region Private Instance Methods - Cache Management
 
         /// <summary>
-        /// Extracts a hashtable from various statement types (PipelineAst, CommandExpressionAst).
+        /// Ensures the assignment cache is initialized before use.
         /// </summary>
-        /// <param name="statement">The StatementAst to analyze</param>
-        /// <returns>The HashtableAst if found, null otherwise</returns>
-        private static HashtableAst ExtractHashtableFromStatement(StatementAst statement)
+        private void EnsureAssignmentCacheInitialized()
         {
-            if (statement is PipelineAst pipelineAst)
+            if (_assignmentCache == null)
             {
-                if (pipelineAst.PipelineElements.Count < 1)
-                    return null;
-
-                if (!(pipelineAst.PipelineElements[0] is CommandExpressionAst cmdExpr))
-                    return null;
-
-                if (!(cmdExpr.Expression is HashtableAst hashtableFromPipeline))
-                    return null;
-
-                return hashtableFromPipeline;
+                _assignmentCache = new Lazy<Dictionary<string, List<AssignmentStatementAst>>>(BuildAssignmentCache);
             }
-
-            if (statement is CommandExpressionAst commandExpr)
-            {
-                if (!(commandExpr.Expression is HashtableAst hashtableFromCommand))
-                    return null;
-
-                return hashtableFromCommand;
-            }
-
-            return null;
         }
 
         /// <summary>
-        /// Extracts a hashtable from an assignment statement's right-hand side.
+        /// Builds case-insensitive cache mapping variable names to their assignment statements.
+        /// Single AST traversal shared across all variable lookups.
         /// </summary>
-        /// <param name="assignmentAst">The AssignmentStatementAst to analyze</param>
-        /// <returns>The HashtableAst if found, null otherwise</returns>
-        private static HashtableAst GetHashtableFromAssignment(AssignmentStatementAst assignmentAst)
+        /// <returns>Dictionary of variable assignments indexed by variable name</returns>
+        private Dictionary<string, List<AssignmentStatementAst>> BuildAssignmentCache()
         {
-            var rightHandSide = assignmentAst.Right;
+            var cache = new Dictionary<string, List<AssignmentStatementAst>>(StringComparer.OrdinalIgnoreCase);
 
-            HashtableAst hashtable = ExtractHashtableFromStatement(rightHandSide);
+            foreach (var ast in _rootAst.FindAll(ast => ast is AssignmentStatementAst, true))
+            {
+                var assignment = (AssignmentStatementAst)ast;
+                VariableExpressionAst leftVar = null;
 
-            if (hashtable != null)
-                return hashtable;
+                switch (assignment.Left)
+                {
+                    case VariableExpressionAst varAst:
+                        leftVar = varAst;
+                        break;
+                    case ConvertExpressionAst convertExpr when convertExpr.Child is VariableExpressionAst convertedVar:
+                        leftVar = convertedVar;
+                        break;
+                }
 
-            var hashtableNodes = rightHandSide.FindAll(ast => ast is HashtableAst, true);
-            return hashtableNodes.FirstOrDefault() as HashtableAst;
+                if (leftVar != null)
+                {
+                    var variableName = GetVariableNameWithoutScope(leftVar);
+
+                    if (!cache.TryGetValue(variableName, out var list))
+                    {
+                        list = new List<AssignmentStatementAst>(4);
+                        cache[variableName] = list;
+                    }
+
+                    list.Add(assignment);
+                }
+            }
+
+            return cache;
         }
 
         /// <summary>
-        /// Extracts the left-hand variable from an assignment statement.
+        /// Retrieves cached assignment statements for the specified variable.
         /// </summary>
-        /// <param name="assignment">The assignment statement</param>
-        /// <returns>The variable expression, or null if not found</returns>
-        private static VariableExpressionAst GetLeftVariableFromAssignment(AssignmentStatementAst assignment)
+        /// <param name="variableName">Variable name to look up</param>
+        /// <returns>List of assignment statements or empty list if none found</returns>
+        private List<AssignmentStatementAst> FindHashtableAssignments(string variableName)
         {
-            if (assignment.Left is VariableExpressionAst leftVar)
-                return leftVar;
+            var cache = _assignmentCache.Value;
+            return cache.TryGetValue(variableName, out var assignments)
+                ? assignments
+                : new List<AssignmentStatementAst>();
+        }
 
-            if (assignment.Left is ConvertExpressionAst convertAst &&
-                convertAst.Child is VariableExpressionAst typedVar)
-                return typedVar;
+        #endregion
 
-            return null;
+        #region Private Instance Methods - Hashtable Analysis
+
+        /// <summary>
+        /// Checks hashtable for ComObject keys, supporting parameter abbreviation.
+        /// Handles string literals, expandable strings, and variable keys.
+        /// </summary>
+        /// <param name="hashtableAst">Hashtable AST to examine</param>
+        /// <returns>True if any key matches ComObject parameter name or abbreviation</returns>
+        private bool HasComObjectKey(HashtableAst hashtableAst)
+        {
+            foreach (var keyValuePair in hashtableAst.KeyValuePairs)
+            {
+                var keyStrings = GetKeyStrings(keyValuePair.Item1);
+
+                foreach (var keyString in keyStrings)
+                {
+                    // Require minimum 3 characters for COM parameter abbreviation to avoid false positives
+                    if (keyString.Length >= 3)
+                    {
+                        if (ComObjectParameterName.StartsWith(keyString, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
-        /// Extracts the source variable name from a variable-to-variable assignment.
+        /// Extracts string values from hashtable key expressions.
+        /// Supports literals, expandable strings, and variable resolution.
         /// </summary>
-        /// <param name="assignmentAst">The AssignmentStatementAst to analyze</param>
-        /// <returns>The name of the source variable, or null if not a variable assignment</returns>
-        private static string GetVariableFromAssignment(AssignmentStatementAst assignmentAst)
+        /// <param name="keyExpression">Key expression from hashtable</param>
+        /// <returns>List of resolved string values for the key</returns>
+        private List<string> GetKeyStrings(ExpressionAst keyExpression)
         {
-            var rightHandSide = assignmentAst.Right;
-
-            if (rightHandSide is PipelineAst pipelineAst)
+            switch (keyExpression)
             {
-                if (pipelineAst.PipelineElements.Count != 1)
-                    return null;
+                case StringConstantExpressionAst stringAst:
+                    return new List<string>(1) { stringAst.Value };
 
-                if (!(pipelineAst.PipelineElements[0] is CommandExpressionAst cmdExpr))
-                    return null;
+                case ExpandableStringExpressionAst expandableAst:
+                    var expandedStrings = Helper.Instance.GetStringsFromExpressionAst(expandableAst);
 
-                if (!(cmdExpr.Expression is VariableExpressionAst varExpr))
-                    return null;
+                    if (expandedStrings is IList<string> list && list.Count > 0)
+                        return new List<string>(list);
 
-                return GetVariableNameWithoutScope(varExpr);
+                    // Fallback for single variable case
+                    if (expandableAst.NestedExpressions?.Count == 1 &&
+                        expandableAst.NestedExpressions[0] is VariableExpressionAst varAst)
+                    {
+                        return ResolveVariableValues(varAst.VariablePath.UserPath);
+                    }
+                    break;
+
+                case VariableExpressionAst variableAst:
+                    return ResolveVariableValues(variableAst.VariablePath.UserPath);
             }
 
-            if (rightHandSide is CommandExpressionAst commandExpr)
-            {
-                if (!(commandExpr.Expression is VariableExpressionAst directVarExpr))
-                    return null;
+            return new List<string>(0);
+        }
 
-                return GetVariableNameWithoutScope(directVarExpr);
+        /// <summary>
+        /// Resolves variable values by analyzing string assignments using cached lookups.
+        /// </summary>
+        /// <param name="variableName">Variable name to resolve</param>
+        /// <returns>List of possible string values assigned to the variable</returns>
+        private List<string> ResolveVariableValues(string variableName)
+        {
+            var values = new List<string>();
+
+            // Optimize scope removal
+            var colonIndex = variableName.IndexOf(':');
+            var normalizedName = colonIndex >= 0
+                ? TrimQuotes(variableName.Substring(colonIndex + 1))
+                : TrimQuotes(variableName);
+
+            if (_assignmentCache.Value.TryGetValue(normalizedName, out var variableAssignments))
+            {
+                foreach (var assignment in variableAssignments)
+                {
+                    if (assignment.Right is CommandExpressionAst cmdExpr)
+                    {
+                        var extractedValues = Helper.Instance.GetStringsFromExpressionAst(cmdExpr.Expression);
+
+                        // Avoid AddRange if possible
+                        if (extractedValues is IList<string> list)
+                        {
+                            for (int i = 0; i < list.Count; i++)
+                                values.Add(list[i]);
+                        }
+                        else
+                        {
+                            values.AddRange(extractedValues);
+                        }
+                    }
+                }
             }
 
-            return null;
+            return values;
+        }
+
+        #endregion
+
+        #region Private Static Methods
+
+        /// <summary>
+        /// Extracts parameter name without allocating substrings.
+        /// </summary>
+        private static string GetParameterNameFromExpandedValue(string expandedValue)
+        {
+            // Skip the '-' prefix
+            var startIndex = 1;
+            var length = expandedValue.Length - 1;
+
+            // Check for quotes and adjust
+            if (length >= 2)
+            {
+                var firstChar = expandedValue[startIndex];
+                var lastChar = expandedValue[expandedValue.Length - 1];
+
+                if ((firstChar == '"' || firstChar == '\'') && firstChar == lastChar)
+                {
+                    startIndex++;
+                    length -= 2;
+                }
+            }
+
+            // Only allocate if we need to trim
+            return startIndex == 1 && length == expandedValue.Length - 1
+                ? expandedValue.Substring(1)
+                : expandedValue.Substring(startIndex, length);
         }
 
         /// <summary>
@@ -525,6 +574,69 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return input.Substring(1, input.Length - 2);
 
             return input;
+        }
+
+        #endregion
+
+        #region IScriptRule Implementation
+
+        /// <summary>
+        /// Gets the fully qualified name of this rule.
+        /// </summary>
+        /// <returns>Rule name in format "SourceName\RuleName"</returns>
+        public string GetName()
+        {
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.NameSpaceFormat,
+                GetSourceName(),
+                Strings.AvoidUsingNewObjectName
+            );
+        }
+
+        /// <summary>
+        /// Gets the user-friendly common name of this rule.
+        /// </summary>
+        /// <returns>Localized common name</returns>
+        public string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingNewObjectCommonName);
+        }
+
+        /// <summary>
+        /// Gets the detailed description of what this rule checks.
+        /// </summary>
+        /// <returns>Localized rule description</returns>
+        public string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingNewObjectDescription);
+        }
+
+        /// <summary>
+        /// Gets the severity level of violations detected by this rule.
+        /// </summary>
+        /// <returns>Warning severity level</returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
+
+        /// <summary>
+        /// Gets the source name for this rule.
+        /// </summary>
+        /// <returns>PSScriptAnalyzer source name</returns>
+        public string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+
+        /// <summary>
+        /// Gets the source type indicating this is a built-in rule.
+        /// </summary>
+        /// <returns>Builtin source type</returns>
+        public SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
         }
 
         #endregion

--- a/Rules/AvoidUsingNewObject.cs
+++ b/Rules/AvoidUsingNewObject.cs
@@ -1,0 +1,373 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Management.Automation.Language;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+
+#if !CORECLR
+using System.ComponentModel.Composition;
+#endif
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
+{
+    /// <summary>
+    /// AvoidUsingNewObject: Check to make sure that New-Object is not used.
+    /// </summary>
+#if !CORECLR
+    [Export(typeof(IScriptRule))]
+#endif
+    public class AvoidUsingNewObject : IScriptRule
+    {
+        private const string _cmdletName = "New-Object";
+        private const string _comObjectParameterName = "ComObject";
+        private const string _typeNameParameterName = "TypeName";
+
+        private Ast _rootAst;
+
+        /// <summary>
+        /// AnalyzeScript: Analyzes the given Ast and returns DiagnosticRecords based on the analysis.
+        /// </summary>
+        /// <param name="ast">The script's ast</param>
+        /// <param name="fileName">The name of the script file being analyzed</param>
+        /// <returns>The results of the analysis</returns>
+        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
+            if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
+
+            // Required to query New-Object Parameter Splats / Variable reassignments
+            _rootAst = ast;
+
+            IEnumerable<Ast> commandAsts = ast.FindAll(testAst => testAst is CommandAst, true);
+
+            foreach (CommandAst cmdAst in commandAsts)
+            {
+                if (cmdAst.GetCommandName() == null) continue;
+
+                if (!string.Equals(cmdAst.GetCommandName(), _cmdletName, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                if (IsComObject(cmdAst))
+                {
+                    continue;
+                }
+
+                yield return new DiagnosticRecord(
+                        GetError(),
+                        cmdAst.Extent,
+                        GetName(),
+                        GetDiagnosticSeverity(),
+                        fileName,
+                        cmdAst.GetCommandName());
+            }
+        }
+
+        /// <summary>
+        /// Determines if the New-Object command is creating a COM object.
+        /// </summary>
+        /// <param name="cmdAst">The CommandAst representing the New-Object command</param>
+        /// <returns>True if the command is creating a COM object, false otherwise</returns>
+        private bool IsComObject(CommandAst cmdAst)
+        {
+            foreach (var element in cmdAst.CommandElements)
+            {
+                if (element is CommandParameterAst cmdParameterAst)
+                {
+                    if (string.Equals(cmdParameterAst.ParameterName, _comObjectParameterName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                    else if (string.Equals(cmdParameterAst.ParameterName, _typeNameParameterName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return false;
+                    }
+
+                    continue;
+                }
+                else if (element is VariableExpressionAst splattedVarAst && splattedVarAst.Splatted)
+                {
+                    return ProcessParameterSplat(splattedVarAst);
+                }
+                else if (element is UsingExpressionAst usingExprAst && usingExprAst.SubExpression is VariableExpressionAst usingVarAst)
+                {
+                    if (!usingVarAst.Splatted)
+                    {
+                        continue;
+                    }
+
+                    return ProcessParameterSplat(usingVarAst);
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Processes a Parameter Splat to determine if it contains COM object parameter.
+        /// </summary>
+        /// <param name="splattedVarAst">The VariableExpressionAst representing the splatted variable</param>
+        /// <returns>True if the variable contains COM object parameter, false otherwise</returns>
+        private bool ProcessParameterSplat(VariableExpressionAst splattedVarAst)
+        {
+            var variableName = Helper.Instance.VariableNameWithoutScope(splattedVarAst.VariablePath);
+            var visitedVariables = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            return ProcessVariable(variableName, visitedVariables);
+        }
+
+        /// <summary>
+        /// Recursively processes variable assignments to trace back to the original hashtable definition.
+        /// </summary>
+        /// <param name="variableName">The name of the variable to process</param>
+        /// <param name="visitedVariables">Set of already visited variables to prevent infinite recursion</param>
+        /// <returns>True if the variable chain leads to a COM object parameter, false otherwise</returns>
+        private bool ProcessVariable(string variableName, HashSet<string> visitedVariables)
+        {
+            // Prevent infinite recursion
+            if (visitedVariables.Contains(variableName))
+            {
+                return false;
+            }
+
+            visitedVariables.Add(variableName);
+
+            var assignments = FindAssignmentsInScope(variableName);
+
+            foreach (var assignment in assignments)
+            {
+                var hashtableAst = GetHashtableFromAssignment(assignment);
+                if (hashtableAst != null)
+                {
+                    return CheckHashtableForComObjectKey(hashtableAst);
+                }
+
+                var sourceVariable = GetVariableFromAssignment(assignment);
+                if (sourceVariable != null)
+                {
+                    var result = ProcessVariable(sourceVariable, visitedVariables);
+
+                    if (result)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Extracts the source variable name from a variable-to-variable assignment.
+        /// </summary>
+        /// <param name="assignmentAst">The AssignmentStatementAst to analyze</param>
+        /// <returns>The name of the source variable, or null if not a variable assignment</returns>
+        private static string GetVariableFromAssignment(AssignmentStatementAst assignmentAst)
+        {
+            var rightHandSide = assignmentAst.Right;
+
+            if (rightHandSide is PipelineAst pipelineAst &&
+                pipelineAst.PipelineElements.Count == 1 &&
+                pipelineAst.PipelineElements[0] is CommandExpressionAst cmdExpr &&
+                cmdExpr.Expression is VariableExpressionAst varExpr)
+            {
+                return Helper.Instance.VariableNameWithoutScope(varExpr.VariablePath);
+            }
+
+            if (rightHandSide is CommandExpressionAst commandExpr &&
+                commandExpr.Expression is VariableExpressionAst directVarExpr)
+            {
+                return Helper.Instance.VariableNameWithoutScope(directVarExpr.VariablePath);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Finds all assignment statements in the current scope that assign to the specified variable.
+        /// </summary>
+        /// <param name="variableName">The name of the variable to search for</param>
+        /// <returns>A list of AssignmentStatementAst objects that assign to the variable</returns>
+        private List<AssignmentStatementAst> FindAssignmentsInScope(string variableName)
+        {
+            var assignments = new List<AssignmentStatementAst>();
+
+            var allAssignments = _rootAst.FindAll(ast => ast is AssignmentStatementAst, true);
+
+            foreach (var assignment in allAssignments.Cast<AssignmentStatementAst>())
+            {
+                VariableExpressionAst leftVarAst = null;
+
+                // Handle direct variable assignment: $var = ...
+                if (assignment.Left is VariableExpressionAst leftVar)
+                {
+                    leftVarAst = leftVar;
+                }
+                // Handle typed assignment: [type]$var = ...
+                else if (assignment.Left is ConvertExpressionAst convertAst &&
+                         convertAst.Child is VariableExpressionAst typedVar)
+                {
+                    leftVarAst = typedVar;
+                }
+
+                if (leftVarAst == null)
+                {
+                    continue;
+                }
+
+                var leftVarName = Helper.Instance.VariableNameWithoutScope(leftVarAst.VariablePath);
+
+                if (string.Equals(leftVarName, variableName, StringComparison.OrdinalIgnoreCase))
+                {
+                    assignments.Add(assignment);
+                }
+            }
+
+            return assignments;
+        }
+
+        /// <summary>
+        /// Checks if a hashtable contains a ComObject key or TypeName key to determine if it's for COM object creation.
+        /// </summary>
+        /// <param name="hashtableAst">The HashtableAst to examine</param>
+        /// <returns>True if the hashtable contains a ComObject key, false if it contains TypeName or neither</returns>
+        private static bool CheckHashtableForComObjectKey(HashtableAst hashtableAst)
+        {
+            foreach (var keyValuePair in hashtableAst.KeyValuePairs)
+            {
+                if (keyValuePair.Item1 is StringConstantExpressionAst keyAst)
+                {
+                    // If the key is ComObject, it's a COM object
+                    if (string.Equals(keyAst.Value, _comObjectParameterName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                    // If the key is TypeName, it's not a COM object
+                    else if (string.Equals(keyAst.Value, _typeNameParameterName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Extracts a hashtable from an assignment statement's right-hand side.
+        /// </summary>
+        /// <param name="assignmentAst">The AssignmentStatementAst to analyze</param>
+        /// <returns>The HashtableAst if found, null otherwise</returns>
+        private static HashtableAst GetHashtableFromAssignment(AssignmentStatementAst assignmentAst)
+        {
+            var rightHandSide = assignmentAst.Right;
+
+            HashtableAst hashtable = ExtractHashtableFromStatement(rightHandSide);
+
+            if (hashtable != null)
+            {
+                return hashtable;
+            }
+
+            var hashtableNodes = rightHandSide.FindAll(ast => ast is HashtableAst, true);
+            return hashtableNodes.FirstOrDefault() as HashtableAst;
+        }
+
+        /// <summary>
+        /// Extracts a hashtable from various statement types (PipelineAst, CommandExpressionAst).
+        /// </summary>
+        /// <param name="statement">The StatementAst to analyze</param>
+        /// <returns>The HashtableAst if found, null otherwise</returns>
+        private static HashtableAst ExtractHashtableFromStatement(StatementAst statement)
+        {
+            switch (statement)
+            {
+                case PipelineAst pipelineAst when pipelineAst.PipelineElements.Count >= 1:
+                    if (pipelineAst.PipelineElements[0] is CommandExpressionAst cmdExpr &&
+                        cmdExpr.Expression is HashtableAst hashtableFromPipeline)
+                    {
+                        return hashtableFromPipeline;
+                    }
+                    break;
+
+                case CommandExpressionAst commandExpr when commandExpr.Expression is HashtableAst hashtableFromCommand:
+                    return hashtableFromCommand;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// GetError: Retrieves the error message
+        /// </summary>
+        /// <returns>The error message</returns>
+        public string GetError()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingNewObjectError);
+        }
+
+        /// <summary>
+        /// GetName: Retrieves the name of this rule.
+        /// </summary>
+        /// <returns>The name of this rule</returns>
+        public string GetName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.NameSpaceFormat, GetSourceName(), Strings.AvoidUsingNewObjectName);
+        }
+
+        /// <summary>
+        /// GetCommonName: Retrieves the common name of this rule.
+        /// </summary>
+        /// <returns>The common name of this rule</returns>
+        public string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingNewObjectCommonName);
+        }
+
+        /// <summary>
+        /// GetDescription: Retrieves the description of this rule.
+        /// </summary>
+        /// <returns>The description of this rule</returns>
+        public string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.AvoidUsingNewObjectDescription);
+        }
+
+        /// <summary>
+        /// Method: Retrieves the type of the rule: builtin, managed or module.
+        /// </summary>
+        public SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
+        }
+
+        /// <summary>
+        /// GetSeverity:Retrieves the severity of the rule: error, warning of information.
+        /// </summary>
+        /// <returns>The severity of the rule</returns>
+        public RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
+
+        /// <summary>
+        /// DiagnosticSeverity: Retrieves the severity of the rule of type DiagnosticSeverity: error, warning or information.
+        /// </summary>
+        /// <returns>The diagnostic severity of the rule</returns>
+        public DiagnosticSeverity GetDiagnosticSeverity()
+        {
+            return DiagnosticSeverity.Warning;
+        }
+
+        /// <summary>
+        /// Method: Retrieves the module/assembly name the rule is from.
+        /// </summary>
+        public string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+    }
+}

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -135,6 +135,12 @@
   <data name="AvoidUsingInvokeExpressionRuleCommonName" xml:space="preserve">
     <value>Avoid Using Invoke-Expression</value>
   </data>
+  <data name="AvoidUsingNewObjectDescription" xml:space="preserve">
+    <value>For creating .NET objects, prefer using type literals (e.g., [Some.Type]::new()) over the New-Object cmdlet. Type literals offer better performance, compile-time validation, and clearer intent, especially for well-known types.</value>
+  </data>
+  <data name="AvoidUsingNewObjectCommonName" xml:space="preserve">
+    <value>Avoid Using New-Object</value>
+  </data>
   <data name="AvoidUsingPositionalParametersDescription" xml:space="preserve">
     <value>Readability and clarity should be the goal of any script we expect to maintain over time. When calling a command that takes parameters, where possible consider using name parameters as opposed to positional parameters. To fix a violation of this rule, please use named parameters instead of positional parameters when calling a command.</value>
   </data>
@@ -381,6 +387,9 @@
   <data name="AvoidUsingInvokeExpressionRuleName" xml:space="preserve">
     <value>AvoidUsingInvokeExpression</value>
   </data>
+  <data name="AvoidUsingNewObjectName" xml:space="preserve">
+    <value>AvoidUsingNewObject</value>
+  </data>
   <data name="AvoidUsingPlainTextForPasswordName" xml:space="preserve">
     <value>AvoidUsingPlainTextForPassword</value>
   </data>
@@ -518,6 +527,9 @@
   </data>
   <data name="AvoidUsingInvokeExpressionError" xml:space="preserve">
     <value>Invoke-Expression is used. Please remove Invoke-Expression from script and find other options instead.</value>
+  </data>
+  <data name="AvoidUsingNewObjectError" xml:space="preserve">
+    <value>Consider replacing the 'New-Object' cmdlet with type literals (e.g., '[System.Object]::new()') for creating .NET objects. This approach is generally more performant and idiomatic.</value>
   </data>
   <data name="AvoidUsingPositionalParametersError" xml:space="preserve">
     <value>Cmdlet '{0}' has positional parameter. Please use named parameters instead of positional parameters when calling a command.</value>

--- a/Tests/Rules/AvoidUsingNewObject.ps1
+++ b/Tests/Rules/AvoidUsingNewObject.ps1
@@ -1,0 +1,90 @@
+$hashset1 = New-Object System.Collections.Generic.HashSet[String] # Issue #1
+
+[Hashtable] $param = @{
+    TypeName = 'System.Collections.Generic.HashSet[String]'
+}
+
+New-Object @param # Issue #2
+
+function Test
+{
+    $hashset2 = New-Object -TypeName System.Collections.Generic.HashSet[String] # Issue #3
+    New-Object -TypeName System.Collections.Generic.HashSet[String] # Issue #4
+
+    [Hashtable] $param = @{
+        TypeName = 'System.Collections.Generic.HashSet[String]'
+    }
+
+    New-Object @param # Issue #5
+
+    Invoke-Command -ComputerName "localhost" -ScriptBlock {
+        New-Object -TypeName System.Collections.Generic.HashSet[String] # Issue #6
+
+        [Hashtable] $param = @{
+            TypeName = 'System.Collections.Generic.HashSet[String]'
+        }
+
+        New-Object @param # Issue #7
+    }
+
+    function Test2
+    {
+        [Cmdletbinding()]
+        Param ()
+
+        New-Object -TypeName System.Collections.Generic.HashSet[String] # Issue #8
+
+        [Hashtable] $param = @{
+            TypeName = 'System.Collections.Generic.HashSet[String]'
+        }
+
+        New-Object @param # Issue #9
+
+        Invoke-Command -ComputerName "localhost" -ScriptBlock {
+            New-Object -TypeName System.Collections.Generic.HashSet[String] # Issue #10
+        }
+    }
+}
+
+class TestClass
+{
+    [System.Collections.Generic.HashSet[String]] $Set
+    [System.Collections.Generic.HashSet[String]] $Set2 = (New-Object -TypeName System.Collections.Generic.HashSet[String]) # Issue #11
+
+    TestClass ()
+    {
+        $this.Set = (New-Object -TypeName System.Collections.Generic.HashSet[String]) # Issue #12
+
+        Invoke-Command -ComputerName "localhost" -ScriptBlock {
+            New-Object -TypeName System.Collections.Generic.HashSet[String] # Issue #13
+
+        }
+
+        [Hashtable] $param = @{
+            TypeName = 'System.Collections.Generic.HashSet[String]'
+        }
+
+        New-Object @param # Issue #14
+    }
+}
+
+[Hashtable] $script:params = @{
+    TypeName = 'System.Collections.Generic.HashSet[String]'
+}
+
+function Test-Scope
+{
+    New-Object @script:params # Issue #15
+
+    $params2 = $script:params
+    New-Object @params2 # Issue #16
+
+    [Hashtable] $params3 = @{
+        TypeName = 'System.Collections.Generic.HashSet[String]'
+    }
+
+    Invoke-Command -ComputerName "localhost" -ScriptBlock {
+        New-Object @using:params3 # Issue #17
+    }
+}
+

--- a/Tests/Rules/AvoidUsingNewObject.ps1
+++ b/Tests/Rules/AvoidUsingNewObject.ps1
@@ -88,3 +88,20 @@ function Test-Scope
     }
 }
 
+$scripbBlockTest = {
+    New-Object -TypeName System.Collections.Generic.HashSet[String] # Issue #18
+
+    [Hashtable] $params4 = @{
+        TypeName = 'System.Collections.Generic.HashSet[String]'
+    }
+
+    New-Object @params4 # Issue #19
+}
+
+$test = "co"
+$value = "WScript.Shell"
+[hashtable] $test1 = @{
+    "$test" = $value
+}
+
+New-Object @test1 # Issue #20

--- a/Tests/Rules/AvoidUsingNewObject.tests.ps1
+++ b/Tests/Rules/AvoidUsingNewObject.tests.ps1
@@ -10,8 +10,8 @@ BeforeAll {
 
 Describe "AvoidUsingNewObject" {
     Context "When there are violations" {
-        It "has 17 New-Object violations" {
-            $violations.Count | Should -Be 17
+        It "has 20 New-Object violations" {
+            $violations.Count | Should -Be 20
         }
 
         It "has the correct description message for New-Object" {

--- a/Tests/Rules/AvoidUsingNewObject.tests.ps1
+++ b/Tests/Rules/AvoidUsingNewObject.tests.ps1
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+BeforeAll {
+    $NewObjectMessage = "Consider replacing the 'New-Object' cmdlet with type literals"
+    $NewObjectName = "PSAvoidUsingNewObject"
+    $violations = Invoke-ScriptAnalyzer "$PSScriptRoot\AvoidUsingNewObject.ps1" | Where-Object { $_.RuleName -eq $NewObjectName }
+    $noViolations = Invoke-ScriptAnalyzer "$PSScriptRoot\AvoidUsingNewObjectNoViolations.ps1" | Where-Object { $_.RuleName -eq $NewObjectName }
+}
+
+Describe "AvoidUsingNewObject" {
+    Context "When there are violations" {
+        It "has 17 New-Object violations" {
+            $violations.Count | Should -Be 17
+        }
+
+        It "has the correct description message for New-Object" {
+            $violations[0].Message | Should -Match $NewObjectMessage
+        }
+    }
+
+    Context "When there are no violations" {
+        It "has 0 violations" {
+            $noViolations.Count | Should -Be 0
+        }
+    }
+}

--- a/Tests/Rules/AvoidUsingNewObjectNoViolations.ps1
+++ b/Tests/Rules/AvoidUsingNewObjectNoViolations.ps1
@@ -1,0 +1,86 @@
+New-Object -ComObject "WScript.Shell"
+
+[Hashtable] $param = @{
+    ComObject = "WScript.Shell"
+}
+
+New-Object @param
+
+function Test
+{
+    New-Object -ComObject "WScript.Shell"
+
+    [Hashtable] $param = @{
+        ComObject = "WScript.Shell"
+    }
+
+    New-Object @param
+
+    Invoke-Command -ComputerName "localhost" -ScriptBlock {
+        New-Object -ComObject "WScript.Shell"
+
+        [Hashtable] $param = @{
+            ComObject = "WScript.Shell"
+        }
+
+        New-Object @param
+    }
+
+    function Test2
+    {
+        [Cmdletbinding()]
+        Param ()
+
+        New-Object -ComObject "WScript.Shell"
+
+        [Hashtable] $param = @{
+            ComObject = "WScript.Shell"
+        }
+
+        New-Object @param
+
+        Invoke-Command -ComputerName "localhost" -ScriptBlock {
+            New-Object -ComObject "WScript.Shell"
+        }
+    }
+}
+
+class TestClass
+{
+    TestClass ()
+    {
+        New-Object -ComObject "WScript.Shell"
+
+        Invoke-Command -ComputerName "localhost" -ScriptBlock {
+            New-Object -ComObject "WScript.Shell"
+
+        }
+
+        [Hashtable] $param = @{
+            ComObject = "WScript.Shell"
+        }
+
+        New-Object @param
+    }
+}
+
+[Hashtable] $script:params = @{
+    ComObject = "WScript.Shell"
+}
+
+function Test-Scope
+{
+    New-Object @script:params
+
+    $params2 = $script:params
+    New-Object @params2
+
+    [Hashtable] $params3 = @{
+        ComObject = "WScript.Shell"
+    }
+
+    Invoke-Command -ComputerName "localhost" -ScriptBlock {
+        New-Object @using:params3
+    }
+}
+

--- a/Tests/Rules/AvoidUsingNewObjectNoViolations.ps1
+++ b/Tests/Rules/AvoidUsingNewObjectNoViolations.ps1
@@ -8,10 +8,11 @@ New-Object @param
 
 function Test
 {
-    New-Object -ComObject "WScript.Shell"
+    $partialParameter = "CO"
+    New-Object -"$partialParameter" "WScript.Shell"
 
     [Hashtable] $param = @{
-        ComObject = "WScript.Shell"
+        ComO = "WScript.Shell"
     }
 
     New-Object @param
@@ -20,7 +21,7 @@ function Test
         New-Object -ComObject "WScript.Shell"
 
         [Hashtable] $param = @{
-            ComObject = "WScript.Shell"
+            CO = "WScript.Shell"
         }
 
         New-Object @param
@@ -34,7 +35,7 @@ function Test
         New-Object -ComObject "WScript.Shell"
 
         [Hashtable] $param = @{
-            ComObject = "WScript.Shell"
+            C = "WScript.Shell"
         }
 
         New-Object @param
@@ -84,3 +85,20 @@ function Test-Scope
     }
 }
 
+$scripbBlockTest = {
+    New-Object -ComObject "WScript.Shell"
+
+    [Hashtable] $params4 = @{
+        ComObject = 'WScript.Shell'
+    }
+
+    New-Object @params4
+}
+
+$partialKey = "COMO"
+$value = "WScript.Shell"
+[hashtable] $partialKeyParams = @{
+    "$partialKey" = $value
+}
+
+New-Object @partialKeyParams

--- a/docs/Rules/AvoidUsingNewObject.md
+++ b/docs/Rules/AvoidUsingNewObject.md
@@ -1,0 +1,256 @@
+---
+description: Avoid Using New-Object
+ms.date: 06/14/2025
+ms.topic: reference
+title: AvoidUsingNewObject
+---
+# AvoidUsingNewObject
+
+**Severity Level: Warning**
+
+## Description
+
+The `New-Object` cmdlet should be avoided in modern PowerShell code except when creating COM objects. PowerShell provides more efficient, readable, and idiomatic alternatives for object creation that offer better performance and cleaner syntax.
+
+This rule flags all uses of `New-Object` ***except*** when used with the `-ComObject` parameter, as COM object creation is one of the few legitimate remaining use cases for this cmdlet.
+
+## Why Avoid New-Object?
+
+### Performance Issues
+`New-Object` uses reflection internally, which is significantly slower than direct type instantiation or accelerated type syntax. The performance difference becomes more pronounced in loops or frequently executed code.
+
+### Readability and Maintainability
+Modern PowerShell syntax is more concise and easier to read than `New-Object` constructions, especially for common .NET types.
+
+### PowerShell Best Practices
+The PowerShell community and Microsoft recommend using native PowerShell syntax over legacy cmdlets when better alternatives exist.
+
+## Examples
+
+### Wrong
+
+```powershell
+# Creating .NET objects
+$list = New-Object System.Collections.Generic.List[string]
+$hashtable = New-Object System.Collections.Hashtable
+$stringBuilder = New-Object System.Text.StringBuilder
+$datetime = New-Object System.DateTime(2023, 12, 25)
+
+# Creating custom objects
+$obj = New-Object PSObject -Property @{
+    Name = "John"
+    Age = 30
+}
+```
+
+### Correct
+
+```powershell
+# Use accelerated type syntax for .NET objects
+$list = [System.Collections.Generic.List[string]]::new()
+$hashtable = @{}  # or [hashtable]@{}
+$stringBuilder = [System.Text.StringBuilder]::new()
+$datetime = [DateTime]::new(2023, 12, 25)
+
+# Use PSCustomObject for custom objects
+$obj = [PSCustomObject]@{
+    Name = "John"
+    Age = 30
+}
+
+# COM objects are still acceptable with New-Object
+$excel = New-Object -ComObject Excel.Application
+$word = New-Object -ComObject Word.Application
+```
+
+## Alternative Approaches
+
+### For .NET Types
+- **Static `new()` method**: `[TypeName]::new(parameters)`
+- **Type accelerators**: Use built-in shortcuts like `@{}` for hashtables
+- **Cast operators**: `[TypeName]$value` for type conversion
+
+### For Custom Objects
+- **PSCustomObject**: `[PSCustomObject]@{ Property = Value }`
+- **Ordered dictionaries**: `[ordered]@{ Property = Value }`
+
+### For Collections
+- **Array subexpression**: `@(items)`
+- **Hashtable literal**: `@{ Key = Value }`
+- **Generic collections**: `[System.Collections.Generic.List[Type]]::new()`
+
+## Performance Comparison
+
+```powershell
+# Slow - uses reflection
+Measure-Command { 1..1000 | ForEach-Object { New-Object System.Text.StringBuilder } }
+
+# Fast - direct instantiation
+Measure-Command { 1..1000 | ForEach-Object { [System.Text.StringBuilder]::new() } }
+```
+
+The modern syntax provides a performance improvement over `New-Object` for most common scenarios.
+
+## Exceptions
+
+The rule allows `New-Object` when used with the `-ComObject` parameter because:
+- COM object creation requires the `New-Object` cmdlet.
+- No direct PowerShell alternative exists for COM instantiation.
+- COM objects are external to the .NET type system.
+
+```powershell
+# This is acceptable
+$shell = New-Object -ComObject WScript.Shell
+$ie = New-Object -ComObject InternetExplorer.Application
+```
+
+---
+
+## Migration Guide
+
+| Old Syntax | New Syntax |
+|------------|------------|
+| **Creating a custom object**: <br> `New-Object PSObject -Property @{ Name = 'John'; Age = 30 }` | **Use PSCustomObject**: <br> `[PSCustomObject]@{ Name = 'John'; Age = 30 }` |
+| **Creating a hashtable**: <br> `New-Object System.Collections.Hashtable` | **Use hashtable literal**: <br> `@{}` <br> **Or explicitly cast**: <br> `[hashtable]@{}` |
+| **Creating a generic list**: <br> `New-Object 'System.Collections.Generic.List[string]'` | **Use static `new()` method**: <br> `[System.Collections.Generic.List[string]]::new()` |
+| **Creating a DateTime object**: <br> `New-Object DateTime -ArgumentList 2023, 12, 25` | **Use static `new()` method**: <br> `[DateTime]::new(2023, 12, 25)` |
+| **Creating a StringBuilder**: <br> `New-Object System.Text.StringBuilder` | **Use static `new()` method**: <br> `[System.Text.StringBuilder]::new()` |
+| **Creating a process object**: <br> `New-Object System.Diagnostics.Process` | **Use static `new()` method**: <br> `[System.Diagnostics.Process]::new()` |
+| **Creating a custom .NET object**: <br> `New-Object -TypeName 'Namespace.TypeName' -ArgumentList $args` | **Use static `new()` method**: <br> `[Namespace.TypeName]::new($args)` |
+
+---
+
+### Detailed Examples
+
+#### Custom Object Creation
+
+**Old Syntax:**
+
+```powershell
+$obj = New-Object PSObject -Property @{
+    Name = 'John'
+    Age = 30
+}
+```
+
+**New Syntax:**
+
+```powershell
+$obj = [PSCustomObject]@{
+    Name = 'John'
+    Age = 30
+}
+```
+
+#### Hashtable Creation
+
+**Old Syntax:**
+
+```powershell
+$hashtable = New-Object System.Collections.Hashtable
+$hashtable.Add('Key', 'Value')
+```
+
+**New Syntax:**
+
+```powershell
+$hashtable = @{
+    Key = 'Value'
+}
+```
+
+Or explicitly cast:
+
+```powershell
+$hashtable = [hashtable]@{
+    Key = 'Value'
+}
+```
+
+#### Generic List Creation
+
+**Old Syntax:**
+
+```powershell
+$list = New-Object 'System.Collections.Generic.List[string]'
+$list.Add('Item1')
+$list.Add('Item2')
+```
+
+**New Syntax:**
+
+```powershell
+$list = [System.Collections.Generic.List[string]]::new()
+$list.Add('Item1')
+$list.Add('Item2')
+```
+
+#### DateTime Object Creation
+
+**Old Syntax:**
+
+```powershell
+$date = New-Object DateTime -ArgumentList 2023, 12, 25
+```
+
+**New Syntax:**
+
+```powershell
+$date = [DateTime]::new(2023, 12, 25)
+```
+
+#### StringBuilder Creation
+
+**Old Syntax:**
+
+```powershell
+$stringBuilder = New-Object System.Text.StringBuilder
+$stringBuilder.Append('Hello')
+```
+
+**New Syntax:**
+
+```powershell
+$stringBuilder = [System.Text.StringBuilder]::new()
+$stringBuilder.Append('Hello')
+```
+
+#### Custom .NET Object Creation
+
+**Old Syntax:**
+
+```powershell
+$customObject = New-Object -TypeName 'Namespace.TypeName' -ArgumentList $arg1, $arg2
+```
+
+**New Syntax:**
+
+```powershell
+$customObject = [Namespace.TypeName]::new($arg1, $arg2)
+```
+
+#### Process Object Creation
+
+**Old Syntax:**
+
+```powershell
+$process = New-Object System.Diagnostics.Process
+```
+
+**New Syntax:**
+
+```powershell
+$process = [System.Diagnostics.Process]::new()
+```
+
+---
+## Related Links
+
+- [New-Object][01]
+- [PowerShell scripting performance considerations][02]
+- [Creating .NET and COM objects][03]
+
+<!-- link references -->
+[01]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/new-object
+[02]: https://learn.microsoft.com/en-us/powershell/scripting/dev-cross-plat/performance/script-authoring-considerations
+[03]: https://learn.microsoft.com/en-us/powershell/scripting/samples/creating-.net-and-com-objects--new-object-


### PR DESCRIPTION
## PR Summary

#2046 

Adds a new built-in rule `PSAvoidUsingNewObject` that flags usage of the `New-Object` cmdlet and recommends using type literals with `::new()` syntax instead for better performance and more idiomatic PowerShell code.

**What Changed**
- **New Rule**: `AvoidUsingNewObject`
- **Severity**: Warning
- **Scope**: Flags `New-Object -TypeName` usage while preserving `New-Object -ComObject` (COM objects cannot use type literals)

**Key Features**
- **Smart COM Object Detection**: Excludes `New-Object -ComObject` calls since they cannot be replaced with type literals
- **Parameter Splatting Support**: Handles complex scenarios where parameters are passed via hashtable splatting (`New-Object @params`)
- **Variable Chain Resolution**: Recursively follows variable assignments to determine if splatted parameters contain COM object references
- **Comprehensive AST Analysis**: Supports both direct parameter usage and various splatting patterns including `$using:` variables

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.