### PR TITLE
Add new code formatting preset "OTPS": OTBS with `else` on new line

### DIFF
--- a/Engine/Settings/CodeFormattingOTPS.psd1
+++ b/Engine/Settings/CodeFormattingOTPS.psd1
@@ -1,0 +1,55 @@
+@{
+    IncludeRules = @(
+        'PSPlaceOpenBrace',
+        'PSPlaceCloseBrace',
+        'PSUseConsistentWhitespace',
+        'PSUseConsistentIndentation',
+        'PSAlignAssignmentStatement',
+        'PSUseCorrectCasing'
+    )
+
+    Rules        = @{
+        PSPlaceOpenBrace           = @{
+            Enable             = $true
+            OnSameLine         = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+        }
+
+        PSPlaceCloseBrace          = @{
+            Enable             = $true
+            NewLineAfter       = $true
+            IgnoreOneLineBlock = $true
+            NoEmptyLineBefore  = $false
+        }
+
+        PSUseConsistentIndentation = @{
+            Enable              = $true
+            Kind                = 'space'
+            PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+            IndentationSize     = 4
+        }
+
+        PSUseConsistentWhitespace  = @{
+            Enable                          = $true
+            CheckInnerBrace                 = $true
+            CheckOpenBrace                  = $true
+            CheckOpenParen                  = $true
+            CheckOperator                   = $true
+            CheckPipe                       = $true
+            CheckPipeForRedundantWhitespace = $false
+            CheckSeparator                  = $true
+            CheckParameter                  = $false
+            IgnoreAssignmentOperatorInsideHashTable = $true
+        }
+
+        PSAlignAssignmentStatement = @{
+            Enable         = $true
+            CheckHashtable = $true
+        }
+
+        PSUseCorrectCasing     = @{
+            Enable             = $true
+        }
+    }
+}

--- a/Tests/Rules/CodeFormattingPresets.tests.ps1
+++ b/Tests/Rules/CodeFormattingPresets.tests.ps1
@@ -84,10 +84,10 @@ function Test-Code
 {
     [CmdletBinding()]
     param(
-        [int]$ParameterOne
+        [int] $ParameterOne
     )
     end {
-        if(10 -gt $ParameterOne) {
+        if (10 -gt $ParameterOne) {
             "Greater"
         }
         else {

--- a/Tests/Rules/CodeFormattingPresets.tests.ps1
+++ b/Tests/Rules/CodeFormattingPresets.tests.ps1
@@ -1,0 +1,149 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+BeforeAll {
+    $testRootDirectory = Split-Path -Parent $PSScriptRoot
+    Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
+
+    $Allman = @'
+enum Color
+{
+    Black,
+    White
+}
+
+function Test-Code
+{
+    [CmdletBinding()]
+    param
+    (
+        [int] $ParameterOne
+    )
+    end
+    {
+        if (10 -gt $ParameterOne)
+        {
+            "Greater"
+        }
+        else
+        {
+            "Lesser"
+        }
+    }
+}
+'@
+
+    $OTBS = @'
+enum Color {
+    Black,
+    White
+}
+
+function Test-Code {
+    [CmdletBinding()]
+    param(
+        [int] $ParameterOne
+    )
+    end {
+        if (10 -gt $ParameterOne) {
+            "Greater"
+        } else {
+            "Lesser"
+        }
+    }
+}
+'@
+    $OTPS = @'
+enum Color {
+    Black,
+    White
+}
+
+function Test-Code {
+    [CmdletBinding()]
+    param(
+        [int] $ParameterOne
+    )
+    end {
+        if (10 -gt $ParameterOne) {
+            "Greater"
+        }
+        else {
+            "Lesser"
+        }
+    }
+}
+'@
+    $Stroustrup = @'
+enum Color {
+    Black,
+    White
+}
+
+function Test-Code
+{
+    [CmdletBinding()]
+    param(
+        [int]$ParameterOne
+    )
+    end {
+        if(10 -gt $ParameterOne) {
+            "Greater"
+        }
+        else {
+            "Lesser"
+        }
+    }
+}
+'@
+}
+
+Describe "CodeFormattingPresets" {
+    Context "Allman" {
+        It "To Allman from OTBS" {
+            Invoke-Formatter -ScriptDefinition $OTBS -Settings 'CodeFormattingAllman' | Should -Be $Allman
+        }
+        It "To Allman from OTPS" {
+            Invoke-Formatter -ScriptDefinition $OTPS -Settings 'CodeFormattingAllman' | Should -Be $Allman
+        }
+        It "To Allman from Stroustrup" {
+            Invoke-Formatter -ScriptDefinition $Stroustrup -Settings 'CodeFormattingAllman' | Should -Be $Allman
+        }
+    }
+
+    Context "OTBS" {
+        It "To OTBS from Allman" {
+            Invoke-Formatter -ScriptDefinition $Allman -Settings 'CodeFormattingOTBS' | Should -Be $OTBS
+        }
+        It "To OTBS from OTPS" {
+            Invoke-Formatter -ScriptDefinition $OTPS -Settings 'CodeFormattingOTBS' | Should -Be $OTBS
+        }
+        It "To OTBS from Stroustrup" {
+            Invoke-Formatter -ScriptDefinition $Stroustrup -Settings 'CodeFormattingOTBS' | Should -Be $OTBS
+        }
+    }
+
+    Context "OTPS" {
+        It "To OTPS from Allman" {
+            Invoke-Formatter -ScriptDefinition $Allman -Settings 'CodeFormattingOTPS' | Should -Be $OTPS
+        }
+        It "To OTPS from OTBS" {
+            Invoke-Formatter -ScriptDefinition $OTBS -Settings 'CodeFormattingOTPS' | Should -Be $OTPS
+        }
+        It "To OTPS from Stroustrup" {
+            Invoke-Formatter -ScriptDefinition $Stroustrup -Settings 'CodeFormattingOTPS' | Should -Be $OTPS
+        }
+    }
+
+    Context "Stroustrup" {
+        It "To Stroustrup from Allman" {
+            Invoke-Formatter -ScriptDefinition $Allman -Settings 'CodeFormattingStroustrup' | Should -Be $Stroustrup
+        }
+        It "To Stroustrup from OTBS" {
+            Invoke-Formatter -ScriptDefinition $OTBS -Settings 'CodeFormattingStroustrup' | Should -Be $Stroustrup
+        }
+        It "To Stroustrup from OTPS" {
+            Invoke-Formatter -ScriptDefinition $OTPS -Settings 'CodeFormattingStroustrup' | Should -Be $Stroustrup
+        }
+    }
+}

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -383,4 +383,54 @@ if ($true) {
             $violations.Count | Should -Be 0
         }
     }
+
+    Context "When formatting presets handles if else" {
+        BeforeAll {
+            $AllmanDefinition = @"
+if (`$true)
+{
+    'yes'
+}
+else
+{
+    'no'
+}
+"@
+            $OTBSDefinition = @"
+if (`$true) {
+    'yes'
+} else {
+    'no'
+}
+"@
+            $OTPSAndStroustrupDefinition = @"
+if (`$true) {
+    "yes"
+}
+else {
+    "no"
+}
+"@
+        }
+
+        It "Allman should have all opening and closing braces on a new line" {
+            Invoke-Formatter -ScriptDefinition $OTBSDefinition -Settings 'CodeFormattingAllman' | Should -Be $AllmanDefinition
+            Invoke-Formatter -ScriptDefinition $OTPSAndStroustrupDefinition -Settings 'CodeFormattingAllman' | Should -Be $AllmanDefinition
+        }
+
+        It "OTBS should place else on same line as the if closing bracket" {
+            Invoke-Formatter -ScriptDefinition $AllmanDefinition -Settings 'CodeFormattingOTBS' | Should -Be $OTBSDefinition
+            Invoke-Formatter -ScriptDefinition $OTPSAndStroustrupDefinition -Settings 'CodeFormattingOTBS' | Should -Be $OTBSDefinition
+        }
+
+        It "OTPS should place else on a new line after the if closing bracket" {
+            Invoke-Formatter -ScriptDefinition $AllmanDefinition -Settings 'CodeFormattingOTPS' | Should -Be $OTPSAndStroustrupDefinition
+            Invoke-Formatter -ScriptDefinition $OTBSDefinition -Settings 'CodeFormattingOTPS' | Should -Be $OTPSAndStroustrupDefinition
+        }
+
+        It "Stroustrup should place else on a new line after the if closing bracket" {
+            Invoke-Formatter -ScriptDefinition $AllmanDefinition -Settings 'CodeFormattingStroustrup' | Should -Be $OTPSAndStroustrupDefinition
+            Invoke-Formatter -ScriptDefinition $OTBSDefinition -Settings 'CodeFormattingStroustrup' | Should -Be $OTPSAndStroustrupDefinition
+        }
+    }
 }

--- a/Tests/Rules/PlaceCloseBrace.tests.ps1
+++ b/Tests/Rules/PlaceCloseBrace.tests.ps1
@@ -405,10 +405,10 @@ if (`$true) {
 "@
             $OTPSAndStroustrupDefinition = @"
 if (`$true) {
-    "yes"
+    'yes'
 }
 else {
-    "no"
+    'no'
 }
 "@
         }

--- a/Tests/Rules/PlaceOpenBrace.tests.ps1
+++ b/Tests/Rules/PlaceOpenBrace.tests.ps1
@@ -56,6 +56,7 @@ foreach ($x in $y) {
             Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be $expected
             Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings 'CodeFormattingStroustrup' | Should -Be $expected
             Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings 'CodeFormattingOTBS' | Should -Be $expected
+            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings 'CodeFormattingOTPS' | Should -Be $expected
         }
 
         It "Should correct violation when brace should be on the same line and take comment into account" {
@@ -73,6 +74,7 @@ foreach ($x in $y) { # useful comment
             Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be $expected
             Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings 'CodeFormattingStroustrup' | Should -Be $expected
             Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings 'CodeFormattingOTBS' | Should -Be $expected
+            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings 'CodeFormattingOTPS' | Should -Be $expected
         }
 
         It "Should correct violation when the brace should be on the next line and take comment into account" {
@@ -90,6 +92,7 @@ foreach ($x in $y) { # useful comment
             Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings $settings | Should -Be $expected
             Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings 'CodeFormattingStroustrup' | Should -Be $expected
             Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings 'CodeFormattingOTBS' | Should -Be $expected
+            Invoke-Formatter -ScriptDefinition $scriptDefinition -Settings 'CodeFormattingOTPS' | Should -Be $expected
         }
     }
 


### PR DESCRIPTION
Edit: Blocked, see <https://github.com/PowerShell/PSScriptAnalyzer/issues/2045#issuecomment-4016377821>.

## PR Summary

* Linked PR in PowerShellEditorServices: <https://github.com/PowerShell/PowerShellEditorServices/pull/2269>
* PR that can be merged after this in vscode-powershell: <https://github.com/PowerShell/vscode-powershell/pull/5413>

This PR adds a new code formatting preset, "OTPS" (**O**ne **T**rue **P**owerShell **S**tyle): OTBS with `else` on new line.

Thoughts behind the name:

* To mock the idea of one true formatting style, even though there are none.
* We do ONE change from OTBS (`else` on new line), also in the name (change B with P).

Feature request:

* <https://github.com/PowerShell/PSScriptAnalyzer/issues/2045>

Context:

* "There is no One True Brace Style": <https://github.com/PoshCode/PowerShellPracticeAndStyle/discussions/177>
  * About OTBS with `else` on a new line:
    * <https://github.com/PoshCode/PowerShellPracticeAndStyle/discussions/177#discussioncomment-6518163>
    * <https://github.com/PoshCode/PowerShellPracticeAndStyle/discussions/177#discussioncomment-6518179>

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.

## Tested like so

```powershell
# Build
.\build.ps1 -PSVersion 7 -Configuration Release

# Import built module
Import-Module -Name './out/PSScriptAnalyzer\1.24.0\PSScriptAnalyzer.psd1'

# Test new preset with OTBS as input
Invoke-Formatter -Settings 'CodeFormattingOTPS' -ScriptDefinition (@'
enum Color {
    Black, 
    White
}

function Test-Code {
    [CmdletBinding()]
    param(
        [int]$ParameterOne
    )
    end {
        if (10 -gt $ParameterOne) {
            "Greater"
        } else {
            "Lesser"
        }
    }
}
'@)
```