### PR TITLE
Improve pipeline indentation handling in UseConsistentIndentation rule

### DIFF
--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -130,9 +130,21 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             var tokens = Helper.Instance.Tokens;
             var diagnosticRecords = new List<DiagnosticRecord>();
             var indentationLevel = 0;
-            var currentIndenationLevelIncreaseDueToPipelines = 0;
             var onNewLine = true;
             var pipelineAsts = ast.FindAll(testAst => testAst is PipelineAst && (testAst as PipelineAst).PipelineElements.Count > 1, true).ToList();
+            // Sort by end position so that inner (nested) pipelines appear before outer ones.
+            // This is required by MatchingPipelineAstEnd, whose early-break optimization
+            // would otherwise skip nested pipelines that end before their outer pipeline.
+            pipelineAsts.Sort((a, b) =>
+            {
+                int lineCmp = a.Extent.EndScriptPosition.LineNumber.CompareTo(b.Extent.EndScriptPosition.LineNumber);
+                return lineCmp != 0 ? lineCmp : a.Extent.EndScriptPosition.ColumnNumber.CompareTo(b.Extent.EndScriptPosition.ColumnNumber);
+            });
+            // Track pipeline indentation increases per PipelineAst instead of as a single
+            // flat counter. A flat counter caused all accumulated pipeline indentation to be
+            // subtracted when *any* pipeline ended, instead of only the contribution from
+            // that specific pipeline — leading to runaway indentation with nested pipelines.
+            var pipelineIndentationIncreases = new Dictionary<PipelineAst, int>();
             /*
                 When an LParen and LBrace are on the same line, it can lead to too much de-indentation.
                 In order to prevent the RParen code from de-indenting too much, we keep a stack of when we skipped the indentation
@@ -188,18 +200,33 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         if (pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationAfterEveryPipeline)
                         {
                             AddViolation(token, indentationLevel++, diagnosticRecords, ref onNewLine);
-                            currentIndenationLevelIncreaseDueToPipelines++;
+                            // Attribute this increase to the innermost pipeline containing
+                            // this pipe token so it is only reversed when that specific
+                            // pipeline ends, not when an unrelated outer pipeline ends.
+                            PipelineAst containingPipeline = FindInnermostContainingPipeline(pipelineAsts, token);
+                            if (containingPipeline != null)
+                            {
+                                if (!pipelineIndentationIncreases.ContainsKey(containingPipeline))
+                                    pipelineIndentationIncreases[containingPipeline] = 0;
+                                pipelineIndentationIncreases[containingPipeline]++;
+                            }
                             break;
                         }
                         if (pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationForFirstPipeline)
                         {
-                            bool isFirstPipeInPipeline = pipelineAsts.Any(pipelineAst =>
-                                PositionIsEqual(LastPipeOnFirstLineWithPipeUsage((PipelineAst)pipelineAst).Extent.EndScriptPosition,
-                                   tokens[tokenIndex - 1].Extent.EndScriptPosition));
-                            if (isFirstPipeInPipeline)
+                            // Capture which specific PipelineAst this is the first pipe for,
+                            // so the indentation increase is attributed to that pipeline only.
+                            PipelineAst firstPipePipeline = pipelineAsts
+                                .Cast<PipelineAst>()
+                                .FirstOrDefault(pipelineAst =>
+                                    PositionIsEqual(LastPipeOnFirstLineWithPipeUsage(pipelineAst).Extent.EndScriptPosition,
+                                       tokens[tokenIndex - 1].Extent.EndScriptPosition));
+                            if (firstPipePipeline != null)
                             {
                                 AddViolation(token, indentationLevel++, diagnosticRecords, ref onNewLine);
-                                currentIndenationLevelIncreaseDueToPipelines++;
+                                if (!pipelineIndentationIncreases.ContainsKey(firstPipePipeline))
+                                    pipelineIndentationIncreases[firstPipePipeline] = 0;
+                                pipelineIndentationIncreases[firstPipePipeline]++;
                             }
                         }
                         break;
@@ -290,8 +317,13 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 if (pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationForFirstPipeline ||
                     pipelineIndentationStyle == PipelineIndentationStyle.IncreaseIndentationAfterEveryPipeline)
                 {
-                    indentationLevel = ClipNegative(indentationLevel - currentIndenationLevelIncreaseDueToPipelines);
-                    currentIndenationLevelIncreaseDueToPipelines = 0;
+                    // Only subtract the indentation contributed by this specific pipeline,
+                    // leaving contributions from outer/unrelated pipelines intact.
+                    if (pipelineIndentationIncreases.TryGetValue(matchingPipeLineAstEnd, out int contribution))
+                    {
+                        indentationLevel = ClipNegative(indentationLevel - contribution);
+                        pipelineIndentationIncreases.Remove(matchingPipeLineAstEnd);
+                    }
                 }
             }
 
@@ -430,6 +462,32 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
 
             return matchingPipeLineAstEnd;
+        }
+
+        /// <summary>
+        /// Finds the innermost (smallest) PipelineAst whose extent fully contains the given token.
+        /// Used to attribute pipeline indentation increases to the correct pipeline when
+        /// using IncreaseIndentationAfterEveryPipeline.
+        /// </summary>
+        private static PipelineAst FindInnermostContainingPipeline(List<Ast> pipelineAsts, Token token)
+        {
+            PipelineAst best = null;
+            int bestSize = int.MaxValue;
+            foreach (var ast in pipelineAsts)
+            {
+                var pipeline = (PipelineAst)ast;
+                int pipelineStart = pipeline.Extent.StartOffset;
+                int pipelineEnd = pipeline.Extent.EndOffset;
+                int pipelineSize = pipelineEnd - pipelineStart;
+                if (pipelineStart <= token.Extent.StartOffset &&
+                    token.Extent.EndOffset <= pipelineEnd &&
+                    pipelineSize < bestSize)
+                {
+                    best = pipeline;
+                    bestSize = pipelineSize;
+                }
+            }
+            return best;
         }
 
         private static bool PositionIsEqual(IScriptPosition position1, IScriptPosition position2)

--- a/Rules/UseConsistentIndentation.cs
+++ b/Rules/UseConsistentIndentation.cs
@@ -143,15 +143,14 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             // Track pipeline indentation increases per PipelineAst instead of as a single
             // flat counter. A flat counter caused all accumulated pipeline indentation to be
             // subtracted when *any* pipeline ended, instead of only the contribution from
-            // that specific pipeline — leading to runaway indentation with nested pipelines.
+            // that specific pipeline - leading to runaway indentation with nested pipelines.
             var pipelineIndentationIncreases = new Dictionary<PipelineAst, int>();
-            /*
-                When an LParen and LBrace are on the same line, it can lead to too much de-indentation.
-                In order to prevent the RParen code from de-indenting too much, we keep a stack of when we skipped the indentation
-                caused by tokens that require a closing RParen (which are LParen, AtParen and DollarParen).
-            */
-            var lParenSkippedIndentation = new Stack<bool>();
-            
+            // When multiple openers appear on the same line (e.g. ({ or @(@{),
+            // only the last unclosed opener should affect indentation. We
+            // track, for every opener, whether its indentation increment was
+            // skipped so that the matching closer knows not to decrement.
+            var openerSkippedIndentation = new Stack<bool>();
+
             for (int tokenIndex = 0; tokenIndex < tokens.Length; tokenIndex++)
             {
                 var token = tokens[tokenIndex];
@@ -165,27 +164,39 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                 {
                     case TokenKind.AtCurly:
                     case TokenKind.LCurly:
-                        AddViolation(token, indentationLevel++, diagnosticRecords, ref onNewLine);
-                        break;
-
                     case TokenKind.DollarParen:
                     case TokenKind.AtParen:
-                        lParenSkippedIndentation.Push(false);
-                        AddViolation(token, indentationLevel++, diagnosticRecords, ref onNewLine);
+                        AddViolation(token, indentationLevel, diagnosticRecords, ref onNewLine);
+                        if (HasUnclosedOpenerBeforeLineEnd(tokens, tokenIndex))
+                        {
+                            openerSkippedIndentation.Push(true);
+                        }
+                        else
+                        {
+                            indentationLevel++;
+                            openerSkippedIndentation.Push(false);
+                        }
                         break;
 
                     case TokenKind.LParen:
                         AddViolation(token, indentationLevel, diagnosticRecords, ref onNewLine);
-                        // When a line starts with a parenthesis and it is not the last non-comment token of that line,
-                        // then indentation does not need to be increased.
+                        // When a line starts with a parenthesis and it is not the
+                        // last non-comment token of that line, indentation does
+                        // not need to be increased.
                         if ((tokenIndex == 0 || tokens[tokenIndex - 1].Kind == TokenKind.NewLine) &&
                             NextTokenIgnoringComments(tokens, tokenIndex)?.Kind != TokenKind.NewLine)
                         {
-                            onNewLine = false;
-                            lParenSkippedIndentation.Push(true);
+                            openerSkippedIndentation.Push(true);
                             break;
                         }
-                        lParenSkippedIndentation.Push(false);
+                        // General case: skip when another opener follows so that
+                        // only the last unclosed opener on a line is indent-affecting.
+                        if (HasUnclosedOpenerBeforeLineEnd(tokens, tokenIndex))
+                        {
+                            openerSkippedIndentation.Push(true);
+                            break;
+                        }
+                        openerSkippedIndentation.Push(false);
                         indentationLevel++;
                         break;
 
@@ -232,23 +243,18 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         break;
 
                     case TokenKind.RParen:
-                        bool matchingLParenIncreasedIndentation = false;
-                        if (lParenSkippedIndentation.Count > 0)
-                        {
-                            matchingLParenIncreasedIndentation = lParenSkippedIndentation.Pop();
-                        }
-                        if (matchingLParenIncreasedIndentation)
-                        {
-                            onNewLine = false;
-                            break;
-                        }
-                        indentationLevel = ClipNegative(indentationLevel - 1);
-                        AddViolation(token, indentationLevel, diagnosticRecords, ref onNewLine);
-                        break;
-
                     case TokenKind.RCurly:
-                        indentationLevel = ClipNegative(indentationLevel - 1);
-                        AddViolation(token, indentationLevel, diagnosticRecords, ref onNewLine);
+                        if (openerSkippedIndentation.Count > 0 && openerSkippedIndentation.Pop())
+                        {
+                            // The matching opener skipped its increment, so we
+                            // skip the decrement but still enforce indentation.
+                            AddViolation(token, indentationLevel, diagnosticRecords, ref onNewLine);
+                        }
+                        else
+                        {
+                            indentationLevel = ClipNegative(indentationLevel - 1);
+                            AddViolation(token, indentationLevel, diagnosticRecords, ref onNewLine);
+                        }
                         break;
 
                     case TokenKind.NewLine:
@@ -328,6 +334,49 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
 
             return diagnosticRecords;
+        }
+
+        /// <summary>
+        /// Scans forward from the current opener to the end of the line.
+        /// Returns true if there is at least one unclosed opener when
+        /// the line ends, meaning the current opener should skip its
+        /// indentation increment.  If the current opener's own closer
+        /// is found on the same line (depth drops below zero), returns
+        /// false so that it indents normally.
+        /// </summary>
+        private static bool HasUnclosedOpenerBeforeLineEnd(Token[] tokens, int currentIndex)
+        {
+            int depth = 0;
+            for (int i = currentIndex + 1; i < tokens.Length; i++)
+            {
+                switch (tokens[i].Kind)
+                {
+                    case TokenKind.NewLine:
+                    case TokenKind.LineContinuation:
+                    case TokenKind.EndOfInput:
+                        return depth > 0;
+
+                    case TokenKind.LCurly:
+                    case TokenKind.AtCurly:
+                    case TokenKind.LParen:
+                    case TokenKind.AtParen:
+                    case TokenKind.DollarParen:
+                        depth++;
+                        break;
+
+                    case TokenKind.RCurly:
+                    case TokenKind.RParen:
+                        depth--;
+                        if (depth < 0)
+                        {
+                            // Our own closer was found on this line.
+                            return false;
+                        }
+                        break;
+                }
+            }
+
+            return depth > 0;
         }
 
         private static Token NextTokenIgnoringComments(Token[] tokens, int startIndex)

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -549,6 +549,370 @@ foo |
         }
     }
 
+    Context "When a nested multi-line pipeline is inside a pipelined script block" {
+
+        It "Should preserve indentation with nested pipeline using <PipelineIndentation>" -TestCases @(
+            @{
+                PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+                IdempotentScriptDefinition = @'
+$Test |
+    ForEach-Object {
+        Get-Process |
+            Select-Object -Last 1
+    }
+'@
+            }
+            @{
+                PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+                IdempotentScriptDefinition = @'
+$Test |
+    ForEach-Object {
+        Get-Process |
+            Select-Object -Last 1
+    }
+'@
+            }
+            @{
+                PipelineIndentation = 'NoIndentation'
+                IdempotentScriptDefinition = @'
+$Test |
+ForEach-Object {
+    Get-Process |
+    Select-Object -Last 1
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'None'
+                IdempotentScriptDefinition = @'
+$Test |
+    ForEach-Object {
+    Get-Process |
+            Select-Object -Last 1
+}
+'@
+            }
+        ) {
+            param ($PipelineIndentation, $IdempotentScriptDefinition)
+
+            $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+            Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition -Settings $settings | Should -Be $IdempotentScriptDefinition
+        }
+
+        It "Should recover indentation after nested pipeline block using <PipelineIndentation>" -TestCases @(
+            @{
+                PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+                IdempotentScriptDefinition = @'
+function foo {
+    $Test |
+        ForEach-Object {
+            Get-Process |
+                Select-Object -Last 1
+        }
+    $thisLineShouldBeAtOneIndent
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+                IdempotentScriptDefinition = @'
+function foo {
+    $Test |
+        ForEach-Object {
+            Get-Process |
+                Select-Object -Last 1
+        }
+    $thisLineShouldBeAtOneIndent
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'NoIndentation'
+                IdempotentScriptDefinition = @'
+function foo {
+    $Test |
+    ForEach-Object {
+        Get-Process |
+        Select-Object -Last 1
+    }
+    $thisLineShouldBeAtOneIndent
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'None'
+                IdempotentScriptDefinition = @'
+function foo {
+    $Test |
+        ForEach-Object {
+        Get-Process |
+                Select-Object -Last 1
+    }
+    $thisLineShouldBeAtOneIndent
+}
+'@
+            }
+        ) {
+            param ($PipelineIndentation, $IdempotentScriptDefinition)
+
+            $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+            Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition -Settings $settings | Should -Be $IdempotentScriptDefinition
+        }
+
+        It "Should handle multiple sequential nested pipeline blocks using <PipelineIndentation>" -TestCases @(
+            @{
+                PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+                IdempotentScriptDefinition = @'
+function foo {
+    $a |
+        ForEach-Object {
+            Get-Process |
+                Select-Object -Last 1
+        }
+    $b |
+        ForEach-Object {
+            Get-Process |
+                Select-Object -Last 1
+        }
+    $stillCorrect
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+                IdempotentScriptDefinition = @'
+function foo {
+    $a |
+        ForEach-Object {
+            Get-Process |
+                Select-Object -Last 1
+        }
+    $b |
+        ForEach-Object {
+            Get-Process |
+                Select-Object -Last 1
+        }
+    $stillCorrect
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'NoIndentation'
+                IdempotentScriptDefinition = @'
+function foo {
+    $a |
+    ForEach-Object {
+        Get-Process |
+        Select-Object -Last 1
+    }
+    $b |
+    ForEach-Object {
+        Get-Process |
+        Select-Object -Last 1
+    }
+    $stillCorrect
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'None'
+                IdempotentScriptDefinition = @'
+function foo {
+    $a |
+        ForEach-Object {
+        Get-Process |
+                Select-Object -Last 1
+    }
+    $b |
+        ForEach-Object {
+        Get-Process |
+                Select-Object -Last 1
+    }
+    $stillCorrect
+}
+'@
+            }
+        ) {
+            param ($PipelineIndentation, $IdempotentScriptDefinition)
+
+            $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+            Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition -Settings $settings | Should -Be $IdempotentScriptDefinition
+        }
+
+        It "Should handle inner pipeline with 3+ elements using <PipelineIndentation>" -TestCases @(
+            @{
+                PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+                IdempotentScriptDefinition = @'
+$Test |
+    ForEach-Object {
+        Get-Process |
+            Where-Object Path |
+            Select-Object -Last 1
+    }
+'@
+            }
+            @{
+                PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+                IdempotentScriptDefinition = @'
+$Test |
+    ForEach-Object {
+        Get-Process |
+            Where-Object Path |
+                Select-Object -Last 1
+    }
+'@
+            }
+            @{
+                PipelineIndentation = 'NoIndentation'
+                IdempotentScriptDefinition = @'
+$Test |
+ForEach-Object {
+    Get-Process |
+    Where-Object Path |
+    Select-Object -Last 1
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'None'
+                IdempotentScriptDefinition = @'
+$Test |
+    ForEach-Object {
+    Get-Process |
+            Where-Object Path |
+            Select-Object -Last 1
+}
+'@
+            }
+        ) {
+            param ($PipelineIndentation, $IdempotentScriptDefinition)
+
+            $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+            Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition -Settings $settings | Should -Be $IdempotentScriptDefinition
+        }
+
+        It "Should handle outer pipeline on same line as command using <PipelineIndentation>" -TestCases @(
+            @{
+                PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+                IdempotentScriptDefinition = @'
+$Test | ForEach-Object {
+    Get-Process |
+        Select-Object -Last 1
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+                IdempotentScriptDefinition = @'
+$Test | ForEach-Object {
+    Get-Process |
+        Select-Object -Last 1
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'NoIndentation'
+                IdempotentScriptDefinition = @'
+$Test | ForEach-Object {
+    Get-Process |
+    Select-Object -Last 1
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'None'
+                IdempotentScriptDefinition = @'
+$Test | ForEach-Object {
+    Get-Process |
+        Select-Object -Last 1
+}
+'@
+            }
+        ) {
+            param ($PipelineIndentation, $IdempotentScriptDefinition)
+
+            $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+            Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition -Settings $settings | Should -Be $IdempotentScriptDefinition
+        }
+
+        It "Should handle deeply nested pipelines (3 levels) using <PipelineIndentation>" -TestCases @(
+            @{
+                PipelineIndentation = 'IncreaseIndentationForFirstPipeline'
+                IdempotentScriptDefinition = @'
+$a |
+    ForEach-Object {
+        $b |
+            ForEach-Object {
+                Get-Process |
+                    Select-Object -Last 1
+            }
+    }
+'@
+            }
+            @{
+                PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline'
+                IdempotentScriptDefinition = @'
+$a |
+    ForEach-Object {
+        $b |
+            ForEach-Object {
+                Get-Process |
+                    Select-Object -Last 1
+            }
+    }
+'@
+            }
+            @{
+                PipelineIndentation = 'NoIndentation'
+                IdempotentScriptDefinition = @'
+$a |
+ForEach-Object {
+    $b |
+    ForEach-Object {
+        Get-Process |
+        Select-Object -Last 1
+    }
+}
+'@
+            }
+            @{
+                PipelineIndentation = 'None'
+                IdempotentScriptDefinition = @'
+$a |
+    ForEach-Object {
+    $b |
+            ForEach-Object {
+        Get-Process |
+                    Select-Object -Last 1
+    }
+}
+'@
+            }
+        ) {
+            param ($PipelineIndentation, $IdempotentScriptDefinition)
+
+            $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+            Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition -Settings $settings | Should -Be $IdempotentScriptDefinition
+        }
+
+        It "Should handle single-line inner pipeline inside multi-line outer pipeline using <PipelineIndentation>" -TestCases @(
+            @{ PipelineIndentation = 'IncreaseIndentationForFirstPipeline' }
+            @{ PipelineIndentation = 'IncreaseIndentationAfterEveryPipeline' }
+            @{ PipelineIndentation = 'NoIndentation' }
+            @{ PipelineIndentation = 'None' }
+        ) {
+            param ($PipelineIndentation)
+
+            $idempotentScriptDefinition = @'
+$Test | ForEach-Object {
+    Get-Process | Select-Object -Last 1
+}
+'@
+            $settings.Rules.PSUseConsistentIndentation.PipelineIndentation = $PipelineIndentation
+            Invoke-Formatter -ScriptDefinition $IdempotentScriptDefinition -Settings $settings | Should -Be $IdempotentScriptDefinition
+        }
+    }
+
     Context "When tabs instead of spaces are used for indentation" {
         BeforeEach {
             $settings.Rules.PSUseConsistentIndentation.Kind = 'tab'

--- a/Tests/Rules/UseConsistentIndentation.tests.ps1
+++ b/Tests/Rules/UseConsistentIndentation.tests.ps1
@@ -913,6 +913,122 @@ $Test | ForEach-Object {
         }
     }
 
+    Context "When multiple openers appear on the same line" {
+        It "Should not double-indent for paren-then-brace: .foreach({" {
+            $def = @'
+@('a', 'b').foreach({
+        $_.ToUpper()
+    })
+'@
+            $expected = @'
+@('a', 'b').foreach({
+    $_.ToUpper()
+})
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
+        }
+
+        It "Should not double-indent for brace-then-paren: {(" {
+            $def = @'
+@('a', 'b').foreach({(
+        $_.ToUpper()
+    )})
+'@
+            $expected = @'
+@('a', 'b').foreach({(
+    $_.ToUpper()
+)})
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
+        }
+
+        It "Should not double-indent for array-then-hashtable on same line: @(@{" {
+            $idempotentScriptDefinition = @'
+$x = @(@{
+    key = 'value'
+})
+'@
+            Invoke-Formatter -ScriptDefinition $idempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
+        }
+
+        It "Should not double-indent when non-opener tokens separate openers: ([PSCustomObject]@{" {
+            $def = @'
+$list.Add([PSCustomObject]@{
+        Name = "Test"
+        Value = 123
+    })
+'@
+            $expected = @'
+$list.Add([PSCustomObject]@{
+    Name = "Test"
+    Value = 123
+})
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
+        }
+
+        It "Should indent normally when all openers are closed on the same line" {
+            $idempotentScriptDefinition = @'
+$list.Add([PSCustomObject]@{Name = "Test"; Value = 123})
+'@
+            Invoke-Formatter -ScriptDefinition $idempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
+        }
+
+        It "Should handle closing brace and paren on separate lines" {
+            $def = @'
+@('a', 'b').foreach({
+            $_.ToUpper()
+        }
+    )
+'@
+            $expected = @'
+@('a', 'b').foreach({
+    $_.ToUpper()
+}
+)
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
+        }
+
+        It "Should handle nested .foreach({ }) calls" {
+            $def = @'
+@(1, 2).foreach({
+@('a', 'b').foreach({
+"$_ and $_"
+})
+})
+'@
+            $expected = @'
+@(1, 2).foreach({
+    @('a', 'b').foreach({
+        "$_ and $_"
+    })
+})
+'@
+            Invoke-Formatter -ScriptDefinition $def -Settings $settings | Should -Be $expected
+        }
+
+        It "Should still indent each opener separately when on different lines" {
+            $idempotentScriptDefinition = @'
+$x = @(
+    @{
+        key = 'value'
+    }
+)
+'@
+            Invoke-Formatter -ScriptDefinition $idempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
+        }
+
+        It "Should still indent normally for sub-expressions" {
+            $idempotentScriptDefinition = @'
+$(
+    Get-Process
+)
+'@
+            Invoke-Formatter -ScriptDefinition $idempotentScriptDefinition -Settings $settings | Should -Be $idempotentScriptDefinition
+        }
+    }
+
     Context "When tabs instead of spaces are used for indentation" {
         BeforeEach {
             $settings.Rules.PSUseConsistentIndentation.Kind = 'tab'


### PR DESCRIPTION
## PR Summary

- Two small improvements in the `UseConsistentIndentation` rule's handing of pipeline indentation. Flagged in [this issue and issue comment](https://github.com/PowerShell/PSScriptAnalyzer/issues/1933#issuecomment-4025211962).

  1. Rule never finds the ends of nested pipelines, as it had a fast-return when it reached a pipeline who's end position was beyond the current tokens line. It would always find the outer/parent pipeline (which contains the nested pipeline and spans past it) and return early, empty-handed.

      This would lead to some cases of "runaway" indents.

      PR sorts the pipelines, in place, by their end line number and column number. This allows the nested pipeline to be found first (as they end before their parent pipeline).

  2. Rule was using a single counter to keep track of pipeline indentation and then removing it all when it found a pipeline end.

      There were some edge cases that were, even with the first issue resolved, not quite right.

      PR adds in tracking of each pipeline's indentation contribution separately.

- Small improvements in the `UseConsistentIndentation` rule's handling of indentation where opening braces are on the same line. Previously, adjacent openers like `.foreach({`, `@(@{`, or `([PSCustomObject]@{` each incremented the indentation level, producing double or triple indentation. Now only the last unclosed opener on a line affects indentation, fixing common patterns like `.foreach({...})` and `$list.Add([PSCustomObject]@{...})`.

*Copilot generated (and I reviewed) a bunch of tests to cover these cases. It's really getting quite good at generating tests now 🤖*

Fixes #1680
Fixes #1933
Fixes #2159

Potentially also Fixes the main issue raised in #1168

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.