### PR TITLE
WIP: Fix: PSUseConsistentWhitespace formatting for do-while, unary operators, and native commands

### DIFF
--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -556,7 +556,28 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     IScriptExtent leftExtent = commandParameterAstElements[i].Extent;
                     IScriptExtent rightExtent = commandParameterAstElements[i + 1].Extent;
+
+                    // Skip if elements are on different lines
                     if (leftExtent.EndLineNumber != rightExtent.StartLineNumber)
+                    {
+                        continue;
+                    }
+
+                    // # 1561 - Skip if the whitespace is inside a string literal
+                    // Check if any string in the command contains this whitespace region
+                    var stringAsts = commandAst.FindAll(a => a is StringConstantExpressionAst || a is ExpandableStringExpressionAst, true);
+                    bool isInsideString = false;
+                    foreach (var stringAst in stringAsts)
+                    {
+                        if (stringAst.Extent.StartOffset < leftExtent.EndOffset && 
+                            stringAst.Extent.EndOffset > rightExtent.StartOffset)
+                        {
+                            isInsideString = true;
+                            break;
+                        }
+                    }
+                    
+                    if (isInsideString)
                     {
                         continue;
                     }

--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -289,37 +289,36 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 var keyword = keywordNode.Value;
 
-                if (keywordNode.Previous != null)
+                if (keywordNode.Previous == null || keywordNode.Previous.Value.Kind != TokenKind.RCurly)
                 {
-                    if (keywordNode.Previous.Value.Kind == TokenKind.RCurly &&
-                        IsPreviousTokenOnSameLine(keywordNode))
-                    {
-                        var hasWhitespace = IsPreviousTokenApartByWhitespace(keywordNode);
-
-                        if (!hasWhitespace)
-                        {
-                            var corrections = new List<CorrectionExtent>
-                            {
-                                new CorrectionExtent(
-                                    keywordNode.Previous.Value.Extent.EndLineNumber,
-                                    keyword.Extent.StartLineNumber,
-                                    keywordNode.Previous.Value.Extent.EndColumnNumber,
-                                    keyword.Extent.StartColumnNumber,
-                                    whiteSpace,
-                                    keyword.Extent.File)
-                            };
-
-                            yield return new DiagnosticRecord(
-                                GetError(ErrorKind.BeforeOpeningBrace),
-                                keyword.Extent,
-                                GetName(),
-                                GetDiagnosticSeverity(),
-                                tokenOperations.Ast.Extent.File,
-                                null,
-                                corrections);
-                        }
-                    }
+                    continue;
                 }
+
+                if (!IsPreviousTokenOnSameLine(keywordNode) || IsPreviousTokenApartByWhitespace(keywordNode))
+                {
+                    continue;
+                }
+
+                // Whitespace required
+                var corrections = new List<CorrectionExtent>
+                {
+                    new CorrectionExtent(
+                        keywordNode.Previous.Value.Extent.EndLineNumber,
+                        keyword.Extent.StartLineNumber,
+                        keywordNode.Previous.Value.Extent.EndColumnNumber,
+                        keyword.Extent.StartColumnNumber,
+                        whiteSpace,
+                        keyword.Extent.File)
+                };
+
+                yield return new DiagnosticRecord(
+                    GetError(ErrorKind.BeforeOpeningBrace),
+                    keyword.Extent,
+                    GetName(),
+                    GetDiagnosticSeverity(),
+                    tokenOperations.Ast.Extent.File,
+                    null,
+                    corrections);
             }
         }
 

--- a/Tests/Rules/UseConsistentWhitespace.tests.ps1
+++ b/Tests/Rules/UseConsistentWhitespace.tests.ps1
@@ -681,6 +681,27 @@ bar -h i `
             Invoke-Formatter -ScriptDefinition $def -Settings $settings |
                 Should -Be $expected
         }
+
+        # Tests for #1561
+        It "Should not remove whitespace inside string literals" {
+            $def = @'
+        $InputList | ForEach-Object {
+            $_.Name
+        } | Select-Object -First 2 | Join-String -sep ", " -OutputPrefix 'Results: '
+'@
+            $expected = @'
+        $InputList | ForEach-Object {
+            $_.Name
+        } | Select-Object -First 2 | Join-String -sep ", " -OutputPrefix 'Results: '
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -BeExactly $expected
+        }
+
+        It "Should not remove whitespace from string parameters with multiple arguments" {
+            $def = 'Get-Process | Out-String -Stream | Select-String -Pattern "chrome", "firefox" -SimpleMatch'
+            $expected = 'Get-Process | Out-String -Stream | Select-String -Pattern "chrome", "firefox" -SimpleMatch'
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -BeExactly $expected
+        }
     }
 
     Context "When keywords follow closing braces" {


### PR DESCRIPTION
## PR Summary

Fixes multiple whitespace formatting issues in `PSUseConsistentWhitespace` rule

### Issues Fixed:
- **#1561** - CheckParameter removing whitespace inside string literals 
- **#1742** - False positive on hashtable closing brace with CheckInnerBrace
- **#2094** - Incorrect comma formatting in native command arguments (e.g., `docker --secret id=x,env=y`)
- **#2095** - Missing space between `}` and keywords in do-while/do-until loops

### Changes Made:

#### Core Fixes:
- Added `FindKeywordAfterBraceViolations` to handle keywords following closing braces
- Enhanced unary operator detection and spacing logic in `FindOperatorViolations`
- Fixed `FindParameterViolations` to skip whitespace inside string literals
- Added comma pattern detection in `FindSeparatorViolations` for native command arguments
- Added the additional keywords to openParenKeywordAllowList: `Until, Do, Else, Catch, Finally`

### Tests Added:
- Added test-cases for the above-mentioned changes.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [ ] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.