### PR TITLE
Preserve braced member access in `UseConsistentWhitespace`

### DIFF
--- a/Rules/UseConsistentWhitespace.cs
+++ b/Rules/UseConsistentWhitespace.cs
@@ -257,6 +257,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
         private IEnumerable<DiagnosticRecord> FindInnerBraceViolations(TokenOperations tokenOperations)
         {
+            // Ranges which represent braced member access. Tokens within these ranges should be
+            // excluded from formatting.
+            var exclusionRanges = tokenOperations.GetBracedMemberAccessRanges();
             foreach (var lCurly in tokenOperations.GetTokenNodes(TokenKind.LCurly))
             {
                 if (lCurly.Next == null
@@ -264,6 +267,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     || lCurly.Next.Value.Kind == TokenKind.NewLine
                     || lCurly.Next.Value.Kind == TokenKind.LineContinuation
                     || lCurly.Next.Value.Kind == TokenKind.RCurly
+                    || exclusionRanges.Any(range =>
+                        lCurly.Value.Extent.StartOffset >= range.Item1 &&
+                        lCurly.Value.Extent.EndOffset <= range.Item2
+                       )
                     )
                 {
                     continue;
@@ -290,6 +297,10 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     || rCurly.Previous.Value.Kind == TokenKind.NewLine
                     || rCurly.Previous.Value.Kind == TokenKind.LineContinuation
                     || rCurly.Previous.Value.Kind == TokenKind.AtCurly
+                    || exclusionRanges.Any(range =>
+                        rCurly.Value.Extent.StartOffset >= range.Item1 &&
+                        rCurly.Value.Extent.EndOffset <= range.Item2
+                       )
                     )
                 {
                     continue;

--- a/Tests/Engine/TokenOperations.tests.ps1
+++ b/Tests/Engine/TokenOperations.tests.ps1
@@ -18,4 +18,181 @@ $h = @{
         $hashTableAst | Should -BeOfType [System.Management.Automation.Language.HashTableAst]
         $hashTableAst.Extent.Text | Should -Be '@{ z = "hi" }'
     }
+
+    Context 'Braced Member Access Ranges' {
+
+        BeforeDiscovery {
+            $RangeTests = @(
+                @{
+                    Name = 'No braced member access'
+                    ScriptDef = '$object.Prop'
+                    ExpectedRanges = @()
+                }
+                @{
+                    Name = 'No braced member access on braced variable name'
+                    ScriptDef = '${object}.Prop'
+                    ExpectedRanges = @()
+                }
+                @{
+                    Name = 'Braced member access'
+                    ScriptDef = '$object.{Prop}'
+                    ExpectedRanges = @(
+                        ,@(8, 14)
+                    )
+                }
+                @{
+                    Name = 'Braced member access with spaces'
+                    ScriptDef = '$object. { Prop }'
+                    ExpectedRanges = @(
+                        ,@(9, 17)
+                    )
+                }
+                @{
+                    Name = 'Braced member access with newline'
+                    ScriptDef = "`$object.`n{ Prop }"
+                    ExpectedRanges = @(
+                        ,@(9, 17)
+                    )
+                }
+                @{
+                    Name = 'Braced member access with comment'
+                    ScriptDef = "`$object. <#comment#>{Prop}"
+                    ExpectedRanges = @(
+                        ,@(20, 26)
+                    )
+                }
+                @{
+                    Name = 'Braced member access with multi-line comment'
+                    ScriptDef = "`$object. <#`ncomment`n#>{Prop}"
+                    ExpectedRanges = @(
+                        ,@(22, 28)
+                    )
+                }
+                @{
+                    Name = 'Braced member access with inline comment'
+                    ScriptDef = "`$object. #comment`n{Prop}"
+                    ExpectedRanges = @(
+                        ,@(18, 24)
+                    )
+                }
+                @{
+                    Name = 'Braced member access with inner curly braces'
+                    ScriptDef = "`$object.{{Prop}}"
+                    ExpectedRanges = @(
+                        ,@(8, 16)
+                    )
+                }
+                @{
+                    Name = 'Indexed Braced member access'
+                    ScriptDef = "`$object[0].{Prop}"
+                    ExpectedRanges = @(
+                        ,@(11, 17)
+                    )
+                }
+                @{
+                    Name = 'Parenthesized Braced member access'
+                    ScriptDef = "(`$object).{Prop}"
+                    ExpectedRanges = @(
+                        ,@(10, 16)
+                    )
+                }
+                @{
+                    Name = 'Chained Braced member access'
+                    ScriptDef = "`$object.{Prop}.{InnerProp}"
+                    ExpectedRanges = @(
+                        ,@(8, 14)
+                        ,@(15, 26)
+                    )
+                }
+                @{
+                    Name = 'Multiple Braced member access in larger script'
+                    ScriptDef = @'
+$var = 1
+$a.prop.{{inner}}
+$a.{
+    $a.{Prop}
+}
+'@
+                    ExpectedRanges = @(
+                        ,@(17, 26)
+                        ,@(30, 47)
+                    )
+                }
+            )
+        }
+
+        It 'Should correctly identify range for <Name>' -ForEach $RangeTests {
+            $tokens = $null
+            $parseErrors = $null
+            $scriptAst = [System.Management.Automation.Language.Parser]::ParseInput($ScriptDef, [ref] $tokens, [ref] $parseErrors)
+            $tokenOperations = [Microsoft.Windows.PowerShell.ScriptAnalyzer.TokenOperations]::new($tokens, $scriptAst)
+            $ranges = $tokenOperations.GetBracedMemberAccessRanges()
+            $ranges.Count | Should -Be $ExpectedRanges.Count
+            for ($i = 0; $i -lt $ranges.Count; $i++) {
+                $ranges[$i].Item1 | Should -Be $ExpectedRanges[$i][0]
+                $ranges[$i].Item2 | Should -Be $ExpectedRanges[$i][1]
+            }
+        }
+
+        It 'Should not identify dot-sourcing as braced member access' {
+            $scriptText = @'
+. {5+5}
+$a=4;. {10+15}
+'@
+            $tokens = $null
+            $parseErrors = $null
+            $scriptAst = [System.Management.Automation.Language.Parser]::ParseInput($scriptText, [ref] $tokens, [ref] $parseErrors)
+            $tokenOperations = [Microsoft.Windows.PowerShell.ScriptAnalyzer.TokenOperations]::new($tokens, $scriptAst)
+            $ranges = $tokenOperations.GetBracedMemberAccessRanges()
+            $ranges.Count | Should -Be 0
+        }
+
+        It 'Should not return a range for an incomplete bracket pair (parse error)' {
+            $scriptText = @'
+$object.{MemberName
+'@
+            $tokens = $null
+            $parseErrors = $null
+            $scriptAst = [System.Management.Automation.Language.Parser]::ParseInput($scriptText, [ref] $tokens, [ref] $parseErrors)
+            $tokenOperations = [Microsoft.Windows.PowerShell.ScriptAnalyzer.TokenOperations]::new($tokens, $scriptAst)
+            $ranges = $tokenOperations.GetBracedMemberAccessRanges()
+            $ranges.Count | Should -Be 0
+        }
+
+        It 'Should find the correct range for null-conditional braced member access' {
+            $scriptText = '$object?.{Prop}'
+            $tokens = $null
+            $parseErrors = $null
+            $scriptAst = [System.Management.Automation.Language.Parser]::ParseInput($scriptText, [ref] $tokens, [ref] $parseErrors)
+            $tokenOperations = [Microsoft.Windows.PowerShell.ScriptAnalyzer.TokenOperations]::new($tokens, $scriptAst)
+            $ranges = $tokenOperations.GetBracedMemberAccessRanges()
+            $ranges.Count | Should -Be 1
+            $ExpectedRanges = @(
+                ,@(9, 15)
+            )
+            for ($i = 0; $i -lt $ranges.Count; $i++) {
+                $ranges[$i].Item1 | Should -Be $ExpectedRanges[$i][0]
+                $ranges[$i].Item2 | Should -Be $ExpectedRanges[$i][1]
+            }
+        } -Skip:$($PSVersionTable.PSVersion.Major -lt 7)
+
+        It 'Should find the correct range for nested null-conditional braced member access' {
+            $scriptText = '$object?.{Prop?.{InnerProp}}'
+            $tokens = $null
+            $parseErrors = $null
+            $scriptAst = [System.Management.Automation.Language.Parser]::ParseInput($scriptText, [ref] $tokens, [ref] $parseErrors)
+            $tokenOperations = [Microsoft.Windows.PowerShell.ScriptAnalyzer.TokenOperations]::new($tokens, $scriptAst)
+            $ranges = $tokenOperations.GetBracedMemberAccessRanges()
+            $ranges.Count | Should -Be 1
+            $ExpectedRanges = @(
+                ,@(9, 28)
+            )
+            for ($i = 0; $i -lt $ranges.Count; $i++) {
+                $ranges[$i].Item1 | Should -Be $ExpectedRanges[$i][0]
+                $ranges[$i].Item2 | Should -Be $ExpectedRanges[$i][1]
+            }
+        } -Skip:$($PSVersionTable.PSVersion.Major -lt 7)
+
+    }
+
 }


### PR DESCRIPTION
## PR Summary

`UseConsistentWhitespace`'s `CheckInnerBrace` breaks braced member access (`$a.{Prop}`) by inserting whitespace after the opening and before the closing curly brace (`$a.{ Prop }`). The inner content of the braces must match the referenced property name exactly. No formatting of the inner content should occur.

Unlike the variable curly-brace format, `${a}`, which is tokenised as a variable, no special tokenisation happens for this bracing.

> Disclaimer: I don't know the correct names for things

PR introduces a new function, `GetBracedMemberAccessRanges()`, in `TokenOperations.cs`, which walks the token list looking for the shape of a braced member access:

- One of these tokens:
    - TokenKind.Variable
    - TokenKind.Identifier
    - TokenKind.StringLiteral
    - TokenKind.StringExpandable
    - TokenKind.HereStringLiteral
    - TokenKind.HereStringExpandable
    - TokenKind.RParen
    - TokenKind.RCurly
    - TokenKind.RBracket
- Optional inline comments(but no whitespace, new lines, line continuations)
- Dot (or QuestionDot on PS7+) Token.
- Optional inline comments, whitespace, new lines, line continuations
- Left Curly Brace
- Inner content
- Matched Right Curly Brace

The function returns a list of int pairs which represent a range from the startoffset of a LCurly to the endoffset of a RCurly. Formatting within these ranges could break braced member access.

In `UseConsistentWhitespace` when checking for inner brace violations in `FindInnerBraceViolations()`, call the function to get the ranges to exclude. Skip whitespace checking for braces within any range (inclusive).

Fixes #2066

*When asking copilot to look this over, it told me I could instead have used the AST, looking for `MemberExpressionAst` who's `Member` started with a `{` and ended with a `}`. I could then infer the offsets of the braces. I could explore that if it's a more desirable/correct solution.*

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.