### PR TITLE
Add Optional PSUseConstrainedLanguageMode rule

### DIFF
--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1313,6 +1313,7 @@
   </data>
   <data name="UseConstrainedLanguageModePSCustomObjectError" xml:space="preserve">
     <value>[PSCustomObject]@{{}} syntax is not permitted in Constrained Language Mode. Use New-Object PSObject -Property @{{}} or plain hashtables instead.</value>
+  </data>
   <data name="UseSingleValueFromPipelineParameterCommonName" xml:space="preserve">
     <value>Use a single ValueFromPipeline parameter per parameter set</value>
   </data>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
     Microsoft ResX Schema
@@ -1235,5 +1235,29 @@
   </data>
   <data name="AvoidReservedWordsAsFunctionNamesError" xml:space="preserve">
     <value>The reserved word '{0}' was used as a function name. This should be avoided.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeName" xml:space="preserve">
+    <value>UseConstrainedLanguageMode</value>
+  </data>
+  <data name="UseConstrainedLanguageModeCommonName" xml:space="preserve">
+    <value>Consider Constrained Language Mode Restrictions</value>
+  </data>
+  <data name="UseConstrainedLanguageModeDescription" xml:space="preserve">
+    <value>Identifies script patterns that are restricted in Constrained Language Mode. Constrained Language Mode limits the types, cmdlets, and .NET methods that can be used to help secure PowerShell in environments requiring additional restrictions.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeAddTypeError" xml:space="preserve">
+    <value>Add-Type is not permitted in Constrained Language Mode. Consider alternative approaches if this script will run in a restricted environment.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeComObjectError" xml:space="preserve">
+    <value>New-Object with COM objects is not permitted in Constrained Language Mode. Consider alternative approaches if this script will run in a restricted environment.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeXamlError" xml:space="preserve">
+    <value>XAML usage is not permitted in Constrained Language Mode. Consider alternative approaches if this script will run in a restricted environment.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeDotSourceError" xml:space="preserve">
+    <value>Dot-sourcing may be restricted in Constrained Language Mode depending on the source location. Ensure scripts are from trusted locations if running in a restricted environment.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeInvokeExpressionError" xml:space="preserve">
+    <value>Invoke-Expression is restricted in Constrained Language Mode. Consider alternative approaches if this script will run in a restricted environment.</value>
   </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1266,4 +1266,13 @@
   <data name="UseConstrainedLanguageModeConstrainedTypeError" xml:space="preserve">
     <value>Type constraint [{0}] is not permitted in Constrained Language Mode. Consider using an allowed type.</value>
   </data>
+  <data name="UseConstrainedLanguageModeTypeExpressionError" xml:space="preserve">
+    <value>Type expression [{0}] is not permitted in Constrained Language Mode. Consider using an allowed type.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeConvertExpressionError" xml:space="preserve">
+    <value>Type cast [{0}] is not permitted in Constrained Language Mode. Consider using an allowed type.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeMemberAccessError" xml:space="preserve">
+    <value>Member '{1}' accessed on type [{0}] which is not permitted in Constrained Language Mode. Consider using an allowed type.</value>
+  </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1249,7 +1249,7 @@
     <value>Add-Type is not permitted in Constrained Language Mode. Consider alternative approaches if this script will run in a restricted environment.</value>
   </data>
   <data name="UseConstrainedLanguageModeComObjectError" xml:space="preserve">
-    <value>New-Object with COM objects is not permitted in Constrained Language Mode. Consider alternative approaches if this script will run in a restricted environment.</value>
+    <value>New-Object with the COM object '{0}' is not permitted in Constrained Language Mode. Consider alternative approaches if this script will run in a restricted environment.</value>
   </data>
   <data name="UseConstrainedLanguageModeXamlError" xml:space="preserve">
     <value>XAML usage is not permitted in Constrained Language Mode. Consider alternative approaches if this script will run in a restricted environment.</value>
@@ -1259,5 +1259,11 @@
   </data>
   <data name="UseConstrainedLanguageModeInvokeExpressionError" xml:space="preserve">
     <value>Invoke-Expression is restricted in Constrained Language Mode. Consider alternative approaches if this script will run in a restricted environment.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeNewObjectError" xml:space="preserve">
+    <value>New-Object with type '{0}' is not permitted in Constrained Language Mode. Consider using an allowed type.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeConstrainedTypeError" xml:space="preserve">
+    <value>Type constraint [{0}] is not permitted in Constrained Language Mode. Consider using an allowed type.</value>
   </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -1282,6 +1282,6 @@
     <value>Module manifest field '{0}' uses wildcard ('*') which is not recommended for Constrained Language Mode. Explicitly list exported items instead.</value>
   </data>
   <data name="UseConstrainedLanguageModeScriptModuleError" xml:space="preserve">
-    <value>Module manifest field '{0}' contains script file '{1}' (.ps1). Use binary modules (.psm1 or .dll) instead for Constrained Language Mode compatibility.</value>
+    <value>Module manifest field '{0}' contains script file '{1}' (.ps1). Use a module file (.psm1) or a binary module (.dll) instead for Constrained Language Mode compatibility.</value>
   </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1275,4 +1275,7 @@
   <data name="UseConstrainedLanguageModeMemberAccessError" xml:space="preserve">
     <value>Member '{1}' accessed on type [{0}] which is not permitted in Constrained Language Mode. Consider using an allowed type.</value>
   </data>
+  <data name="UseConstrainedLanguageModeClassError" xml:space="preserve">
+    <value>PowerShell class '{0}' is not permitted in Constrained Language Mode. Consider using alternative approaches such as hashtables or PSCustomObject.</value>
+  </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1286,6 +1286,7 @@
   </data>
   <data name="UseConstrainedLanguageModePSCustomObjectError" xml:space="preserve">
     <value>[PSCustomObject]@{{}} syntax is not permitted in Constrained Language Mode. Use New-Object PSObject -Property @{{}} or plain hashtables instead.</value>
+  </data>
   <data name="UseConsistentParametersKindCommonName" xml:space="preserve">
     <value>Use correct function parameters definition kind.</value>
   </data>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1278,4 +1278,10 @@
   <data name="UseConstrainedLanguageModeClassError" xml:space="preserve">
     <value>PowerShell class '{0}' is not permitted in Constrained Language Mode. Consider using alternative approaches such as hashtables or PSCustomObject.</value>
   </data>
+  <data name="UseConstrainedLanguageModeWildcardExportError" xml:space="preserve">
+    <value>Module manifest field '{0}' uses wildcard ('*') which is not recommended for Constrained Language Mode. Explicitly list exported items instead.</value>
+  </data>
+  <data name="UseConstrainedLanguageModeScriptModuleError" xml:space="preserve">
+    <value>Module manifest field '{0}' contains script file '{1}' (.ps1). Use binary modules (.psm1 or .dll) instead for Constrained Language Mode compatibility.</value>
+  </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1284,4 +1284,7 @@
   <data name="UseConstrainedLanguageModeScriptModuleError" xml:space="preserve">
     <value>Module manifest field '{0}' contains script file '{1}' (.ps1). Use a module file (.psm1) or a binary module (.dll) instead for Constrained Language Mode compatibility.</value>
   </data>
+  <data name="UseConstrainedLanguageModePSCustomObjectError" xml:space="preserve">
+    <value>[PSCustomObject]@{{}} syntax is not permitted in Constrained Language Mode. Use New-Object PSObject -Property @{{}} or plain hashtables instead.</value>
+  </data>
 </root>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -1311,6 +1311,9 @@
   <data name="UseConstrainedLanguageModeScriptModuleError" xml:space="preserve">
     <value>Module manifest field '{0}' contains script file '{1}' (.ps1). Use a module file (.psm1) or a binary module (.dll) instead for Constrained Language Mode compatibility.</value>
   </data>
+  <data name="UseConstrainedLanguageModeScriptsToProcessError" xml:space="preserve">
+    <value>Module manifest field 'ScriptsToProcess' contains script file '{0}' (.ps1). Scripts in ScriptsToProcess run in the caller's session state and are restricted in Constrained Language Mode. Consider moving this logic to module initialization code</value>
+  </data>
   <data name="UseConstrainedLanguageModePSCustomObjectError" xml:space="preserve">
     <value>[PSCustomObject]@{{}} syntax is not permitted in Constrained Language Mode. Use New-Object PSObject -Property @{{}} or plain hashtables instead.</value>
   </data>

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation.Language;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+#if !CORECLR
+using System.ComponentModel.Composition;
+#endif
+using System.Globalization;
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
+{
+    /// <summary>
+    /// UseConstrainedLanguageMode: Checks for patterns that indicate Constrained Language Mode should be considered.
+    /// </summary>
+#if !CORECLR
+    [Export(typeof(IScriptRule))]
+#endif
+    public class UseConstrainedLanguageMode : ConfigurableRule
+    {
+        /// <summary>
+        /// Analyzes the script to check for patterns that may require Constrained Language Mode.
+        /// </summary>
+        public override IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
+            if (ast == null)
+            {
+                throw new ArgumentNullException(nameof(ast));
+            }
+
+            var diagnosticRecords = new List<DiagnosticRecord>();
+
+            // Check for Add-Type usage (not allowed in Constrained Language Mode)
+            var addTypeCommands = ast.FindAll(testAst =>
+                testAst is CommandAst cmdAst &&
+                cmdAst.GetCommandName() != null &&
+                cmdAst.GetCommandName().Equals("Add-Type", StringComparison.OrdinalIgnoreCase),
+                true);
+
+            foreach (CommandAst cmd in addTypeCommands)
+            {
+                diagnosticRecords.Add(
+                    new DiagnosticRecord(
+                        String.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeAddTypeError),
+                        cmd.Extent,
+                        GetName(),
+                        GetDiagnosticSeverity(),
+                        fileName
+                    ));
+            }
+
+            // Check for New-Object with COM objects (not allowed in Constrained Language Mode)
+            var newObjectCommands = ast.FindAll(testAst =>
+                testAst is CommandAst cmdAst &&
+                cmdAst.GetCommandName() != null &&
+                cmdAst.GetCommandName().Equals("New-Object", StringComparison.OrdinalIgnoreCase),
+                true);
+
+            foreach (CommandAst cmd in newObjectCommands)
+            {
+                // Check if -ComObject parameter is used
+                var comObjectParam = cmd.CommandElements.OfType<CommandParameterAst>()
+                    .FirstOrDefault(p => p.ParameterName.Equals("ComObject", StringComparison.OrdinalIgnoreCase));
+
+                if (comObjectParam != null)
+                {
+                    diagnosticRecords.Add(
+                        new DiagnosticRecord(
+                            String.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeComObjectError),
+                            cmd.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            fileName
+                        ));
+                }
+            }
+
+            // Check for XAML usage (not allowed in Constrained Language Mode)
+            var xamlPatterns = ast.FindAll(testAst =>
+                testAst is StringConstantExpressionAst strAst &&
+                strAst.Value.Contains("<") && strAst.Value.Contains("xmlns"),
+                true);
+
+            foreach (StringConstantExpressionAst xamlAst in xamlPatterns)
+            {
+                if (xamlAst.Value.Contains("http://schemas.microsoft.com/winfx"))
+                {
+                    diagnosticRecords.Add(
+                        new DiagnosticRecord(
+                            String.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeXamlError),
+                            xamlAst.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            fileName
+                        ));
+                }
+            }
+
+            // Check for dot-sourcing - PowerShell doesn't have a specific DotSourceExpressionAst
+            // We look for patterns where a script block or file is dot-sourced
+            // This is best detected through token analysis, but for simplicity we'll check for common patterns
+            var scriptBlocks = ast.FindAll(testAst => testAst is ScriptBlockExpressionAst, true);
+            
+            foreach (ScriptBlockExpressionAst sbAst in scriptBlocks)
+            {
+                // Check if preceded by a dot token (basic heuristic for dot-sourcing)
+                // More sophisticated detection would require token analysis
+                var parent = sbAst.Parent;
+                if (parent is CommandAst cmdAst)
+                {
+                    // Check if this looks like a dot-source pattern
+                    var cmdName = cmdAst.GetCommandName();
+                    if (cmdName != null && cmdName.StartsWith("."))
+                    {
+                        diagnosticRecords.Add(
+                            new DiagnosticRecord(
+                                String.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeDotSourceError),
+                                sbAst.Extent,
+                                GetName(),
+                                GetDiagnosticSeverity(),
+                                fileName
+                            ));
+                    }
+                }
+            }
+
+            // Check for Invoke-Expression usage (restricted in Constrained Language Mode)
+            var invokeExpressionCommands = ast.FindAll(testAst =>
+                testAst is CommandAst cmdAst &&
+                cmdAst.GetCommandName() != null &&
+                cmdAst.GetCommandName().Equals("Invoke-Expression", StringComparison.OrdinalIgnoreCase),
+                true);
+
+            foreach (CommandAst cmd in invokeExpressionCommands)
+            {
+                diagnosticRecords.Add(
+                    new DiagnosticRecord(
+                        String.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeInvokeExpressionError),
+                        cmd.Extent,
+                        GetName(),
+                        GetDiagnosticSeverity(),
+                        fileName
+                    ));
+            }
+
+            return diagnosticRecords;
+        }
+
+        /// <summary>
+        /// Retrieves the common name of this rule.
+        /// </summary>
+        public override string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeCommonName);
+        }
+
+        /// <summary>
+        /// Retrieves the description of this rule.
+        /// </summary>
+        public override string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeDescription);
+        }
+
+        /// <summary>
+        /// Retrieves the name of this rule.
+        /// </summary>
+        public override string GetName()
+        {
+            return string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.NameSpaceFormat,
+                GetSourceName(),
+                Strings.UseConstrainedLanguageModeName);
+        }
+
+        /// <summary>
+        /// Retrieves the severity of the rule: error, warning or information.
+        /// </summary>
+        public override RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Information;
+        }
+
+        /// <summary>
+        /// Gets the severity of the returned diagnostic record: error, warning, or information.
+        /// </summary>
+        public DiagnosticSeverity GetDiagnosticSeverity()
+        {
+            return DiagnosticSeverity.Information;
+        }
+
+        /// <summary>
+        /// Retrieves the name of the module/assembly the rule is from.
+        /// </summary>
+        public override string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+
+        /// <summary>
+        /// Retrieves the type of the rule, Builtin, Managed or Module.
+        /// </summary>
+        public override SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
+        }
+    }
+}

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -109,16 +109,94 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             var diagnosticRecords = new List<DiagnosticRecord>();
 
+            // Basic check if the file is signed
+            bool isFileSigned = IsScriptSigned(fileName);
+
             // Check if this is a module manifest (.psd1 file)
             bool isModuleManifest = fileName != null && fileName.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase);
             
             if (isModuleManifest)
             {
                 // Perform PSD1-specific checks
+                // These checks are ALWAYS enforced, even for signed scripts
                 CheckModuleManifest(ast, fileName, diagnosticRecords);
             }
 
-            // Check for Add-Type usage (not allowed in Constrained Language Mode)
+            // For signed scripts, only check specific patterns that are still restricted
+            if (isFileSigned)
+            {
+                // Even signed scripts have these restrictions in CLM:
+                
+                // 1. Check for dot-sourcing (still restricted in CLM even for signed scripts)
+                CheckDotSourcing(ast, fileName, diagnosticRecords);
+                
+                // 2. Check for type constraints on parameters (still need to be validated)
+                CheckParameterTypeConstraints(ast, fileName, diagnosticRecords);
+                
+                return diagnosticRecords;
+            }
+
+            // For unsigned scripts, perform all CLM checks
+            CheckAllClmRestrictions(ast, fileName, diagnosticRecords);
+
+            return diagnosticRecords;
+        }
+
+        /// <summary>
+        /// Checks if a PowerShell script file appears to be digitally signed.
+        /// Note: This performs a simple text check for the signature block marker.
+        /// It does NOT validate signature authenticity, certificate trust, or file integrity.
+        /// For production use, PowerShell's execution policy and Get-AuthenticodeSignature
+        /// should be used to properly validate signatures.
+        /// </summary>
+        private bool IsScriptSigned(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName) || !System.IO.File.Exists(fileName))
+            {
+                return false;
+            }
+
+            // Only check .ps1, .psm1, and .psd1 files
+            string extension = System.IO.Path.GetExtension(fileName);
+            if (!extension.Equals(".ps1", StringComparison.OrdinalIgnoreCase) &&
+                !extension.Equals(".psm1", StringComparison.OrdinalIgnoreCase) &&
+                !extension.Equals(".psd1", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            try
+            {
+                // Read the file content
+                string content = System.IO.File.ReadAllText(fileName);
+                
+                // Check for signature block marker
+                // A signed PowerShell script contains a signature block that starts with:
+                // # SIG # Begin signature block
+                //
+                // IMPORTANT: This is a simple text check only. It does NOT validate:
+                // - Signature authenticity
+                // - Certificate validity or trust
+                // - File integrity (hash matching)
+                // - Certificate expiration
+                //
+                // This check assumes that if a signature block is present, the script
+                // was intended to be signed. Actual signature validation is performed
+                // by PowerShell at execution time based on execution policy.
+                return content.IndexOf("# SIG # Begin signature block", StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+            catch
+            {
+                // If we can't read the file, assume it's not signed
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Performs all CLM restriction checks (for unsigned scripts).
+        /// </summary>
+        private void CheckAllClmRestrictions(Ast ast, string fileName, List<DiagnosticRecord> diagnosticRecords)
+        {
             var addTypeCommands = ast.FindAll(testAst =>
                 testAst is CommandAst cmdAst &&
                 cmdAst.GetCommandName() != null &&
@@ -230,33 +308,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
             }
 
-            // Check for dot-sourcing - PowerShell doesn't have a specific DotSourceExpressionAst
-            // We look for patterns where a script block or file is dot-sourced
-            // This is best detected through token analysis, but for simplicity we'll check for common patterns
-            var scriptBlocks = ast.FindAll(testAst => testAst is ScriptBlockExpressionAst, true);
-            
-            foreach (ScriptBlockExpressionAst sbAst in scriptBlocks)
-            {
-                // Check if preceded by a dot token (basic heuristic for dot-sourcing)
-                // More sophisticated detection would require token analysis
-                var parent = sbAst.Parent;
-                if (parent is CommandAst cmdAst)
-                {
-                    // Check if this looks like a dot-source pattern
-                    var cmdName = cmdAst.GetCommandName();
-                    if (cmdName != null && cmdName.StartsWith("."))
-                    {
-                        diagnosticRecords.Add(
-                            new DiagnosticRecord(
-                                String.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeDotSourceError),
-                                sbAst.Extent,
-                                GetName(),
-                                GetDiagnosticSeverity(),
-                                fileName
-                            ));
-                    }
-                }
-            }
+            // Check for dot-sourcing (also called separately for signed scripts)
+            CheckDotSourcing(ast, fileName, diagnosticRecords);
 
             // Check for Invoke-Expression usage (restricted in Constrained Language Mode)
             var invokeExpressionCommands = ast.FindAll(testAst =>
@@ -296,8 +349,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     ));
             }
 
-            // Check for disallowed type constraints (e.g., [System.Net.WebClient]$client)
-            var typeConstraints = ast.FindAll(testAst => testAst is TypeConstraintAst, true);
+            // Check for parameter type constraints (also called separately for signed scripts)
+            CheckParameterTypeConstraints(ast, fileName, diagnosticRecords);
+
+            // Check for disallowed type constraints on variables (e.g., [System.Net.WebClient]$client)
+            var typeConstraints = ast.FindAll(testAst => 
+                testAst is TypeConstraintAst typeConstraint && 
+                !(typeConstraint.Parent is ParameterAst), // Exclude parameters - handled above
+                true);
+                
             foreach (TypeConstraintAst typeConstraint in typeConstraints)
             {
                 var typeName = typeConstraint.TypeName.FullName;
@@ -400,8 +460,71 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         ));
                 }
             }
+        }
 
-            return diagnosticRecords;
+        /// <summary>
+        /// Checks for dot-sourcing patterns which are restricted in CLM even for signed scripts.
+        /// </summary>
+        private void CheckDotSourcing(Ast ast, string fileName, List<DiagnosticRecord> diagnosticRecords)
+        {
+            // Check for dot-sourcing - PowerShell doesn't have a specific DotSourceExpressionAst
+            // We look for patterns where a script block or file is dot-sourced
+            var scriptBlocks = ast.FindAll(testAst => testAst is ScriptBlockExpressionAst, true);
+            
+            foreach (ScriptBlockExpressionAst sbAst in scriptBlocks)
+            {
+                // Check if preceded by a dot token (basic heuristic for dot-sourcing)
+                var parent = sbAst.Parent;
+                if (parent is CommandAst cmdAst)
+                {
+                    // Check if this looks like a dot-source pattern
+                    var cmdName = cmdAst.GetCommandName();
+                    if (cmdName != null && cmdName.StartsWith("."))
+                    {
+                        diagnosticRecords.Add(
+                            new DiagnosticRecord(
+                                String.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeDotSourceError),
+                                sbAst.Extent,
+                                GetName(),
+                                GetDiagnosticSeverity(),
+                                fileName
+                            ));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks parameter type constraints which need validation even for signed scripts.
+        /// </summary>
+        private void CheckParameterTypeConstraints(Ast ast, string fileName, List<DiagnosticRecord> diagnosticRecords)
+        {
+            // Find all parameter definitions
+            var parameters = ast.FindAll(testAst => testAst is ParameterAst, true);
+            
+            foreach (ParameterAst param in parameters)
+            {
+                // Check for type constraints on parameters
+                var typeConstraints = param.Attributes.OfType<TypeConstraintAst>();
+                
+                foreach (var typeConstraint in typeConstraints)
+                {
+                    var typeName = typeConstraint.TypeName.FullName;
+                    if (!IsTypeAllowed(typeName))
+                    {
+                        diagnosticRecords.Add(
+                            new DiagnosticRecord(
+                                String.Format(CultureInfo.CurrentCulture,
+                                    Strings.UseConstrainedLanguageModeConstrainedTypeError,
+                                    typeName),
+                                typeConstraint.Extent,
+                                GetName(),
+                                GetDiagnosticSeverity(),
+                                fileName
+                            ));
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -591,6 +714,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// </summary>
         private void CheckWildcardExports(HashtableAst hashtableAst, string fileName, List<DiagnosticRecord> diagnosticRecords)
         {
+            //AliasesToExport and VariablesToExport can use wildcards in CLM, but it is not recommended for performance reasons. We will flag it as an informational message to encourage best practices.
             string[] exportFields = { "FunctionsToExport", "CmdletsToExport", "AliasesToExport", "VariablesToExport" };
 
             foreach (var kvp in hashtableAst.KeyValuePairs)

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -109,6 +109,15 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             var diagnosticRecords = new List<DiagnosticRecord>();
 
+            // Check if this is a module manifest (.psd1 file)
+            bool isModuleManifest = fileName != null && fileName.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase);
+            
+            if (isModuleManifest)
+            {
+                // Perform PSD1-specific checks
+                CheckModuleManifest(ast, fileName, diagnosticRecords);
+            }
+
             // Check for Add-Type usage (not allowed in Constrained Language Mode)
             var addTypeCommands = ast.FindAll(testAst =>
                 testAst is CommandAst cmdAst &&
@@ -555,6 +564,227 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
             
             return null;
+        }
+
+        /// <summary>
+        /// Checks module manifest (.psd1) files for CLM compatibility issues.
+        /// </summary>
+        private void CheckModuleManifest(Ast ast, string fileName, List<DiagnosticRecord> diagnosticRecords)
+        {
+            // Find the hashtable in the manifest
+            var hashtableAst = ast.Find(x => x is HashtableAst, false) as HashtableAst;
+            
+            if (hashtableAst == null)
+            {
+                return;
+            }
+
+            // Check for wildcard exports in FunctionsToExport, CmdletsToExport, AliasesToExport
+            CheckWildcardExports(hashtableAst, fileName, diagnosticRecords);
+            
+            // Check for .ps1 files in RootModule and NestedModules
+            CheckScriptModules(hashtableAst, fileName, diagnosticRecords);
+        }
+
+        /// <summary>
+        /// Checks for wildcard ('*') in export fields which are not allowed in CLM.
+        /// </summary>
+        private void CheckWildcardExports(HashtableAst hashtableAst, string fileName, List<DiagnosticRecord> diagnosticRecords)
+        {
+            string[] exportFields = { "FunctionsToExport", "CmdletsToExport", "AliasesToExport", "VariablesToExport" };
+
+            foreach (var kvp in hashtableAst.KeyValuePairs)
+            {
+                if (kvp.Item1 is StringConstantExpressionAst keyAst)
+                {
+                    string keyName = keyAst.Value;
+                    
+                    if (exportFields.Contains(keyName, StringComparer.OrdinalIgnoreCase))
+                    {
+                        // Check if the value contains a wildcard
+                        bool hasWildcard = false;
+                        IScriptExtent wildcardExtent = null;
+
+                        // The value in a hashtable is a StatementAst, need to extract the expression
+                        var valueExpr = GetExpressionFromStatement(kvp.Item2);
+                        
+                        if (valueExpr is StringConstantExpressionAst stringValue)
+                        {
+                            if (stringValue.Value == "*")
+                            {
+                                hasWildcard = true;
+                                wildcardExtent = stringValue.Extent;
+                            }
+                        }
+                        else if (valueExpr is ArrayLiteralAst arrayValue)
+                        {
+                            foreach (var element in arrayValue.Elements)
+                            {
+                                if (element is StringConstantExpressionAst strElement && strElement.Value == "*")
+                                {
+                                    hasWildcard = true;
+                                    wildcardExtent = strElement.Extent;
+                                    break;
+                                }
+                            }
+                        }
+                        else if (valueExpr is ArrayExpressionAst arrayExpr)
+                        {
+                            // Array expressions like @('a', 'b') have a SubExpression inside
+                            if (arrayExpr.SubExpression?.Statements != null)
+                            {
+                                foreach (var stmt in arrayExpr.SubExpression.Statements)
+                                {
+                                    var expr = GetExpressionFromStatement(stmt);
+                                    if (expr is ArrayLiteralAst arrayLiteral)
+                                    {
+                                        foreach (var element in arrayLiteral.Elements)
+                                        {
+                                            if (element is StringConstantExpressionAst strElement && strElement.Value == "*")
+                                            {
+                                                hasWildcard = true;
+                                                wildcardExtent = strElement.Extent;
+                                                break;
+                                            }
+                                        }
+                                    }
+                                    if (hasWildcard) break;
+                                }
+                            }
+                        }
+
+                        if (hasWildcard && wildcardExtent != null)
+                        {
+                            diagnosticRecords.Add(
+                                new DiagnosticRecord(
+                                    String.Format(CultureInfo.CurrentCulture,
+                                        Strings.UseConstrainedLanguageModeWildcardExportError,
+                                        keyName),
+                                    wildcardExtent,
+                                    GetName(),
+                                    GetDiagnosticSeverity(),
+                                    fileName
+                                ));
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks for .ps1 files in RootModule and NestedModules which are not recommended for CLM.
+        /// </summary>
+        private void CheckScriptModules(HashtableAst hashtableAst, string fileName, List<DiagnosticRecord> diagnosticRecords)
+        {
+            string[] moduleFields = { "RootModule", "ModuleToProcess", "NestedModules" };
+
+            foreach (var kvp in hashtableAst.KeyValuePairs)
+            {
+                if (kvp.Item1 is StringConstantExpressionAst keyAst)
+                {
+                    string keyName = keyAst.Value;
+                    
+                    if (moduleFields.Contains(keyName, StringComparer.OrdinalIgnoreCase))
+                    {
+                        var valueExpr = GetExpressionFromStatement(kvp.Item2);
+                        CheckForPs1Files(valueExpr, keyName, fileName, diagnosticRecords);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Extracts an ExpressionAst from a StatementAst (typically from hashtable values).
+        /// </summary>
+        private ExpressionAst GetExpressionFromStatement(StatementAst statement)
+        {
+            if (statement is PipelineAst pipeline && pipeline.PipelineElements.Count == 1)
+            {
+                if (pipeline.PipelineElements[0] is CommandExpressionAst commandExpr)
+                {
+                    return commandExpr.Expression;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Helper method to check if an expression contains .ps1 file references.
+        /// </summary>
+        private void CheckForPs1Files(ExpressionAst valueAst, string fieldName, string fileName, List<DiagnosticRecord> diagnosticRecords)
+        {
+            if (valueAst is StringConstantExpressionAst stringValue)
+            {
+                if (stringValue.Value != null && stringValue.Value.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
+                {
+                    diagnosticRecords.Add(
+                        new DiagnosticRecord(
+                            String.Format(CultureInfo.CurrentCulture,
+                                Strings.UseConstrainedLanguageModeScriptModuleError,
+                                fieldName,
+                                stringValue.Value),
+                            stringValue.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            fileName
+                        ));
+                }
+            }
+            else if (valueAst is ArrayLiteralAst arrayValue)
+            {
+                foreach (var element in arrayValue.Elements)
+                {
+                    if (element is StringConstantExpressionAst strElement &&
+                        strElement.Value != null &&
+                        strElement.Value.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
+                    {
+                        diagnosticRecords.Add(
+                            new DiagnosticRecord(
+                                String.Format(CultureInfo.CurrentCulture,
+                                    Strings.UseConstrainedLanguageModeScriptModuleError,
+                                    fieldName,
+                                    strElement.Value),
+                                strElement.Extent,
+                                GetName(),
+                                GetDiagnosticSeverity(),
+                                fileName
+                            ));
+                    }
+                }
+            }
+            else if (valueAst is ArrayExpressionAst arrayExpr)
+            {
+                // Array expressions like @('a', 'b') have a SubExpression inside
+                if (arrayExpr.SubExpression?.Statements != null)
+                {
+                    foreach (var stmt in arrayExpr.SubExpression.Statements)
+                    {
+                        var expr = GetExpressionFromStatement(stmt);
+                        if (expr is ArrayLiteralAst arrayLiteral)
+                        {
+                            foreach (var element in arrayLiteral.Elements)
+                            {
+                                if (element is StringConstantExpressionAst strElement &&
+                                    strElement.Value != null &&
+                                    strElement.Value.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    diagnosticRecords.Add(
+                                        new DiagnosticRecord(
+                                            String.Format(CultureInfo.CurrentCulture,
+                                                Strings.UseConstrainedLanguageModeScriptModuleError,
+                                                fieldName,
+                                                strElement.Value),
+                                            strElement.Extent,
+                                            GetName(),
+                                            GetDiagnosticSeverity(),
+                                            fileName
+                                        ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         /// <summary>

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     ));
             }
 
-            // Check for disallowed type accelerators and type constraints
+            // Check for disallowed type constraints (e.g., [System.Net.WebClient]$client)
             var typeConstraints = ast.FindAll(testAst => testAst is TypeConstraintAst, true);
             foreach (TypeConstraintAst typeConstraint in typeConstraints)
             {
@@ -288,7 +288,254 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 }
             }
 
+            // Check for disallowed type expressions and casts (e.g., [System.Net.WebClient]::new() or $x -as [Type])
+            var typeExpressions = ast.FindAll(testAst => testAst is TypeExpressionAst, true);
+            foreach (TypeExpressionAst typeExpr in typeExpressions)
+            {
+                var typeName = typeExpr.TypeName.FullName;
+                if (!IsTypeAllowed(typeName))
+                {
+                    diagnosticRecords.Add(
+                        new DiagnosticRecord(
+                            String.Format(CultureInfo.CurrentCulture,
+                                Strings.UseConstrainedLanguageModeTypeExpressionError,
+                                typeName),
+                            typeExpr.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            fileName
+                        ));
+                }
+            }
+
+            // Check for convert expressions (e.g., $x = [System.Net.WebClient]$value)
+            var convertExpressions = ast.FindAll(testAst => testAst is ConvertExpressionAst, true);
+            foreach (ConvertExpressionAst convertExpr in convertExpressions)
+            {
+                var typeName = convertExpr.Type.TypeName.FullName;
+                if (!IsTypeAllowed(typeName))
+                {
+                    diagnosticRecords.Add(
+                        new DiagnosticRecord(
+                            String.Format(CultureInfo.CurrentCulture,
+                                Strings.UseConstrainedLanguageModeConvertExpressionError,
+                                typeName),
+                            convertExpr.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            fileName
+                        ));
+                }
+            }
+
+            // Check for member invocations on disallowed types
+            // This includes method calls and property access on variables with type constraints
+            var memberInvocations = ast.FindAll(testAst => 
+                testAst is InvokeMemberExpressionAst || testAst is MemberExpressionAst, true);
+            
+            foreach (Ast memberAst in memberInvocations)
+            {
+                // Skip static member access - already handled by TypeExpressionAst check
+                if (memberAst is InvokeMemberExpressionAst invokeAst && invokeAst.Static)
+                {
+                    continue;
+                }
+                
+                if (memberAst is MemberExpressionAst memAst && memAst.Static)
+                {
+                    continue;
+                }
+
+                // Get the expression being invoked on (e.g., the variable in $var.Method())
+                ExpressionAst targetExpr = memberAst is InvokeMemberExpressionAst invExpr 
+                    ? invExpr.Expression 
+                    : ((MemberExpressionAst)memberAst).Expression;
+
+                // Check if the target has a type constraint
+                string constrainedType = GetTypeConstraintFromExpression(targetExpr);
+                if (!string.IsNullOrWhiteSpace(constrainedType) && !IsTypeAllowed(constrainedType))
+                {
+                    string memberName = memberAst is InvokeMemberExpressionAst inv
+                        ? (inv.Member as StringConstantExpressionAst)?.Value ?? "<unknown>"
+                        : ((memberAst as MemberExpressionAst).Member as StringConstantExpressionAst)?.Value ?? "<unknown>";
+
+                    diagnosticRecords.Add(
+                        new DiagnosticRecord(
+                            String.Format(CultureInfo.CurrentCulture,
+                                Strings.UseConstrainedLanguageModeMemberAccessError,
+                                constrainedType,
+                                memberName),
+                            memberAst.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            fileName
+                        ));
+                }
+            }
+
             return diagnosticRecords;
+        }
+
+        /// <summary>
+        /// Attempts to determine if an expression has a type constraint.
+        /// Returns the type name if found, otherwise null.
+        /// </summary>
+        private string GetTypeConstraintFromExpression(ExpressionAst expr)
+        {
+            if (expr == null)
+            {
+                return null;
+            }
+
+            // Check if this is a convert expression with a type (e.g., [Type]$var)
+            if (expr is ConvertExpressionAst convertExpr)
+            {
+                return convertExpr.Type.TypeName.FullName;
+            }
+
+            // Check if this is a variable expression
+            if (expr is VariableExpressionAst varExpr)
+            {
+                // Walk up the AST to find if this variable has a type constraint in a parameter
+                var parameterAst = FindParameterForVariable(varExpr);
+                if (parameterAst != null)
+                {
+                    // Get the first type constraint attribute
+                    var typeConstraint = parameterAst.Attributes
+                        .OfType<TypeConstraintAst>()
+                        .FirstOrDefault();
+                    
+                    if (typeConstraint != null)
+                    {
+                        return typeConstraint.TypeName.FullName;
+                    }
+                }
+
+                // Check if the variable was declared with a type constraint elsewhere
+                // Look for assignment statements with type constraints
+                var assignmentWithType = FindTypedAssignment(varExpr);
+                if (assignmentWithType != null)
+                {
+                    return assignmentWithType;
+                }
+            }
+
+            // Check if this is a member expression that might have a known return type
+            // For now, we'll be conservative and only check direct type constraints
+            
+            return null;
+        }
+
+        /// <summary>
+        /// Finds the parameter AST for a given variable expression, if it exists.
+        /// </summary>
+        private ParameterAst FindParameterForVariable(VariableExpressionAst varExpr)
+        {
+            if (varExpr == null)
+            {
+                return null;
+            }
+
+            var varName = varExpr.VariablePath.UserPath;
+            
+            // Walk up to find the containing function or script block
+            Ast current = varExpr.Parent;
+            while (current != null)
+            {
+                if (current is FunctionDefinitionAst funcAst)
+                {
+                    // Check parameters in the param block
+                    var paramBlock = funcAst.Body?.ParamBlock;
+                    if (paramBlock?.Parameters != null)
+                    {
+                        foreach (var param in paramBlock.Parameters)
+                        {
+                            if (string.Equals(param.Name.VariablePath.UserPath, varName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                return param;
+                            }
+                        }
+                    }
+                    
+                    // Check function parameters (for functions with parameters outside param block)
+                    if (funcAst.Parameters != null)
+                    {
+                        foreach (var param in funcAst.Parameters)
+                        {
+                            if (string.Equals(param.Name.VariablePath.UserPath, varName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                return param;
+                            }
+                        }
+                    }
+                    
+                    break; // Don't check outer function scopes
+                }
+                
+                if (current is ScriptBlockAst scriptAst)
+                {
+                    var paramBlock = scriptAst.ParamBlock;
+                    if (paramBlock?.Parameters != null)
+                    {
+                        foreach (var param in paramBlock.Parameters)
+                        {
+                            if (string.Equals(param.Name.VariablePath.UserPath, varName, StringComparison.OrdinalIgnoreCase))
+                            {
+                                return param;
+                            }
+                        }
+                    }
+                    break; // Don't check outer script block scopes
+                }
+                
+                current = current.Parent;
+            }
+            
+            return null;
+        }
+
+        /// <summary>
+        /// Looks for a typed assignment to a variable (e.g., [Type]$var = ...)
+        /// </summary>
+        private string FindTypedAssignment(VariableExpressionAst varExpr)
+        {
+            if (varExpr == null)
+            {
+                return null;
+            }
+
+            var varName = varExpr.VariablePath.UserPath;
+            
+            // Walk up to find the containing function or script block
+            Ast searchScope = varExpr.Parent;
+            while (searchScope != null && 
+                   !(searchScope is FunctionDefinitionAst) && 
+                   !(searchScope is ScriptBlockAst))
+            {
+                searchScope = searchScope.Parent;
+            }
+            
+            if (searchScope == null)
+            {
+                return null;
+            }
+
+            // Find all assignment statements in this scope
+            var assignments = searchScope.FindAll(testAst => 
+                testAst is AssignmentStatementAst, true);
+            
+            foreach (AssignmentStatementAst assignment in assignments)
+            {
+                // Check if the left side is a convert expression with our variable
+                if (assignment.Left is ConvertExpressionAst convertExpr &&
+                    convertExpr.Child is VariableExpressionAst assignedVar &&
+                    string.Equals(assignedVar.VariablePath.UserPath, varName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return convertExpr.Type.TypeName.FullName;
+                }
+            }
+            
+            return null;
         }
 
         /// <summary>

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -538,7 +538,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 // Check if the command extent starts with a dot followed by whitespace
                 // This indicates dot-sourcing
                 string extentText = cmdAst.Extent.Text.TrimStart();
-                if (extentText.StartsWith(". ") || extentText.StartsWith(".\t"))
+                if (extentText.StartsWith(".") && extentText.Length > 1 && char.IsWhiteSpace(extentText[1]))
                 {
                     diagnosticRecords.Add(
                         new DiagnosticRecord(
@@ -800,8 +800,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             // Check for wildcard exports in FunctionsToExport, CmdletsToExport, AliasesToExport
             CheckWildcardExports(hashtableAst, fileName, diagnosticRecords);
-            
-            // Check for .ps1 files in RootModule and NestedModules
+
+            // Check for .ps1 files in RootModule, NestedModules, and ScriptsToProcess
             CheckScriptModules(hashtableAst, fileName, diagnosticRecords);
         }
 
@@ -810,8 +810,8 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// </summary>
         private void CheckWildcardExports(HashtableAst hashtableAst, string fileName, List<DiagnosticRecord> diagnosticRecords)
         {
-            //AliasesToExport and VariablesToExport can use wildcards in CLM, but it is not recommended for performance reasons. We will flag it as an informational message to encourage best practices.
-            string[] exportFields = { "FunctionsToExport", "CmdletsToExport", "AliasesToExport", "VariablesToExport" };
+            //AliasesToExport and VariablesToExport can use wildcards in CLM, but it is not recommended for performance reasons.
+            string[] exportFields = { "FunctionsToExport", "CmdletsToExport"};
 
             foreach (var kvp in hashtableAst.KeyValuePairs)
             {
@@ -868,9 +868,16 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                             }
                                         }
                                     }
+                                    else if (expr is StringConstantExpressionAst strElement && strElement.Value == "*")
+                                    {
+                                        // Handle single-item array expressions like @('*')
+                                        hasWildcard = true;
+                                        wildcardExtent = strElement.Extent;
+                                        break;
+                                    }
                                     if (hasWildcard) break;
                                 }
-                            }
+                            } 
                         }
 
                         if (hasWildcard && wildcardExtent != null)
@@ -892,11 +899,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         }
 
         /// <summary>
-        /// Checks for .ps1 files in RootModule and NestedModules which are not recommended for CLM.
+        /// Checks for .ps1 files in RootModule, NestedModules, and ScriptsToProcess which are not recommended for CLM.
         /// </summary>
         private void CheckScriptModules(HashtableAst hashtableAst, string fileName, List<DiagnosticRecord> diagnosticRecords)
         {
-            string[] moduleFields = { "RootModule", "ModuleToProcess", "NestedModules" };
+            string[] moduleFields = { "RootModule", "NestedModules", "ScriptsToProcess" };
 
             foreach (var kvp in hashtableAst.KeyValuePairs)
             {
@@ -929,6 +936,26 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         }
 
         /// <summary>
+        /// Helper method to get the appropriate error message for .ps1 file usage in module manifests.
+        /// </summary>
+        private string GetPs1FileErrorMessage(string fieldName, string scriptFileName)
+        {
+            if (fieldName.Equals("ScriptsToProcess", StringComparison.OrdinalIgnoreCase))
+            {
+                return String.Format(CultureInfo.CurrentCulture,
+                    Strings.UseConstrainedLanguageModeScriptsToProcessError,
+                    scriptFileName);
+            }
+            else
+            {
+                return String.Format(CultureInfo.CurrentCulture,
+                    Strings.UseConstrainedLanguageModeScriptModuleError,
+                    fieldName,
+                    scriptFileName);
+            }
+        }
+
+        /// <summary>
         /// Helper method to check if an expression contains .ps1 file references.
         /// </summary>
         private void CheckForPs1Files(ExpressionAst valueAst, string fieldName, string fileName, List<DiagnosticRecord> diagnosticRecords)
@@ -939,10 +966,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     diagnosticRecords.Add(
                         new DiagnosticRecord(
-                            String.Format(CultureInfo.CurrentCulture,
-                                Strings.UseConstrainedLanguageModeScriptModuleError,
-                                fieldName,
-                                stringValue.Value),
+                            GetPs1FileErrorMessage(fieldName, stringValue.Value),
                             stringValue.Extent,
                             GetName(),
                             GetDiagnosticSeverity(),
@@ -960,10 +984,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     {
                         diagnosticRecords.Add(
                             new DiagnosticRecord(
-                                String.Format(CultureInfo.CurrentCulture,
-                                    Strings.UseConstrainedLanguageModeScriptModuleError,
-                                    fieldName,
-                                    strElement.Value),
+                                GetPs1FileErrorMessage(fieldName, strElement.Value),
                                 strElement.Extent,
                                 GetName(),
                                 GetDiagnosticSeverity(),
@@ -990,10 +1011,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                 {
                                     diagnosticRecords.Add(
                                         new DiagnosticRecord(
-                                            String.Format(CultureInfo.CurrentCulture,
-                                                Strings.UseConstrainedLanguageModeScriptModuleError,
-                                                fieldName,
-                                                strElement.Value),
+                                            GetPs1FileErrorMessage(fieldName, strElement.Value),
                                             strElement.Extent,
                                             GetName(),
                                             GetDiagnosticSeverity(),
@@ -1001,6 +1019,19 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                                         ));
                                 }
                             }
+                        }
+                        else if (expr is StringConstantExpressionAst strElement &&
+                            strElement.Value != null &&
+                            strElement.Value.EndsWith(".ps1", StringComparison.OrdinalIgnoreCase))
+                        {
+                            diagnosticRecords.Add(
+                                    new DiagnosticRecord(
+                                        GetPs1FileErrorMessage(fieldName, strElement.Value),
+                                        strElement.Extent,
+                                        GetName(),
+                                        GetDiagnosticSeverity(),
+                                        fileName
+                                    ));
                         }
                     }
                 }

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -467,29 +467,27 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// </summary>
         private void CheckDotSourcing(Ast ast, string fileName, List<DiagnosticRecord> diagnosticRecords)
         {
-            // Check for dot-sourcing - PowerShell doesn't have a specific DotSourceExpressionAst
-            // We look for patterns where a script block or file is dot-sourced
-            var scriptBlocks = ast.FindAll(testAst => testAst is ScriptBlockExpressionAst, true);
+            // Dot-sourcing is detected by looking for commands where the extent text starts with a dot
+            // Example: . $PSScriptRoot\Helper.ps1
+            // Example: . .\script.ps1
+            // PowerShell doesn't have a specific DotSourceExpressionAst, so we check the command extent
+            var commands = ast.FindAll(testAst => testAst is CommandAst, true);
             
-            foreach (ScriptBlockExpressionAst sbAst in scriptBlocks)
+            foreach (CommandAst cmdAst in commands)
             {
-                // Check if preceded by a dot token (basic heuristic for dot-sourcing)
-                var parent = sbAst.Parent;
-                if (parent is CommandAst cmdAst)
+                // Check if the command extent starts with a dot followed by whitespace
+                // This indicates dot-sourcing
+                string extentText = cmdAst.Extent.Text.TrimStart();
+                if (extentText.StartsWith(". ") || extentText.StartsWith(".\t"))
                 {
-                    // Check if this looks like a dot-source pattern
-                    var cmdName = cmdAst.GetCommandName();
-                    if (cmdName != null && cmdName.StartsWith("."))
-                    {
-                        diagnosticRecords.Add(
-                            new DiagnosticRecord(
-                                String.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeDotSourceError),
-                                sbAst.Extent,
-                                GetName(),
-                                GetDiagnosticSeverity(),
-                                fileName
-                            ));
-                    }
+                    diagnosticRecords.Add(
+                        new DiagnosticRecord(
+                            String.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeDotSourceError),
+                            cmdAst.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            fileName
+                        ));
                 }
             }
         }

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation.Language;
 using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+using System.Management.Automation;
+
 #if !CORECLR
 using System.ComponentModel.Composition;
 #endif
@@ -21,6 +23,80 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 #endif
     public class UseConstrainedLanguageMode : ConfigurableRule
     {
+        // Allowed COM objects in Constrained Language Mode
+        private static readonly HashSet<string> AllowedComObjects = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Scripting.Dictionary",
+            "Scripting.FileSystemObject",
+            "VBScript.RegExp"
+        };
+
+        // Allowed types in Constrained Language Mode (type accelerators and common types)
+        private static readonly HashSet<string> AllowedTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "adsi", "adsisearcher", "Alias", "AllowEmptyCollection", "AllowEmptyString",
+            "AllowNull", "ArgumentCompleter", "ArgumentCompletions", "array", "bigint",
+            "bool", "byte", "char", "cimclass", "cimconverter", "ciminstance", "CimSession",
+            "cimtype", "CmdletBinding", "cultureinfo", "datetime", "decimal", "double",
+            "DscLocalConfigurationManager", "DscProperty", "DscResource", "ExperimentAction",
+            "Experimental", "ExperimentalFeature", "float", "guid", "hashtable", "int",
+            "int16", "int32", "int64", "ipaddress", "IPEndpoint", "long", "mailaddress",
+            "Microsoft.PowerShell.Commands.ModuleSpecification", "NoRunspaceAffinity",
+            "NullString", "Object[]", "ObjectSecurity", "ordered", "OutputType", "Parameter",
+            "PhysicalAddress", "pscredential", "pscustomobject", "PSDefaultValue",
+            "pslistmodifier", "psobject", "psprimitivedictionary", "PSTypeNameAttribute",
+            "regex", "sbyte", "securestring", "semver", "short", "single", "string",
+            "SupportsWildcards", "switch", "timespan", "uint", "uint16", "uint32", "uint64",
+            "ulong", "uri", "ushort", "ValidateCount", "ValidateDrive", "ValidateLength",
+            "ValidateNotNull", "ValidateNotNullOrEmpty", "ValidateNotNullOrWhiteSpace",
+            "ValidatePattern", "ValidateRange", "ValidateScript", "ValidateSet",
+            "ValidateTrustedData", "ValidateUserDrive", "version", "void", "WildcardPattern",
+            "wmi", "wmiclass", "wmisearcher", "X500DistinguishedName", "X509Certificate", "xml",
+            // Full type names for common allowed types
+            "System.Object", "System.String", "System.Int32", "System.Boolean", "System.Byte",
+            "System.Collections.Hashtable", "System.DateTime", "System.Version", "System.Uri",
+            "System.Guid", "System.TimeSpan", "System.Management.Automation.PSCredential",
+            "System.Management.Automation.PSObject", "System.Security.SecureString",
+            "System.Text.RegularExpressions.Regex", "System.Xml.XmlDocument",
+            "System.Collections.ArrayList", "System.Collections.Generic.List",
+            "System.Net.IPAddress", "System.Net.Mail.MailAddress"
+        };
+
+        public UseConstrainedLanguageMode()
+        {
+            // This rule is disabled by default - users must explicitly enable it
+            Enable = false;
+        }
+
+        /// <summary>
+        /// Checks if a type name is allowed in Constrained Language Mode
+        /// </summary>
+        private bool IsTypeAllowed(string typeName)
+        {
+            if (string.IsNullOrWhiteSpace(typeName))
+            {
+                return true; // Can't determine, so don't flag
+            }
+
+            // Check exact match first
+            if (AllowedTypes.Contains(typeName))
+            {
+                return true;
+            }
+
+            // Check simple name (last part after last dot)
+            if (typeName.Contains('.'))
+            {
+                var simpleTypeName = typeName.Substring(typeName.LastIndexOf('.') + 1);
+                if (AllowedTypes.Contains(simpleTypeName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Analyzes the script to check for patterns that may require Constrained Language Mode.
         /// </summary>
@@ -52,7 +128,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     ));
             }
 
-            // Check for New-Object with COM objects (not allowed in Constrained Language Mode)
+            // Check for New-Object with COM objects and TypeName (only specific ones are allowed in CLM)
             var newObjectCommands = ast.FindAll(testAst =>
                 testAst is CommandAst cmdAst &&
                 cmdAst.GetCommandName() != null &&
@@ -61,20 +137,66 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             foreach (CommandAst cmd in newObjectCommands)
             {
-                // Check if -ComObject parameter is used
-                var comObjectParam = cmd.CommandElements.OfType<CommandParameterAst>()
-                    .FirstOrDefault(p => p.ParameterName.Equals("ComObject", StringComparison.OrdinalIgnoreCase));
-
-                if (comObjectParam != null)
+                // Use StaticParameterBinder to reliably get parameter values
+                var bindingResult = StaticParameterBinder.BindCommand(cmd, true);
+                
+                // Check for -ComObject parameter
+                if (bindingResult.BoundParameters.ContainsKey("ComObject"))
                 {
-                    diagnosticRecords.Add(
-                        new DiagnosticRecord(
-                            String.Format(CultureInfo.CurrentCulture, Strings.UseConstrainedLanguageModeComObjectError),
-                            cmd.Extent,
-                            GetName(),
-                            GetDiagnosticSeverity(),
-                            fileName
-                        ));
+                    string comObjectValue = null;
+                    
+                    // Try to get the value from the AST directly first
+                    if (bindingResult.BoundParameters["ComObject"].Value is StringConstantExpressionAst strAst)
+                    {
+                        comObjectValue = strAst.Value;
+                    }
+                    else
+                    {
+                        // Fall back to ConstantValue
+                        comObjectValue = bindingResult.BoundParameters["ComObject"].ConstantValue as string;
+                    }
+                    
+                    // Only flag if COM object name was found AND it's not in the allowed list
+                    if (!string.IsNullOrWhiteSpace(comObjectValue) && !AllowedComObjects.Contains(comObjectValue))
+                    {
+                        diagnosticRecords.Add(
+                            new DiagnosticRecord(
+                                String.Format(CultureInfo.CurrentCulture, 
+                                    Strings.UseConstrainedLanguageModeComObjectError, 
+                                    comObjectValue),
+                                cmd.Extent,
+                                GetName(),
+                                GetDiagnosticSeverity(),
+                                fileName
+                            ));
+                    }
+                }
+                
+                // Check for -TypeName parameter
+                if (bindingResult.BoundParameters.ContainsKey("TypeName"))
+                {
+                    var typeNameValue = bindingResult.BoundParameters["TypeName"].ConstantValue as string;
+                    
+                    // If ConstantValue is null, try to extract from the AST Value
+                    if (typeNameValue == null && bindingResult.BoundParameters["TypeName"].Value is StringConstantExpressionAst typeStrAst)
+                    {
+                        typeNameValue = typeStrAst.Value;
+                    }
+                    
+                    // Only flag if type name was found AND it's not in the allowed list
+                    if (!string.IsNullOrWhiteSpace(typeNameValue) && !IsTypeAllowed(typeNameValue))
+                    {
+                        diagnosticRecords.Add(
+                            new DiagnosticRecord(
+                                String.Format(CultureInfo.CurrentCulture, 
+                                    Strings.UseConstrainedLanguageModeNewObjectError, 
+                                    typeNameValue),
+                                cmd.Extent,
+                                GetName(),
+                                GetDiagnosticSeverity(),
+                                fileName
+                            ));
+                    }
                 }
             }
 
@@ -144,6 +266,26 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         GetDiagnosticSeverity(),
                         fileName
                     ));
+            }
+
+            // Check for disallowed type accelerators and type constraints
+            var typeConstraints = ast.FindAll(testAst => testAst is TypeConstraintAst, true);
+            foreach (TypeConstraintAst typeConstraint in typeConstraints)
+            {
+                var typeName = typeConstraint.TypeName.FullName;
+                if (!IsTypeAllowed(typeName))
+                {
+                    diagnosticRecords.Add(
+                        new DiagnosticRecord(
+                            String.Format(CultureInfo.CurrentCulture,
+                                Strings.UseConstrainedLanguageModeConstrainedTypeError,
+                                typeName),
+                            typeConstraint.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            fileName
+                        ));
+                }
             }
 
             return diagnosticRecords;

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -62,10 +62,22 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             "System.Net.IPAddress", "System.Net.Mail.MailAddress"
         };
 
+        /// <summary>
+        /// When true, ignores script signatures and runs all CLM checks regardless of signature status.
+        /// When false (default), scripts with valid signatures are treated as having elevated permissions
+        /// and only critical checks (dot-sourcing, parameter types, manifests) are performed.
+        /// Set to true to enforce full CLM compliance even for signed scripts.
+        /// </summary>
+        [ConfigurableRuleProperty(defaultValue: false)]
+        public bool IgnoreSignatures { get; set; }
+
         public UseConstrainedLanguageMode()
         {
             // This rule is disabled by default - users must explicitly enable it
             Enable = false;
+            
+            // IgnoreSignatures defaults to false (respects signatures)
+            IgnoreSignatures = false;
         }
 
         /// <summary>
@@ -78,16 +90,31 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return true; // Can't determine, so don't flag
             }
 
+            // Handle array types (e.g., string[], System.String[], int[][])
+            // Strip array brackets and check the base type
+            string baseTypeName = typeName;
+            if (typeName.EndsWith("[]"))
+            {
+                // Remove all trailing [] pairs
+                baseTypeName = typeName.TrimEnd('[', ']');
+                
+                // Handle multi-dimensional or jagged arrays by removing all brackets
+                while (baseTypeName.EndsWith("[]"))
+                {
+                    baseTypeName = baseTypeName.Substring(0, baseTypeName.Length - 2);
+                }
+            }
+
             // Check exact match first
-            if (AllowedTypes.Contains(typeName))
+            if (AllowedTypes.Contains(baseTypeName))
             {
                 return true;
             }
 
             // Check simple name (last part after last dot)
-            if (typeName.Contains('.'))
+            if (baseTypeName.Contains('.'))
             {
-                var simpleTypeName = typeName.Substring(typeName.LastIndexOf('.') + 1);
+                var simpleTypeName = baseTypeName.Substring(baseTypeName.LastIndexOf('.') + 1);
                 if (AllowedTypes.Contains(simpleTypeName))
                 {
                     return true;
@@ -109,8 +136,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 
             var diagnosticRecords = new List<DiagnosticRecord>();
 
-            // Basic check if the file is signed
-            bool isFileSigned = IsScriptSigned(fileName);
+            // Check if the file is signed (via signature block detection)
+            bool isFileSigned = IgnoreSignatures ? false : IsScriptSigned(fileName);
+            
+            // Note: If IgnoreSignatures is true, isFileSigned will always be false,
+            // causing all CLM checks to run regardless of actual signature status
 
             // Check if this is a module manifest (.psd1 file)
             bool isModuleManifest = fileName != null && fileName.EndsWith(".psd1", StringComparison.OrdinalIgnoreCase);
@@ -123,6 +153,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
 
             // For signed scripts, only check specific patterns that are still restricted
+            // (unless IgnoreSignatures is true, then this block is skipped)
             if (isFileSigned)
             {
                 // Even signed scripts have these restrictions in CLM:
@@ -136,7 +167,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return diagnosticRecords;
             }
 
-            // For unsigned scripts, perform all CLM checks
+            // For unsigned scripts (or when IgnoreSignatures is true), perform all CLM checks
             CheckAllClmRestrictions(ast, fileName, diagnosticRecords);
 
             return diagnosticRecords;

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -973,7 +973,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// </summary>
         public override RuleSeverity GetSeverity()
         {
-            return RuleSeverity.Information;
+            return RuleSeverity.Warning;
         }
 
         /// <summary>
@@ -981,7 +981,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         /// </summary>
         public DiagnosticSeverity GetDiagnosticSeverity()
         {
-            return DiagnosticSeverity.Information;
+            return DiagnosticSeverity.Warning;
         }
 
         /// <summary>

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -442,6 +442,25 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             foreach (ConvertExpressionAst convertExpr in convertExpressions)
             {
                 var typeName = convertExpr.Type.TypeName.FullName;
+                
+                // Special case: [PSCustomObject]@{} is not allowed in CLM
+                // Even though PSCustomObject is an allowed type for parameters,
+                // the type cast syntax with hashtable literal is blocked in CLM
+                if (typeName.Equals("PSCustomObject", StringComparison.OrdinalIgnoreCase) &&
+                    convertExpr.Child is HashtableAst)
+                {
+                    diagnosticRecords.Add(
+                        new DiagnosticRecord(
+                            String.Format(CultureInfo.CurrentCulture,
+                                Strings.UseConstrainedLanguageModePSCustomObjectError),
+                            convertExpr.Extent,
+                            GetName(),
+                            GetDiagnosticSeverity(),
+                            fileName
+                        ));
+                    continue; // Already flagged, skip general type check
+                }
+                
                 if (!IsTypeAllowed(typeName))
                 {
                     diagnosticRecords.Add(

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -268,6 +268,25 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     ));
             }
 
+            // Check for class definitions (not allowed in Constrained Language Mode)
+            var classDefinitions = ast.FindAll(testAst =>
+                testAst is TypeDefinitionAst typeAst && typeAst.IsClass,
+                true);
+
+            foreach (TypeDefinitionAst classDef in classDefinitions)
+            {
+                diagnosticRecords.Add(
+                    new DiagnosticRecord(
+                        String.Format(CultureInfo.CurrentCulture, 
+                            Strings.UseConstrainedLanguageModeClassError,
+                            classDef.Name),
+                        classDef.Extent,
+                        GetName(),
+                        GetDiagnosticSeverity(),
+                        fileName
+                    ));
+            }
+
             // Check for disallowed type constraints (e.g., [System.Net.WebClient]$client)
             var typeConstraints = ast.FindAll(testAst => testAst is TypeConstraintAst, true);
             foreach (TypeConstraintAst typeConstraint in typeConstraints)

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             "Experimental", "ExperimentalFeature", "float", "guid", "hashtable", "int",
             "int16", "int32", "int64", "ipaddress", "IPEndpoint", "long", "mailaddress",
             "Microsoft.PowerShell.Commands.ModuleSpecification", "NoRunspaceAffinity",
-            "NullString", "Object[]", "ObjectSecurity", "ordered", "OutputType", "Parameter",
+            "NullString", "Object", "ObjectSecurity", "ordered", "OutputType", "Parameter",
             "PhysicalAddress", "pscredential", "pscustomobject", "PSDefaultValue",
             "pslistmodifier", "psobject", "psprimitivedictionary", "PSTypeNameAttribute",
             "regex", "sbyte", "securestring", "semver", "short", "single", "string",

--- a/Rules/UseConstrainedLanguageMode.cs
+++ b/Rules/UseConstrainedLanguageMode.cs
@@ -63,10 +63,20 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         };
 
         /// <summary>
-        /// When true, ignores script signatures and runs all CLM checks regardless of signature status.
-        /// When false (default), scripts with valid signatures are treated as having elevated permissions
-        /// and only critical checks (dot-sourcing, parameter types, manifests) are performed.
-        /// Set to true to enforce full CLM compliance even for signed scripts.
+        /// Cache for typed variable assignments per scope to avoid O(N*M) performance issues.
+        /// Key: Scope AST (FunctionDefinitionAst or ScriptBlockAst)
+        /// Value: Dictionary mapping variable names to their type names
+        /// </summary>
+        private Dictionary<Ast, Dictionary<string, string>> _typedVariableCache;
+
+        /// <summary>
+        /// When True, ignores the presence of script signature blocks and runs all CLM checks
+        /// regardless of whether a script appears to be signed.
+        /// When False (default), scripts that contain a PowerShell signature block (for example,
+        /// one starting with '# SIG # Begin signature block') are treated as having elevated
+        /// permissions for this rule and only critical checks (dot-sourcing, parameter types,
+        /// manifests) are performed. No cryptographic validation or trust evaluation of the
+        /// signature is performed.
         /// </summary>
         [ConfigurableRuleProperty(defaultValue: false)]
         public bool IgnoreSignatures { get; set; }
@@ -93,17 +103,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // Handle array types (e.g., string[], System.String[], int[][])
             // Strip array brackets and check the base type
             string baseTypeName = typeName;
-            if (typeName.EndsWith("[]"))
-            {
-                // Remove all trailing [] pairs
-                baseTypeName = typeName.TrimEnd('[', ']');
+           
                 
-                // Handle multi-dimensional or jagged arrays by removing all brackets
-                while (baseTypeName.EndsWith("[]"))
-                {
-                    baseTypeName = baseTypeName.Substring(0, baseTypeName.Length - 2);
-                }
+            // Handle multi-dimensional or jagged arrays by removing all brackets
+            while (baseTypeName.EndsWith("[]", StringComparison.Ordinal))
+            {
+                baseTypeName = baseTypeName.Substring(0, baseTypeName.Length - 2);
             }
+
 
             // Check exact match first
             if (AllowedTypes.Contains(baseTypeName))
@@ -133,6 +140,9 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             {
                 throw new ArgumentNullException(nameof(ast));
             }
+
+            // Initialize cache for this analysis to avoid O(N*M) performance issues
+            _typedVariableCache = new Dictionary<Ast, Dictionary<string, string>>();
 
             var diagnosticRecords = new List<DiagnosticRecord>();
 
@@ -675,7 +685,52 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         }
 
         /// <summary>
-        /// Looks for a typed assignment to a variable (e.g., [Type]$var = ...)
+        /// Builds and caches typed variable assignments for a given scope.
+        /// This is called once per scope to avoid O(N*M) performance issues.
+        /// </summary>
+        private Dictionary<string, string> GetOrBuildTypedVariableCache(Ast scope)
+        {
+            if (scope == null)
+            {
+                return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            // Check if we already have cached results for this scope
+            if (_typedVariableCache.TryGetValue(scope, out var cachedResults))
+            {
+                return cachedResults;
+            }
+
+            // Build the cache for this scope
+            var typedVariables = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            // Find all assignment statements in this scope
+            var assignments = scope.FindAll(testAst => testAst is AssignmentStatementAst, true);
+
+            foreach (AssignmentStatementAst assignment in assignments)
+            {
+                // Check if the left side is a convert expression with a variable
+                if (assignment.Left is ConvertExpressionAst convertExpr &&
+                    convertExpr.Child is VariableExpressionAst assignedVar)
+                {
+                    var varName = assignedVar.VariablePath.UserPath;
+                    var typeName = convertExpr.Type.TypeName.FullName;
+                    
+                    // Store in cache (first assignment wins)
+                    if (!typedVariables.ContainsKey(varName))
+                    {
+                        typedVariables[varName] = typeName;
+                    }
+                }
+            }
+
+            // Cache the results
+            _typedVariableCache[scope] = typedVariables;
+            return typedVariables;
+        }
+
+        /// <summary>
+        /// Looks for a typed assignment to a variable using cached results.
         /// </summary>
         private string FindTypedAssignment(VariableExpressionAst varExpr)
         {
@@ -700,19 +755,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 return null;
             }
 
-            // Find all assignment statements in this scope
-            var assignments = searchScope.FindAll(testAst => 
-                testAst is AssignmentStatementAst, true);
+            // Use cached results instead of re-scanning the entire scope
+            var typedVariables = GetOrBuildTypedVariableCache(searchScope);
             
-            foreach (AssignmentStatementAst assignment in assignments)
+            if (typedVariables.TryGetValue(varName, out string typeName))
             {
-                // Check if the left side is a convert expression with our variable
-                if (assignment.Left is ConvertExpressionAst convertExpr &&
-                    convertExpr.Child is VariableExpressionAst assignedVar &&
-                    string.Equals(assignedVar.VariablePath.UserPath, varName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return convertExpr.Type.TypeName.FullName;
-                }
+                return typeName;
             }
             
             return null;

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -235,6 +235,22 @@ enum MyEnum {
             $matchingViolations[0].Message | Should -BeLike "*FunctionsToExport*wildcard*"
         }
 
+                It "Should flag wildcard array in FunctionsToExport" {
+            $manifestPath = Join-Path $tempPath "WildcardFunctions.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    FunctionsToExport = @('*')
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*FunctionsToExport*wildcard*"
+        }
+
         It "Should flag wildcard in CmdletsToExport" {
             $manifestPath = Join-Path $tempPath "WildcardCmdlets.psd1"
             $manifestContent = @'
@@ -249,22 +265,6 @@ enum MyEnum {
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations.Count | Should -BeGreaterThan 0
             $matchingViolations[0].Message | Should -BeLike "*CmdletsToExport*wildcard*"
-        }
-
-        It "Should flag wildcard in array of exports" {
-            $manifestPath = Join-Path $tempPath "WildcardArray.psd1"
-            $manifestContent = @'
-@{
-    ModuleVersion = '1.0.0'
-    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
-    AliasesToExport = @('Get-Foo', '*', 'Set-Bar')
-}
-'@
-            Set-Content -Path $manifestPath -Value $manifestContent
-            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
-            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
-            $matchingViolations.Count | Should -BeGreaterThan 0
-            $matchingViolations[0].Message | Should -BeLike "*AliasesToExport*wildcard*"
         }
 
         It "Should NOT flag explicit list of exports" {
@@ -336,6 +336,73 @@ enum MyEnum {
             $scriptModuleViolations | Should -BeNullOrEmpty
         }
 
+        It "Should flag .ps1 file in ScriptsToProcess" {
+            $manifestPath = Join-Path $tempPath "ScriptsToProcess.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    ScriptsToProcess = @('Init.ps1', 'Setup.ps1')
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*ScriptsToProcess*Init.ps1*"
+        }
+
+        It "Should use different error message for ScriptsToProcess" {
+            $manifestPath = Join-Path $tempPath "ScriptsToProcessMessage.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    ScriptsToProcess = 'Init.ps1'
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -Be 1
+            # ScriptsToProcess should have a specific message about caller's session state
+            $matchingViolations[0].Message | Should -BeLike "*caller*session state*"
+            $matchingViolations[0].Message | Should -BeLike "*Init.ps1*"
+        }
+
+        It "Should flag single-item array in ScriptsToProcess" {
+            $manifestPath = Join-Path $tempPath "ScriptsToProcessArray.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    ScriptsToProcess = @('Init.ps1')
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -Be 1
+            $matchingViolations[0].Message | Should -BeLike "*ScriptsToProcess*Init.ps1*"
+        }
+
+        It "Should NOT flag .psm1 files in ScriptsToProcess" {
+            $manifestPath = Join-Path $tempPath "ScriptsToProcessPsm1.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    ScriptsToProcess = @('Init.psm1')
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $scriptViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*ScriptsToProcess*" 
+            }
+            $scriptViolations | Should -BeNullOrEmpty
+        }
+
         It "Should flag both wildcard and .ps1 issues in same manifest" {
             $manifestPath = Join-Path $tempPath "MultipleIssues.psd1"
             $manifestContent = @'
@@ -352,6 +419,33 @@ enum MyEnum {
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             # Should have at least 3 violations: RootModule .ps1, FunctionsToExport *, CmdletsToExport *
             $matchingViolations.Count | Should -BeGreaterOrEqual 3
+        }
+
+        It "Should flag ScriptsToProcess and RootModule with different messages" {
+            $manifestPath = Join-Path $tempPath "MixedScriptFields.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    RootModule = 'MyModule.ps1'
+    ScriptsToProcess = @('Init.ps1')
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -Be 2
+
+            # Check that we have both types of messages
+            $scriptsToProcessMsg = $matchingViolations | Where-Object { $_.Message -like "*caller*session state*" }
+            $rootModuleMsg = $matchingViolations | Where-Object { $_.Message -like "*RootModule*" -and $_.Message -notlike "*caller*session state*" }
+
+            $scriptsToProcessMsg.Count | Should -Be 1
+            $rootModuleMsg.Count | Should -Be 1
+
+            # Verify the specific field names are mentioned
+            $scriptsToProcessMsg[0].Message | Should -BeLike "*Init.ps1*"
+            $rootModuleMsg[0].Message | Should -BeLike "*MyModule.ps1*"
         }
     }
 
@@ -628,6 +722,7 @@ class MyClass {
             $scriptPath = Join-Path $tempPath "SignedWithDotSource.ps1"
             $scriptContent = @'
 . .\Helper.ps1
+.      .\U  tility.ps1
 
 # SIG # Begin signature block
 # MIIFFAYJKoZIhvcNAQcCoIIFBTCCBQECAQExCzAJ...

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -120,8 +120,24 @@ $xaml = @"
     }
 
     Context "When type constraints are used" {
-        It "Should flag disallowed type constraint" {
+        It "Should flag disallowed type constraint on parameter" {
             $def = 'function Test { param([System.Net.WebClient]$Client) }'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*not permitted*"
+        }
+
+        It "Should flag disallowed type constraint on variable declaration" {
+            $def = '[System.Net.WebClient]$client = $null'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*not permitted*"
+        }
+
+        It "Should flag disallowed type cast on variable assignment" {
+            $def = '$client = [System.Net.WebClient]$value'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations.Count | Should -BeGreaterThan 0
@@ -132,6 +148,126 @@ $xaml = @"
             $def = 'function Test { param([string]$Name, [int]$Count, [hashtable]$Data) }'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+
+        It "Should NOT flag allowed type cast on variable" {
+            $def = '[string]$name = $null'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+
+        It "Should flag multiple type issues in same script" {
+            $def = @'
+function Test {
+    param([System.Net.WebClient]$Client)
+    [System.Net.Sockets.TcpClient]$tcp = $null
+    $web = [System.Net.WebClient]::new()
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            # Should flag: 1) param type constraint, 2) variable type constraint, 3) type expression
+            # Note: May also flag member access if methods/properties are called on typed variables
+            $matchingViolations.Count | Should -BeGreaterOrEqual 3
+        }
+    }
+
+    Context "When instance methods are invoked on disallowed types" {
+        It "Should flag method invocation on parameter with disallowed type constraint" {
+            $def = @'
+function Download-File {
+    param([System.Net.WebClient]$Client, [string]$Url)
+    $Client.DownloadString($Url)
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            # Should flag both the type constraint AND the member access
+            $matchingViolations.Count | Should -BeGreaterThan 1
+            # At least one violation should mention DownloadString
+            ($matchingViolations.Message | Where-Object { $_ -like "*DownloadString*" }).Count | Should -BeGreaterThan 0
+        }
+
+        It "Should flag property access on variable with disallowed type constraint" {
+            $def = @'
+function Test {
+    param([System.Net.WebClient]$Client)
+    $baseAddr = $Client.BaseAddress
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            # Should flag both the type constraint AND the member access
+            $matchingViolations.Count | Should -BeGreaterThan 1
+            # At least one violation should mention BaseAddress
+            ($matchingViolations.Message | Where-Object { $_ -like "*BaseAddress*" }).Count | Should -BeGreaterThan 0
+        }
+
+        It "Should flag method invocation on typed variable assignment" {
+            $def = @'
+[System.Net.WebClient]$client = $null
+$result = $client.DownloadString("http://example.com")
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            # Should flag both the type constraint AND the member access
+            $matchingViolations.Count | Should -BeGreaterThan 1
+            # At least one violation should mention DownloadString
+            ($matchingViolations.Message | Where-Object { $_ -like "*DownloadString*" }).Count | Should -BeGreaterThan 0
+        }
+
+        It "Should NOT flag method invocation on allowed types" {
+            $def = @'
+function Test {
+    param([string]$Text)
+    $upper = $Text.ToUpper()
+    $length = $Text.Length
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+
+        It "Should NOT flag static method calls on disallowed types (already caught by type expression check)" {
+            $def = '[System.Net.WebClient]::New()'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            # Should only flag once for the type expression, not for member access
+            $matchingViolations.Count | Should -Be 1
+            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*"
+        }
+
+        It "Should flag chained method calls on disallowed types" {
+            $def = @'
+function Test {
+    param([System.Net.WebClient]$Client)
+    $result = $Client.DownloadString("http://example.com").ToUpper()
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            # Should flag the type constraint and at least the first member access
+            $matchingViolations.Count | Should -BeGreaterThan 1
+        }
+
+        It "Should handle complex scenarios with multiple typed variables" {
+            $def = @'
+function Complex-Test {
+    param(
+        [System.Net.WebClient]$WebClient,
+        [System.Net.Sockets.TcpClient]$TcpClient,
+        [string]$SafeString
+    )
+    
+    $data = $WebClient.DownloadData("http://test.com")
+    $TcpClient.Connect("localhost", 8080)
+    $upper = $SafeString.ToUpper()
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            # Should flag: 2 type constraints + 2 method invocations (not SafeString)
+            $matchingViolations.Count | Should -BeGreaterThan 2
         }
     }
 }

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -110,6 +110,56 @@ $xaml = @"
         }
     }
 
+    Context "When PowerShell classes are used" {
+        It "Should detect class definition" {
+            $def = @'
+class MyClass {
+    [string]$Name
+    [int]$Value
+    
+    MyClass([string]$name) {
+        $this.Name = $name
+    }
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -Be 1
+            $matchingViolations[0].Message | Should -BeLike "*class*MyClass*"
+        }
+
+        It "Should detect multiple class definitions" {
+            $def = @'
+class FirstClass {
+    [string]$Name
+}
+
+class SecondClass {
+    [int]$Value
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -Be 2
+        }
+
+        It "Should not flag enum definitions" {
+            $def = @'
+enum MyEnum {
+    Value1
+    Value2
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            # Enums are allowed, so no class-specific violations
+            # (though we may still flag other issues if present)
+            $classViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*class*" 
+            }
+            $classViolations | Should -BeNullOrEmpty
+        }
+    }
+
     Context "Informational severity" {
         It "Should have Information severity" {
             $def = 'Add-Type -AssemblyName System.Windows.Forms'

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -716,20 +716,12 @@ function Test {
             [void]$scriptBuilder.AppendLine('}')
             $def = $scriptBuilder.ToString()
             
-            # Measure performance
-            $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
-            $stopwatch.Stop()
             
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             
             # Should detect violations (30 type constraints + 50 member accesses = 80+)
             $matchingViolations.Count | Should -BeGreaterThan 50
-            
-            # Performance check: Should complete quickly (under 500ms)
-            # With cache: O(N+M) = 30+50 = 80 operations
-            # Without cache: O(N*M) = 50*30 = 1,500 operations (much slower)
-            $stopwatch.ElapsedMilliseconds | Should -BeLessThan 500
         }
 
         It "Should cache results per scope correctly" {

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -160,6 +160,148 @@ enum MyEnum {
         }
     }
 
+    Context "When module manifests (.psd1) are analyzed" {
+        BeforeAll {
+            $tempPath = Join-Path $TestDrive "TestManifests"
+            New-Item -Path $tempPath -ItemType Directory -Force | Out-Null
+        }
+
+        It "Should flag wildcard in FunctionsToExport" {
+            $manifestPath = Join-Path $tempPath "WildcardFunctions.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    FunctionsToExport = '*'
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*FunctionsToExport*wildcard*"
+        }
+
+        It "Should flag wildcard in CmdletsToExport" {
+            $manifestPath = Join-Path $tempPath "WildcardCmdlets.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    CmdletsToExport = '*'
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*CmdletsToExport*wildcard*"
+        }
+
+        It "Should flag wildcard in array of exports" {
+            $manifestPath = Join-Path $tempPath "WildcardArray.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    AliasesToExport = @('Get-Foo', '*', 'Set-Bar')
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*AliasesToExport*wildcard*"
+        }
+
+        It "Should NOT flag explicit list of exports" {
+            $manifestPath = Join-Path $tempPath "ExplicitExports.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    FunctionsToExport = @('Get-MyFunction', 'Set-MyFunction')
+    CmdletsToExport = @('Get-MyCmdlet')
+    AliasesToExport = @()
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $wildcardViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*wildcard*" 
+            }
+            $wildcardViolations | Should -BeNullOrEmpty
+        }
+
+        It "Should flag .ps1 file in RootModule" {
+            $manifestPath = Join-Path $tempPath "ScriptRootModule.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    RootModule = 'MyModule.ps1'
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*RootModule*MyModule.ps1*"
+        }
+
+        It "Should flag .ps1 file in NestedModules" {
+            $manifestPath = Join-Path $tempPath "ScriptNestedModule.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    NestedModules = @('Helper.ps1', 'Utility.psm1')
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*NestedModules*Helper.ps1*"
+        }
+
+        It "Should NOT flag .psm1 or .dll modules" {
+            $manifestPath = Join-Path $tempPath "BinaryModules.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    RootModule = 'MyModule.psm1'
+    NestedModules = @('Helper.dll', 'Utility.psm1')
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $scriptModuleViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*.ps1*" 
+            }
+            $scriptModuleViolations | Should -BeNullOrEmpty
+        }
+
+        It "Should flag both wildcard and .ps1 issues in same manifest" {
+            $manifestPath = Join-Path $tempPath "MultipleIssues.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    RootModule = 'MyModule.ps1'
+    FunctionsToExport = '*'
+    CmdletsToExport = '*'
+}
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            # Should have at least 3 violations: RootModule .ps1, FunctionsToExport *, CmdletsToExport *
+            $matchingViolations.Count | Should -BeGreaterOrEqual 3
+        }
+    }
+
     Context "Informational severity" {
         It "Should have Information severity" {
             $def = 'Add-Type -AssemblyName System.Windows.Forms'

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -5,7 +5,6 @@ BeforeAll {
     $testRootDirectory = Split-Path -Parent $PSScriptRoot
     Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
 
-    $violationMessage = "is not permitted in Constrained Language Mode"
     $violationName = "PSUseConstrainedLanguageMode"
     $ruleName = $violationName
     
@@ -33,7 +32,7 @@ Add-Type -TypeDefinition @"
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $violations.Count | Should -Be 1
             $violations[0].RuleName | Should -Be $violationName
-            $violations[0].Message | Should -BeLike "*Add-Type*$violationMessage*"
+            $violations[0].Message | Should -BeLike "*Add-Type*"
         }
 
         It "Should not flag other commands" {
@@ -44,18 +43,44 @@ Add-Type -TypeDefinition @"
     }
 
     Context "When New-Object with COM is used" {
-        It "Should detect New-Object -ComObject usage" {
-            $def = 'New-Object -ComObject "Scripting.FileSystemObject"'
+        It "Should detect disallowed New-Object -ComObject usage" {
+            $def = 'New-Object -ComObject "Excel.Application"'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations.Count | Should -Be 1
-            $matchingViolations[0].Message | Should -BeLike "*COM object*$violationMessage*"
+            $matchingViolations[0].Message | Should -BeLike "*COM object*"
         }
 
-        It "Should not flag New-Object without -ComObject" {
+        It "Should NOT flag allowed COM objects - Scripting.Dictionary" {
+            $def = 'New-Object -ComObject "Scripting.Dictionary"'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+
+        It "Should NOT flag allowed COM objects - Scripting.FileSystemObject" {
+            $def = 'New-Object -ComObject "Scripting.FileSystemObject"'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+
+        It "Should NOT flag allowed COM objects - VBScript.RegExp" {
+            $def = 'New-Object -ComObject "VBScript.RegExp"'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+
+        It "Should NOT flag New-Object with allowed TypeName" {
             $def = 'New-Object -TypeName System.Collections.ArrayList'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+
+        It "Should flag New-Object with disallowed TypeName" {
+            $def = 'New-Object -TypeName System.Net.WebClient'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -Be 1
+            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*not permitted*"
         }
     }
 
@@ -71,7 +96,7 @@ $xaml = @"
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations.Count | Should -Be 1
-            $matchingViolations[0].Message | Should -BeLike "*XAML*$violationMessage*"
+            $matchingViolations[0].Message | Should -BeLike "*XAML*"
         }
     }
 
@@ -81,7 +106,7 @@ $xaml = @"
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations.Count | Should -Be 1
-            $matchingViolations[0].Message | Should -BeLike "*Invoke-Expression*$violationMessage*"
+            $matchingViolations[0].Message | Should -BeLike "*Invoke-Expression*"
         }
     }
 
@@ -91,6 +116,22 @@ $xaml = @"
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations[0].Severity | Should -Be 'Information'
+        }
+    }
+
+    Context "When type constraints are used" {
+        It "Should flag disallowed type constraint" {
+            $def = 'function Test { param([System.Net.WebClient]$Client) }'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*not permitted*"
+        }
+
+        It "Should NOT flag allowed type constraint" {
+            $def = 'function Test { param([string]$Name, [int]$Count, [hashtable]$Data) }'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
         }
     }
 }

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -1,6 +1,22 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+# Tests for UseConstrainedLanguageMode rule
+#
+# Some tests are Windows-specific (COM objects, XAML) and will be skipped on non-Windows platforms.
 
+BeforeDiscovery {
+    # Detect OS for platform-specific tests
+    $script:IsWindowsOS = $true
+    $script:IsLinuxOS = $false
+    $script:IsMacOSOS = $false
+    
+    if ($PSVersionTable.PSVersion.Major -ge 6) {
+        # PowerShell Core has built-in OS detection variables
+        $script:IsWindowsOS = $IsWindows
+        $script:IsLinuxOS = $IsLinux
+        $script:IsMacOSOS = $IsMacOS
+    }
+}
 BeforeAll {
     $testRootDirectory = Split-Path -Parent $PSScriptRoot
     Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
@@ -20,7 +36,7 @@ BeforeAll {
 }
 
 Describe "UseConstrainedLanguageMode" {
-    Context "When Add-Type is used" {
+Context "When Add-Type is used" {
         It "Should detect Add-Type usage" {
             $def = @'
 Add-Type -TypeDefinition @"
@@ -43,7 +59,7 @@ Add-Type -TypeDefinition @"
     }
 
     Context "When New-Object with COM is used" {
-        It "Should detect disallowed New-Object -ComObject usage" {
+        It "Should detect disallowed New-Object -ComObject usage" -Skip:(-not $script:IsWindowsOS) {
             $def = 'New-Object -ComObject "Excel.Application"'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
@@ -51,19 +67,19 @@ Add-Type -TypeDefinition @"
             $matchingViolations[0].Message | Should -BeLike "*COM object*"
         }
 
-        It "Should NOT flag allowed COM objects - Scripting.Dictionary" {
+        It "Should NOT flag allowed COM objects - Scripting.Dictionary" -Skip:(-not $script:IsWindowsOS) {
             $def = 'New-Object -ComObject "Scripting.Dictionary"'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
         }
 
-        It "Should NOT flag allowed COM objects - Scripting.FileSystemObject" {
+        It "Should NOT flag allowed COM objects - Scripting.FileSystemObject" -Skip:(-not $script:IsWindowsOS) {
             $def = 'New-Object -ComObject "Scripting.FileSystemObject"'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
         }
 
-        It "Should NOT flag allowed COM objects - VBScript.RegExp" {
+        It "Should NOT flag allowed COM objects - VBScript.RegExp" -Skip:(-not $script:IsWindowsOS) {
             $def = 'New-Object -ComObject "VBScript.RegExp"'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
@@ -85,7 +101,7 @@ Add-Type -TypeDefinition @"
     }
 
     Context "When XAML is used" {
-        It "Should detect XAML usage" {
+        It "Should detect XAML usage" -Skip:(-not $script:IsWindowsOS) {
             $def = @'
 $xaml = @"
 <Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -76,11 +76,11 @@ Add-Type -TypeDefinition @"
         }
 
         It "Should flag New-Object with disallowed TypeName" {
-            $def = 'New-Object -TypeName System.Net.WebClient'
+            $def = 'New-Object -TypeName System.IO.File'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations.Count | Should -Be 1
-            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*not permitted*"
+            $matchingViolations[0].Message | Should -BeLike "*System.IO.File*not permitted*"
         }
     }
 
@@ -172,11 +172,11 @@ enum MyEnum {
 
     Context "When type expressions are used" {
         It "Should flag static type reference with new()" {
-            $def = '$instance = [System.Net.WebClient]::new()'
+            $def = '$instance = [System.IO.Directory]::new()'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations.Count | Should -BeGreaterThan 0
-            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*"
+            $matchingViolations[0].Message | Should -BeLike "*System.IO.Directory*"
         }
 
         It "Should flag static method call on disallowed type" {
@@ -388,9 +388,9 @@ enum MyEnum {
         It "Should flag multiple type issues in same script" {
             $def = @'
 function Test {
-    param([System.Net.WebClient]$Client)
-    [System.Net.Sockets.TcpClient]$tcp = $null
-    $web = [System.Net.WebClient]::new()
+    param([System.IO.File]$FileHelper)
+    [System.IO.Directory]$dirHelper = $null
+    $pathHelper = [System.IO.Path]::new()
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
@@ -401,41 +401,89 @@ function Test {
         }
     }
 
+    Context "When PSCustomObject type cast is used" {
+        It "Should flag [PSCustomObject]@{} syntax" {
+            $def = '$obj = [PSCustomObject]@{ Name = "Test"; Value = 42 }'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*PSCustomObject*"
+        }
+        
+        It "Should flag multiple [PSCustomObject]@{} instances" {
+            $def = @'
+$obj1 = [PSCustomObject]@{ Name = "Test1" }
+$obj2 = [PSCustomObject]@{ Name = "Test2" }
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -Be 2
+        }
+        
+        It "Should NOT flag PSCustomObject as parameter type" {
+            $def = 'function Test { param([PSCustomObject]$InputObject) }'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+        
+        It "Should NOT flag New-Object PSObject" {
+            $def = '$obj = New-Object PSObject -Property @{ Name = "Test" }'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+        
+        It "Should NOT flag plain hashtables" {
+            $def = '$obj = @{ Name = "Test"; Value = 42 }'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+        
+        It "Should NOT flag [PSCustomObject] with variable (not hashtable literal)" {
+            $def = '$hash = @{}; $obj = [PSCustomObject]$hash'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            # This is a type cast but not the @{} literal pattern
+            # Since PSCustomObject is in allowed list, this won't be flagged
+            $matchingViolations | Should -BeNullOrEmpty
+        }
+
+    }
+
     Context "When instance methods are invoked on disallowed types" {
         It "Should flag method invocation on parameter with disallowed type constraint" {
             $def = @'
-function Download-File {
-    param([System.Net.WebClient]$Client, [string]$Url)
-    $Client.DownloadString($Url)
+function Read-File {
+    param([System.IO.File]$FileHelper, [string]$Path)
+    $FileHelper.ReadAllText($Path)
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             # Should flag both the type constraint AND the member access
             $matchingViolations.Count | Should -BeGreaterThan 1
-            # At least one violation should mention DownloadString
-            ($matchingViolations.Message | Where-Object { $_ -like "*DownloadString*" }).Count | Should -BeGreaterThan 0
+            # At least one violation should mention ReadAllText
+            ($matchingViolations.Message | Where-Object { $_ -like "*ReadAllText*" }).Count | Should -BeGreaterThan 0
         }
 
         It "Should flag property access on variable with disallowed type constraint" {
             $def = @'
 function Test {
-    param([System.Net.WebClient]$Client)
-    $baseAddr = $Client.BaseAddress
+    param([System.IO.FileInfo]$FileHelper)
+    $fullPath = $FileHelper.FullName
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             # Should flag both the type constraint AND the member access
             $matchingViolations.Count | Should -BeGreaterThan 1
-            # At least one violation should mention BaseAddress
-            ($matchingViolations.Message | Where-Object { $_ -like "*BaseAddress*" }).Count | Should -BeGreaterThan 0
+            # At least one violation should mention FullName
+            ($matchingViolations.Message | Where-Object { $_ -like "*FullName*" }).Count | Should -BeGreaterThan 0
         }
 
         It "Should flag method invocation on typed variable assignment" {
             $def = @'
-[System.Net.WebClient]$client = $null
-$result = $client.DownloadString("http://example.com")
+[System.IO.File]$fileHelper = $null
+$result = $fileHelper.ReadAllText("C:\test.txt")
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -1,0 +1,96 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+BeforeAll {
+    $testRootDirectory = Split-Path -Parent $PSScriptRoot
+    Import-Module (Join-Path $testRootDirectory "PSScriptAnalyzerTestHelper.psm1")
+
+    $violationMessage = "is not permitted in Constrained Language Mode"
+    $violationName = "PSUseConstrainedLanguageMode"
+    $ruleName = $violationName
+    
+    # The rule is disabled by default, so we need to enable it
+    $settings = @{
+        IncludeRules = @($ruleName)
+        Rules = @{
+            $ruleName = @{
+                Enable = $true
+            }
+        }
+    }
+}
+
+Describe "UseConstrainedLanguageMode" {
+    Context "When Add-Type is used" {
+        It "Should detect Add-Type usage" {
+            $def = @'
+Add-Type -TypeDefinition @"
+    public class TestType {
+        public static string Test() { return "test"; }
+    }
+"@
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations.Count | Should -Be 1
+            $violations[0].RuleName | Should -Be $violationName
+            $violations[0].Message | Should -BeLike "*Add-Type*$violationMessage*"
+        }
+
+        It "Should not flag other commands" {
+            $def = 'Get-Process | Where-Object { $_.Name -eq "powershell" }'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "When New-Object with COM is used" {
+        It "Should detect New-Object -ComObject usage" {
+            $def = 'New-Object -ComObject "Scripting.FileSystemObject"'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -Be 1
+            $matchingViolations[0].Message | Should -BeLike "*COM object*$violationMessage*"
+        }
+
+        It "Should not flag New-Object without -ComObject" {
+            $def = 'New-Object -TypeName System.Collections.ArrayList'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $violations | Where-Object { $_.RuleName -eq $violationName } | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "When XAML is used" {
+        It "Should detect XAML usage" {
+            $def = @'
+$xaml = @"
+<Window xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+    <Button>Click me</Button>
+</Window>
+"@
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -Be 1
+            $matchingViolations[0].Message | Should -BeLike "*XAML*$violationMessage*"
+        }
+    }
+
+    Context "When Invoke-Expression is used" {
+        It "Should detect Invoke-Expression usage" {
+            $def = 'Invoke-Expression "Get-Process"'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -Be 1
+            $matchingViolations[0].Message | Should -BeLike "*Invoke-Expression*$violationMessage*"
+        }
+    }
+
+    Context "Informational severity" {
+        It "Should have Information severity" {
+            $def = 'Add-Type -AssemblyName System.Windows.Forms'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations[0].Severity | Should -Be 'Information'
+        }
+    }
+}

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -110,6 +110,16 @@ $xaml = @"
         }
     }
 
+    Context "When dot-sourcing is used" {
+        It "Should detect dot-sourcing in unsigned scripts" {
+            $def = '. $PSScriptRoot\Helper.ps1'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*dot*"
+        }
+    }
+
     Context "When PowerShell classes are used" {
         It "Should detect class definition" {
             $def = @'
@@ -157,6 +167,33 @@ enum MyEnum {
                 $_.RuleName -eq $violationName -and $_.Message -like "*class*" 
             }
             $classViolations | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "When type expressions are used" {
+        It "Should flag static type reference with new()" {
+            $def = '$instance = [System.Net.WebClient]::new()'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*"
+        }
+
+        It "Should flag static method call on disallowed type" {
+            $def = '[System.IO.File]::ReadAllText("C:\test.txt")'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            $matchingViolations.Count | Should -BeGreaterThan 0
+            $matchingViolations[0].Message | Should -BeLike "*System.IO.File*"
+        }
+
+        It "Should NOT flag static reference to allowed type" {
+            $def = '[string]::Empty'
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $typeExprViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*type expression*string*"
+            }
+            $typeExprViolations | Should -BeNullOrEmpty
         }
     }
 
@@ -462,4 +499,149 @@ function Complex-Test {
             $matchingViolations.Count | Should -BeGreaterThan 2
         }
     }
+
+    Context "When scripts are digitally signed" {
+        BeforeAll {
+            $tempPath = Join-Path $TestDrive "SignedScripts"
+            New-Item -Path $tempPath -ItemType Directory -Force | Out-Null
+        }
+
+        It "Should NOT flag Add-Type in signed scripts" {
+            $scriptPath = Join-Path $tempPath "SignedWithAddType.ps1"
+            $scriptContent = @'
+Add-Type -TypeDefinition "public class Test { }"
+
+# SIG # Begin signature block
+# MIIFFAYJKoZIhvcNAQcCoIIFBTCCBQECAQExCzAJ...
+# SIG # End signature block
+'@
+            Set-Content -Path $scriptPath -Value $scriptContent
+            $violations = Invoke-ScriptAnalyzer -Path $scriptPath -Settings $settings
+            $addTypeViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*Add-Type*" 
+            }
+            $addTypeViolations | Should -BeNullOrEmpty
+        }
+
+        It "Should NOT flag disallowed types in signed scripts" {
+            $scriptPath = Join-Path $tempPath "SignedWithDisallowedType.ps1"
+            $scriptContent = @'
+$client = New-Object System.Net.WebClient
+$data = $client.DownloadString("http://example.com")
+
+# SIG # Begin signature block
+# MIIFFAYJKoZIhvcNAQcCoIIFBTCCBQECAQExCzAJ...
+# SIG # End signature block
+'@
+            Set-Content -Path $scriptPath -Value $scriptContent
+            $violations = Invoke-ScriptAnalyzer -Path $scriptPath -Settings $settings
+            $typeViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*WebClient*type*" 
+            }
+            $typeViolations | Should -BeNullOrEmpty
+        }
+
+        It "Should NOT flag classes in signed scripts" {
+            $scriptPath = Join-Path $tempPath "SignedWithClass.ps1"
+            $scriptContent = @'
+class MyClass {
+    [string]$Name
 }
+
+# SIG # Begin signature block
+# MIIFFAYJKoZIhvcNAQcCoIIFBTCCBQECAQExCzAJ...
+# SIG # End signature block
+'@
+            Set-Content -Path $scriptPath -Value $scriptContent
+            $violations = Invoke-ScriptAnalyzer -Path $scriptPath -Settings $settings
+            $classViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*class*MyClass*" 
+            }
+            $classViolations | Should -BeNullOrEmpty
+        }
+
+        It "Should STILL flag dot-sourcing in signed scripts" {
+            $scriptPath = Join-Path $tempPath "SignedWithDotSource.ps1"
+            $scriptContent = @'
+. .\Helper.ps1
+
+# SIG # Begin signature block
+# MIIFFAYJKoZIhvcNAQcCoIIFBTCCBQECAQExCzAJ...
+# SIG # End signature block
+'@
+            Set-Content -Path $scriptPath -Value $scriptContent
+            $violations = Invoke-ScriptAnalyzer -Path $scriptPath -Settings $settings
+            $dotSourceViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*dot*"
+            }
+            # Dot-sourcing should still be flagged even in signed scripts
+            $dotSourceViolations.Count | Should -BeGreaterThan 0
+        }
+
+        It "Should STILL flag disallowed parameter types in signed scripts" {
+            $scriptPath = Join-Path $tempPath "SignedWithBadParam.ps1"
+            $scriptContent = @'
+function Test {
+    param([System.Net.WebClient]$Client)
+    Write-Output "Test"
+}
+
+# SIG # Begin signature block
+# MIIFFAYJKoZIhvcNAQcCoIIFBTCCBQECAQExCzAJ...
+# SIG # End signature block
+'@
+            Set-Content -Path $scriptPath -Value $scriptContent
+            $violations = Invoke-ScriptAnalyzer -Path $scriptPath -Settings $settings
+            $paramViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*WebClient*"
+            }
+            # Parameter type constraints should still be flagged
+            $paramViolations.Count | Should -BeGreaterThan 0
+        }
+
+        It "Should STILL flag wildcard exports in signed manifests" {
+            $manifestPath = Join-Path $tempPath "SignedManifest.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    FunctionsToExport = '*'
+}
+
+# SIG # Begin signature block
+# MIIFFAYJKoZIhvcNAQcCoIIFBTCCBQECAQExCzAJ...
+# SIG # End signature block
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $wildcardViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*wildcard*"
+            }
+            # Wildcard exports should still be flagged
+            $wildcardViolations.Count | Should -BeGreaterThan 0
+        }
+
+        It "Should STILL flag .ps1 modules in signed manifests" {
+            $manifestPath = Join-Path $tempPath "SignedManifestWithScript.psd1"
+            $manifestContent = @'
+@{
+    ModuleVersion = '1.0.0'
+    GUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+    RootModule = 'MyModule.ps1'
+}
+
+# SIG # Begin signature block
+# MIIFFAYJKoZIhvcNAQcCoIIFBTCCBQECAQExCzAJ...
+# SIG # End signature block
+'@
+            Set-Content -Path $manifestPath -Value $manifestContent
+            $violations = Invoke-ScriptAnalyzer -Path $manifestPath -Settings $settings
+            $scriptModuleViolations = $violations | Where-Object { 
+                $_.RuleName -eq $violationName -and $_.Message -like "*.ps1*"
+            }
+            # Script modules should still be flagged
+            $scriptModuleViolations.Count | Should -BeGreaterThan 0
+        }
+    }
+}
+

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -339,8 +339,8 @@ enum MyEnum {
         }
     }
 
-    Context "Informational severity" {
-        It "Should have Information severity" {
+    Context "Rule severity" {
+        It "Should have Warning severity" {
             $def = 'Add-Type -AssemblyName System.Windows.Forms'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
@@ -350,27 +350,27 @@ enum MyEnum {
 
     Context "When type constraints are used" {
         It "Should flag disallowed type constraint on parameter" {
-            $def = 'function Test { param([System.Net.WebClient]$Client) }'
+            $def = 'function Test { param([System.IO.File]$FileHelper) }'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations.Count | Should -BeGreaterThan 0
-            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*not permitted*"
+            $matchingViolations[0].Message | Should -BeLike "*System.IO.File*not permitted*"
         }
 
         It "Should flag disallowed type constraint on variable declaration" {
-            $def = '[System.Net.WebClient]$client = $null'
+            $def = '[System.IO.File]$fileHelper = $null'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations.Count | Should -BeGreaterThan 0
-            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*not permitted*"
+            $matchingViolations[0].Message | Should -BeLike "*System.IO.File*not permitted*"
         }
 
         It "Should flag disallowed type cast on variable assignment" {
-            $def = '$client = [System.Net.WebClient]$value'
+            $def = '$fileHelper = [System.IO.File]$value'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             $matchingViolations.Count | Should -BeGreaterThan 0
-            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*not permitted*"
+            $matchingViolations[0].Message | Should -BeLike "*System.IO.File*not permitted*"
         }
 
         It "Should NOT flag allowed type constraint" {
@@ -441,8 +441,8 @@ $result = $client.DownloadString("http://example.com")
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             # Should flag both the type constraint AND the member access
             $matchingViolations.Count | Should -BeGreaterThan 1
-            # At least one violation should mention DownloadString
-            ($matchingViolations.Message | Where-Object { $_ -like "*DownloadString*" }).Count | Should -BeGreaterThan 0
+            # At least one violation should mention ReadAllText
+            ($matchingViolations.Message | Where-Object { $_ -like "*ReadAllText*" }).Count | Should -BeGreaterThan 0
         }
 
         It "Should NOT flag method invocation on allowed types" {
@@ -458,19 +458,19 @@ function Test {
         }
 
         It "Should NOT flag static method calls on disallowed types (already caught by type expression check)" {
-            $def = '[System.Net.WebClient]::New()'
+            $def = '[System.IO.File]::Exists("test.txt")'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
             # Should only flag once for the type expression, not for member access
             $matchingViolations.Count | Should -Be 1
-            $matchingViolations[0].Message | Should -BeLike "*System.Net.WebClient*"
+            $matchingViolations[0].Message | Should -BeLike "*System.IO.File*"
         }
 
         It "Should flag chained method calls on disallowed types" {
             $def = @'
 function Test {
-    param([System.Net.WebClient]$Client)
-    $result = $Client.DownloadString("http://example.com").ToUpper()
+    param([System.IO.FileInfo]$FileHelper)
+    $result = $FileHelper.OpenText().ReadToEnd()
 }
 '@
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
@@ -483,13 +483,13 @@ function Test {
             $def = @'
 function Complex-Test {
     param(
-        [System.Net.WebClient]$WebClient,
-        [System.Net.Sockets.TcpClient]$TcpClient,
+        [System.IO.File]$FileHelper,
+        [System.IO.Directory]$DirHelper,
         [string]$SafeString
     )
     
-    $data = $WebClient.DownloadData("http://test.com")
-    $TcpClient.Connect("localhost", 8080)
+    $data = $FileHelper.ReadAllBytes("C:\test.bin")
+    $DirHelper.GetFiles("C:\temp")
     $upper = $SafeString.ToUpper()
 }
 '@
@@ -526,8 +526,8 @@ Add-Type -TypeDefinition "public class Test { }"
         It "Should NOT flag disallowed types in signed scripts" {
             $scriptPath = Join-Path $tempPath "SignedWithDisallowedType.ps1"
             $scriptContent = @'
-$client = New-Object System.Net.WebClient
-$data = $client.DownloadString("http://example.com")
+$fileHelper = New-Object System.IO.FileInfo("C:\test.txt")
+$data = $fileHelper.OpenText()
 
 # SIG # Begin signature block
 # MIIFFAYJKoZIhvcNAQcCoIIFBTCCBQECAQExCzAJ...
@@ -536,7 +536,7 @@ $data = $client.DownloadString("http://example.com")
             Set-Content -Path $scriptPath -Value $scriptContent
             $violations = Invoke-ScriptAnalyzer -Path $scriptPath -Settings $settings
             $typeViolations = $violations | Where-Object { 
-                $_.RuleName -eq $violationName -and $_.Message -like "*WebClient*type*" 
+                $_.RuleName -eq $violationName -and $_.Message -like "*FileInfo*type*" 
             }
             $typeViolations | Should -BeNullOrEmpty
         }
@@ -582,7 +582,7 @@ class MyClass {
             $scriptPath = Join-Path $tempPath "SignedWithBadParam.ps1"
             $scriptContent = @'
 function Test {
-    param([System.Net.WebClient]$Client)
+    param([System.IO.File]$FileHelper)
     Write-Output "Test"
 }
 
@@ -593,7 +593,7 @@ function Test {
             Set-Content -Path $scriptPath -Value $scriptContent
             $violations = Invoke-ScriptAnalyzer -Path $scriptPath -Settings $settings
             $paramViolations = $violations | Where-Object { 
-                $_.RuleName -eq $violationName -and $_.Message -like "*WebClient*"
+                $_.RuleName -eq $violationName -and $_.Message -like "*File*"
             }
             # Parameter type constraints should still be flagged
             $paramViolations.Count | Should -BeGreaterThan 0
@@ -643,5 +643,71 @@ function Test {
             $scriptModuleViolations.Count | Should -BeGreaterThan 0
         }
     }
+
+    Context "Performance with large scripts" {
+        It "Should handle scripts with many typed variables and member invocations efficiently" {
+            # This test verifies the O(N+M) cache optimization
+            # Without caching, this would be O(N*M) and very slow
+            
+            # Build a script with many typed variables and member invocations
+            $scriptBuilder = [System.Text.StringBuilder]::new()
+            [void]$scriptBuilder.AppendLine('function Test-Performance {')
+            [void]$scriptBuilder.AppendLine('    param([string]$Path)')
+            
+            # Add 30 typed variable assignments
+            for ($i = 1; $i -le 30; $i++) {
+                [void]$scriptBuilder.AppendLine("    [System.IO.File]`$file$i = `$null")
+            }
+            
+            # Add 50 member invocations (testing cache reuse)
+            for ($i = 1; $i -le 50; $i++) {
+                $varNum = ($i % 30) + 1
+                [void]$scriptBuilder.AppendLine("    `$result$i = `$file$varNum.ReadAllText(`$Path)")
+            }
+            
+            [void]$scriptBuilder.AppendLine('}')
+            $def = $scriptBuilder.ToString()
+            
+            # Measure performance
+            $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $stopwatch.Stop()
+            
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            
+            # Should detect violations (30 type constraints + 50 member accesses = 80+)
+            $matchingViolations.Count | Should -BeGreaterThan 50
+            
+            # Performance check: Should complete quickly (under 500ms)
+            # With cache: O(N+M) = 30+50 = 80 operations
+            # Without cache: O(N*M) = 50*30 = 1,500 operations (much slower)
+            $stopwatch.ElapsedMilliseconds | Should -BeLessThan 500
+        }
+
+        It "Should cache results per scope correctly" {
+            # Test that cache is scoped properly and doesn't leak between functions
+            $def = @'
+function Function1 {
+    [System.IO.File]$file1 = $null
+    $result1 = $file1.ReadAllText("C:\test1.txt")
 }
 
+function Function2 {
+    [System.IO.Directory]$file1 = $null
+    $result2 = $file1.GetFiles("C:\temp")
+}
+'@
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
+            $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
+            
+            # Should detect violations in both functions
+            # Each function has: 1 type constraint + 1 member access = 2 violations each
+            $matchingViolations.Count | Should -BeGreaterOrEqual 4
+            
+            # Verify both File and Directory are mentioned
+            $messages = $matchingViolations.Message -join ' '
+            $messages | Should -BeLike "*File*"
+            $messages | Should -BeLike "*Directory*"
+        }
+    }
+}

--- a/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
+++ b/Tests/Rules/UseConstrainedLanguageMode.tests.ps1
@@ -344,7 +344,7 @@ enum MyEnum {
             $def = 'Add-Type -AssemblyName System.Windows.Forms'
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $def -Settings $settings
             $matchingViolations = $violations | Where-Object { $_.RuleName -eq $violationName }
-            $matchingViolations[0].Severity | Should -Be 'Information'
+            $matchingViolations[0].Severity | Should -Be 'Warning'
         }
     }
 

--- a/docs/Rules/README.md
+++ b/docs/Rules/README.md
@@ -69,6 +69,7 @@ The PSScriptAnalyzer contains the following rule definitions.
 | [UseCompatibleTypes](./UseCompatibleTypes.md)                                                     | Warning     |         No         |       Yes       |
 | [UseConsistentIndentation](./UseConsistentIndentation.md)                                         | Warning     |         No         |       Yes       |
 | [UseConsistentWhitespace](./UseConsistentWhitespace.md)                                           | Warning     |         No         |       Yes       |
+| [UseConstrainedLanguageMode](./UseConstrainedLanguageMode.md)                                     | Warning     |         No         |       Yes       |
 | [UseCorrectCasing](./UseCorrectCasing.md)                                                         | Information |         No         |       Yes       |
 | [UseDeclaredVarsMoreThanAssignments](./UseDeclaredVarsMoreThanAssignments.md)                     | Warning     |        Yes         |                 |
 | [UseLiteralInitializerForHashtable](./UseLiteralInitializerForHashtable.md)                       | Warning     |        Yes         |                 |

--- a/docs/Rules/UseConstrainedLanguageMode.md
+++ b/docs/Rules/UseConstrainedLanguageMode.md
@@ -1,0 +1,374 @@
+---
+description: Use patterns compatible with Constrained Language Mode
+ms.date: 03/17/2026
+ms.topic: reference
+title: UseConstrainedLanguageMode
+---
+# UseConstrainedLanguageMode
+
+**Severity Level: Information**
+
+## Description
+
+This rule identifies PowerShell patterns that are restricted or not permitted in Constrained Language Mode (CLM).
+
+Constrained Language Mode is a PowerShell security feature that restricts:
+- .NET types that can be used
+- COM objects that can be instantiated
+- Commands that can be executed
+- Language features that can be used
+
+CLM is commonly used in:
+- Application Control environments (Application Control for Business, AppLocker)
+- Just Enough Administration (JEA) endpoints
+- Secure environments requiring additional PowerShell restrictions
+
+**Signed Script Behavior**: Digitally signed scripts from trusted publishers execute in Full Language Mode (FLM) even in CLM environments. The rule detects signature blocks (`# SIG # Begin signature block`) and adjusts checks accordingly - most restrictions don't apply to signed scripts, but certain checks (dot-sourcing, parameter types, manifest best practices) are always enforced.
+
+**Important**: The rule performs a simple text check for signature blocks and does NOT validate signature authenticity or certificate trust. Actual signature validation is performed by PowerShell at runtime.
+
+## Constrained Language Mode Restrictions
+
+### Unsigned Scripts (Full CLM Checking)
+
+The following are flagged for unsigned scripts:
+
+1. **Add-Type** - Code compilation not permitted
+2. **Disallowed COM Objects** - Only Scripting.Dictionary, Scripting.FileSystemObject, VBScript.RegExp allowed
+3. **Disallowed .NET Types** - Only ~70 allowed types (string, int, hashtable, pscredential, etc.)
+4. **Type Constraints** - On parameters and variables
+5. **Type Expressions** - Static type references like `[Type]::Method()`
+6. **Type Casts** - Converting to disallowed types
+7. **Member Invocations** - Methods/properties on disallowed types
+8. **PowerShell Classes** - `class` keyword not permitted
+9. **XAML/WPF** - Not permitted
+10. **Invoke-Expression** - Restricted
+11. **Dot-Sourcing** - May be restricted depending on the file being sourced
+12. **Module Manifest Wildcards** - Wildcard exports not recommended
+13. **Module Manifest .ps1 Files** - Script modules ending with .ps1 not allowed
+
+Always enforced, even for signed scripts
+
+### Signed Scripts (Selective Checking)
+
+For scripts with signature blocks, only these are checked:
+- Dot-sourcing
+- Parameter type constraints
+- Module manifest wildcards (.psd1 files)
+- Module manifest script modules (.psd1 files)
+
+## Configuration
+
+### Basic Configuration
+
+```powershell
+@{
+    Rules = @{
+        PSUseConstrainedLanguageMode = @{
+            Enable = $true
+        }
+    }
+}
+```
+
+### Parameters
+
+#### Enable: bool (Default value is `$false`)
+
+Enable or disable the rule during ScriptAnalyzer invocation. This rule is disabled by default because not all scripts need CLM compatibility.
+
+#### IgnoreSignatures: bool (Default value is `$false`)
+
+Control signature detection behavior:
+
+- `$false` (default): Automatically detect signatures. Signed scripts get selective checking, unsigned get full checking.
+- `$true`: Bypass signature detection. ALL scripts get full CLM checking regardless of signature status.
+
+```powershell
+@{
+    Rules = @{
+        PSUseConstrainedLanguageMode = @{
+            Enable = $true
+            IgnoreSignatures = $true  # Enforce full CLM compliance for all scripts
+        }
+    }
+}
+```
+
+**Use `IgnoreSignatures = $true` when:**
+- Auditing signed scripts for complete CLM compatibility
+- Preparing scripts for untrusted environments
+- Enforcing strict CLM compliance organization-wide
+- Development/testing to see all potential issues
+
+## How to Fix
+
+### Replace Add-Type
+
+Use allowed cmdlets or pre-compile assemblies.
+
+### Replace Disallowed COM Objects
+
+Use only allowed COM objects (Scripting.Dictionary, Scripting.FileSystemObject, VBScript.RegExp) or PowerShell cmdlets.
+
+### Replace Disallowed Types
+
+Use allowed type accelerators (`[string]`, `[int]`, `[hashtable]`, etc.) or allowed cmdlets instead of disallowed .NET types.
+
+### Replace PowerShell Classes
+
+Use `New-Object PSObject` with `Add-Member` or hashtables instead of classes.
+
+**Important**: `[PSCustomObject]@{}` syntax is NOT allowed in CLM because it uses type casting.
+
+### Avoid XAML
+
+Don't use WPF/XAML in CLM-compatible scripts.
+
+### Replace Invoke-Expression
+
+Use direct execution (`&`) or safer alternatives.
+
+### Replace Dot-Sourcing
+
+Use modules with Import-Module instead of dot-sourcing when possible.
+
+### Fix Module Manifests
+
+- Replace wildcard exports (`*`) with explicit lists
+- Use `.psm1` or `.dll` instead of `.ps1` for RootModule/NestedModules
+
+## Examples
+
+### Example 1: Add-Type
+
+#### Wrong
+
+```powershell
+Add-Type -TypeDefinition @"
+    public class Helper {
+        public static string DoWork() { return "Done"; }
+    }
+"@
+```
+
+#### Correct
+
+```powershell
+# Code sign your module using Add-Type
+# Use allowed cmdlets instead
+# Or pre-compile and load the assembly
+```
+
+### Example 2: COM Objects
+
+#### Wrong
+
+```powershell
+$excel = New-Object -ComObject Excel.Application
+```
+
+#### Correct
+
+```powershell
+# Use allowed COM object
+$dict = New-Object -ComObject Scripting.Dictionary
+
+# Or use PowerShell cmdlets
+Import-Excel -Path $file  # From ImportExcel module
+```
+
+### Example 3: Disallowed Types
+
+#### Wrong
+
+```powershell
+# Type constraint and member invocation flagged
+function Download-File {
+    param([System.Net.WebClient]$Client)
+    $Client.DownloadString($url)
+}
+
+# Type cast and method call flagged
+[System.Net.WebClient]$client = New-Object System.Net.WebClient
+$data = $client.DownloadData($url)
+```
+
+#### Correct
+
+```powershell
+# Use allowed cmdlets
+function Download-File {
+    param([string]$Url)
+    Invoke-WebRequest -Uri $Url
+}
+
+# Use allowed types
+function Process-Text {
+    param([string]$Text)
+    $upper = $Text.ToUpper()  # String methods are allowed
+}
+```
+
+### Example 4: PowerShell Classes
+
+#### Wrong
+
+```powershell
+class MyClass {
+    [string]$Name
+    
+    [string]GetInfo() {
+        return $this.Name
+    }
+}
+
+# Also wrong - uses type cast
+$obj = [PSCustomObject]@{
+    Name = "Test"
+}
+```
+
+#### Correct
+
+```powershell
+# Option 1: New-Object PSObject with Add-Member
+$obj = New-Object PSObject -Property @{
+    Name = "Test"
+}
+
+$obj | Add-Member -MemberType ScriptMethod -Name GetInfo -Value {
+    return $this.Name
+}
+
+Add-Member -InputObject $obj -NotePropertyMembers @{"Number" = 42}
+
+# Option 2: Hashtable
+$obj = @{
+    Name = "Test"
+    Number = 42
+}
+```
+
+### Example 5: Module Manifests
+
+#### Wrong
+
+```powershell
+@{
+    ModuleVersion = '1.0.0'
+    RootModule = 'MyModule.ps1'        # .ps1 not recommended
+    FunctionsToExport = '*'             # Wildcard not recommended
+    CmdletsToExport = '*'
+}
+```
+
+#### Correct
+
+```powershell
+@{
+    ModuleVersion = '1.0.0'
+    RootModule = 'MyModule.psm1'       # Use .psm1 or .dll
+    FunctionsToExport = @(              # Explicit list
+        'Get-MyFunction'
+        'Set-MyFunction'
+    )
+    CmdletsToExport = @()
+}
+```
+
+### Example 6: Array Types
+
+#### Wrong
+
+```powershell
+# Disallowed type in array
+param([System.Net.WebClient[]]$Clients)
+```
+
+#### Correct
+
+```powershell
+# Allowed types in arrays are fine
+param([string[]]$Names)
+param([int[]]$Numbers)
+param([hashtable[]]$Configuration)
+```
+
+## Detailed Restrictions
+
+### 1. Add-Type
+`Add-Type` allows compiling arbitrary C# code and is not permitted in CLM.
+
+**Enforced For**: Unsigned scripts only
+
+### 2. COM Objects
+Only three COM objects are allowed:
+- `Scripting.Dictionary`
+- `Scripting.FileSystemObject`
+- `VBScript.RegExp`
+
+All others (Excel.Application, WScript.Shell, etc.) are flagged.
+
+**Enforced For**: Unsigned scripts only
+
+### 3. .NET Types
+Only ~70 allowed types including:
+- Primitives: `string`, `int`, `bool`, `byte`, `char`, `datetime`, `decimal`, `double`, etc.
+- Collections: `hashtable`, `array`, `arraylist`
+- PowerShell: `pscredential`, `psobject`, `securestring`
+- Utilities: `regex`, `guid`, `version`, `uri`, `xml`
+- Arrays: `string[]`, `int[][]`, etc. (array of any allowed type)
+
+The rule checks type usage in:
+- Parameter type constraints (**always enforced, even for signed scripts**)
+- Variable type constraints
+- New-Object -TypeName
+- Type expressions (`[Type]::Method()`)
+- Type casts (`[Type]$variable`)
+- Member invocations on typed variables
+
+**Enforced For**: Parameter constraints always; others unsigned only
+
+### 4. PowerShell Classes
+The `class` keyword is not permitted. Use `New-Object PSObject` with `Add-Member` or hashtables.
+
+**Note**: `[PSCustomObject]@{}` is also not allowed because it uses type casting.
+
+**Enforced For**: Unsigned scripts only
+
+### 5. XAML/WPF
+XAML and WPF are not permitted in CLM.
+
+**Enforced For**: Unsigned scripts only
+
+### 6. Invoke-Expression
+`Invoke-Expression` is restricted in CLM.
+
+**Enforced For**: Unsigned scripts only
+
+### 7. Dot-Sourcing
+Dot-sourcing (`. $PSScriptRoot\script.ps1`) may be restricted depending on source location.
+
+**Enforced For**: ALL scripts (unsigned and signed)
+
+### 8. Module Manifest Best Practices
+
+#### Wildcard Exports
+Don't use `*` in: `FunctionsToExport`, `CmdletsToExport`, `AliasesToExport`, `VariablesToExport`
+
+Use explicit lists for security and clarity.
+
+**Enforced For**: ALL .psd1 files (unsigned and signed)
+
+#### Script Module Files
+Don't use `.ps1` files in: `RootModule`, `ModuleToProcess`, `NestedModules`
+
+Use `.psm1` (script modules) or `.dll` (binary modules) for better performance and compatibility.
+
+**Enforced For**: ALL .psd1 files (unsigned and signed)
+
+## More Information
+
+- [About Language Modes](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_language_modes)
+- [PowerShell Constrained Language Mode](https://devblogs.microsoft.com/powershell/powershell-constrained-language-mode/)

--- a/docs/Rules/UseConstrainedLanguageMode.md
+++ b/docs/Rules/UseConstrainedLanguageMode.md
@@ -137,6 +137,7 @@ Use modules with Import-Module instead of dot-sourcing when possible.
 
 - Replace wildcard exports (`*`) with explicit lists
 - Use `.psm1` or `.dll` instead of `.ps1` for RootModule/NestedModules
+- Don't use ScriptsToProcess as it loads in the caller's scope and will be blocked. 
 
 ## Examples
 

--- a/docs/Rules/UseConstrainedLanguageMode.md
+++ b/docs/Rules/UseConstrainedLanguageMode.md
@@ -6,7 +6,7 @@ title: UseConstrainedLanguageMode
 ---
 # UseConstrainedLanguageMode
 
-**Severity Level: Information**
+**Severity Level: Warning**
 
 ## Description
 

--- a/docs/Rules/UseConstrainedLanguageMode.md
+++ b/docs/Rules/UseConstrainedLanguageMode.md
@@ -155,9 +155,10 @@ Add-Type -TypeDefinition @"
 #### Correct
 
 ```powershell
-# Code sign your module using Add-Type
-# Use allowed cmdlets instead
-# Or pre-compile and load the assembly
+ # Code sign your scripts/modules using proper signing tools
+ #   (for example, Set-AuthenticodeSignature or external signing processes)
+ # Use allowed cmdlets instead of Add-Type-defined types where possible
+ # Or pre-compile, sign, and load the assembly (for example, via Add-Type -Path)
 ```
 
 ### Example 2: COM Objects
@@ -370,5 +371,7 @@ Use `.psm1` (script modules) or `.dll` (binary modules) for better performance a
 
 ## More Information
 
-- [About Language Modes](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_language_modes)
+- [About Language Modes](https://learn.microsoft.com/powershell/module/microsoft.powershell.core/about/about_language_modes)
 - [PowerShell Constrained Language Mode](https://devblogs.microsoft.com/powershell/powershell-constrained-language-mode/)
+- [PowerShell Module Function Export in Constrained Language](https://devblogs.microsoft.com/powershell/powershell-module-function-export-in-constrained-language/)
+- [PowerShell Constrained Language Mode and the Dot-Source Operator](https://devblogs.microsoft.com/powershell/powershell-constrained-language-mode-and-the-dot-source-operator/)


### PR DESCRIPTION
## PR Summary

This PR adds a new rule PSUseConstrainedLanguageMode that identifies PowerShell patterns incompatible with Constrained Language Mode, helping developers ensure scripts work in restricted environments. This rule is a Warning, but is optional and not enabled by default.

New files:
`Rules/UseConstrainedLanguageMode.cs`  - Implements 14 CLM restriction checks
`Tests/Rules/UseConstrainedLanguageMode.tests.ps1` - Adds 46 comprehensive tests
`docs/Rules/UseConstrainedLanguageMode.md` - Provides complete user documentation

Modified files;

`Rules/strings.resx` - Adds 16 new diagnostic message strings

Features
Detects CLM Violations:
- Add-Type usage (code compilation)
- Disallowed COM objects (only allows Scripting.Dictionary, Scripting.FileSystemObject, VBScript.RegExp)
- Disallowed .NET types (validates ~70 allowed types including primitives, collections, PowerShell types)
- PowerShell classes (class keyword)
- XAML/WPF usage
- Invoke-Expression usage
- Dot-sourcing patterns
- Type constraints, expressions, and casts
- Member invocations on disallowed types
- Module manifest wildcards and .ps1 references  

Signature Awareness:
- Detects signature blocks (# SIG # Begin signature block)
- Applies selective checking to signed scripts (dot-sourcing, parameter types, manifests only)
- Applies full checking to unsigned scripts

Array Type Support:
- Handles array notation correctly ([string[]], [int[][]])
- Strips brackets and validates base types

Configuration:
- IgnoreSignatures property (default: false) bypasses signature detection and enforces full CLM compliance for all scripts

Testing:
<img width="860" height="859" alt="image" src="https://github.com/user-attachments/assets/d92bbc94-2864-41d5-b85a-748e5bdbc307" />


## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.