### PR TITLE
Add new MissingTryBlock rule

### DIFF
--- a/Rules/MissingTryBlock.cs
+++ b/Rules/MissingTryBlock.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     public class MissingTryBlock : IScriptRule
     {
         /// <summary>
-        /// Analyzes the PowerShell AST for catch - or finally blocks that misses the try block.
+        /// Analyzes the PowerShell AST for catch or finally blocks that miss the try block.
         /// </summary>
         /// <param name="ast">The PowerShell Abstract Syntax Tree to analyze.</param>
         /// <param name="fileName">The name of the file being analyzed (for diagnostic reporting).</param>

--- a/Rules/MissingTryBlock.cs
+++ b/Rules/MissingTryBlock.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 #endif
 
     /// <summary>
-    /// Rule that warns when reserved words are used as function names
+    /// Rule that warns when catch or finally blocks are used without a corresponding try block
     /// </summary>
     public class MissingTryBlock : IScriptRule
     {
         /// <summary>
-        /// Analyzes the PowerShell AST for uses of reserved words as function names.
+        /// Analyzes the PowerShell AST for catch - or finally blocks that misses the try block.
         /// </summary>
         /// <param name="ast">The PowerShell Abstract Syntax Tree to analyze.</param>
         /// <param name="fileName">The name of the file being analyzed (for diagnostic reporting).</param>
@@ -57,7 +57,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                         CultureInfo.CurrentCulture.TextInfo.ToTitleCase(missingTryAst.Value)),
                     missingTryAst.Extent,
                     GetName(),
-                    DiagnosticSeverity.Error,
+                    DiagnosticSeverity.Warning,
                     fileName,
                     missingTryAst.Value
                 );

--- a/Rules/MissingTryBlock.cs
+++ b/Rules/MissingTryBlock.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Management.Automation.Language;
+
+#if !CORECLR
+using System.ComponentModel.Composition;
+#endif
+
+namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
+{
+#if !CORECLR
+    [Export(typeof(IScriptRule))]
+#endif
+
+    /// <summary>
+    /// Rule that warns when reserved words are used as function names
+    /// </summary>
+    public class MissingTryBlock : IScriptRule
+    {
+        /// <summary>
+        /// Analyzes the PowerShell AST for uses of reserved words as function names.
+        /// </summary>
+        /// <param name="ast">The PowerShell Abstract Syntax Tree to analyze.</param>
+        /// <param name="fileName">The name of the file being analyzed (for diagnostic reporting).</param>
+        /// <returns>A collection of diagnostic records for each violation.</returns>
+        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        {
+            if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
+
+            // Find all FunctionDefinitionAst in the Ast
+            var missingTryAsts = ast.FindAll(testAst =>
+                // Normally should be part of a TryStatementAst
+                testAst is StringConstantExpressionAst stringAst &&
+                // Catch of finally  are reserved keywords and should be bare words
+                stringAst.StringConstantType == StringConstantType.BareWord &&
+                (
+                    String.Equals(stringAst.Value, "catch", StringComparison.OrdinalIgnoreCase) ||
+                    String.Equals(stringAst.Value, "finally", StringComparison.OrdinalIgnoreCase)
+                ) &&
+                stringAst.Parent is CommandAst commandAst &&
+                // Only violate if the catch or finally is the first command element
+                commandAst.CommandElements[0] == stringAst,
+                true
+            );
+
+            foreach (StringConstantExpressionAst missingTryAst in missingTryAsts)
+            {
+                yield return new DiagnosticRecord(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.MissingTryBlockError,
+                        CultureInfo.CurrentCulture.TextInfo.ToTitleCase(missingTryAst.Value)),
+                    missingTryAst.Extent,
+                    GetName(),
+                    DiagnosticSeverity.Error,
+                    fileName,
+                    missingTryAst.Value
+                );
+            }
+        }
+
+        public string GetCommonName() => Strings.MissingTryBlockCommonName;
+
+        public string GetDescription() => Strings.MissingTryBlockDescription;
+
+        public string GetName() => string.Format(
+                CultureInfo.CurrentCulture,
+                Strings.NameSpaceFormat,
+                GetSourceName(),
+                Strings.MissingTryBlockName);
+
+        public RuleSeverity GetSeverity() => RuleSeverity.Warning;
+
+        public string GetSourceName() => Strings.SourceName;
+
+        public SourceType GetSourceType() => SourceType.Builtin;
+    }
+}

--- a/Rules/MissingTryBlock.cs
+++ b/Rules/MissingTryBlock.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             var missingTryAsts = ast.FindAll(testAst =>
                 // Normally should be part of a TryStatementAst
                 testAst is StringConstantExpressionAst stringAst &&
-                // Catch of finally  are reserved keywords and should be bare words
+                // Catch or finally are reserved keywords and should be bare words
                 stringAst.StringConstantType == StringConstantType.BareWord &&
                 (
                     String.Equals(stringAst.Value, "catch", StringComparison.OrdinalIgnoreCase) ||

--- a/Rules/MissingTryBlock.cs
+++ b/Rules/MissingTryBlock.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
-            // Find all FunctionDefinitionAst in the Ast
+            // Find the bare word 'catch' or 'finally' StringConstantExpressionAst nodes used as commands
             var missingTryAsts = ast.FindAll(testAst =>
                 // Normally should be part of a TryStatementAst
                 testAst is StringConstantExpressionAst stringAst &&
-                // Catch or finally are reserved keywords and should be bare words
+                // Check whether "catch" or "finally" are bare words
                 stringAst.StringConstantType == StringConstantType.BareWord &&
                 (
                     String.Equals(stringAst.Value, "catch", StringComparison.OrdinalIgnoreCase) ||

--- a/Rules/MissingTryBlock.cs
+++ b/Rules/MissingTryBlock.cs
@@ -12,9 +12,6 @@ using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
-    /// <summary>
-    /// Find bare word "catch" or "finally" tokens that are not part of a TryStatementAst
-    /// </summary>
 #if !CORECLR
     [Export(typeof(IScriptRule))]
 #endif

--- a/Rules/MissingTryBlock.cs
+++ b/Rules/MissingTryBlock.cs
@@ -1,18 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Management.Automation.Language;
-
 #if !CORECLR
 using System.ComponentModel.Composition;
 #endif
+using System.Globalization;
+using System.Management.Automation.Language;
+using Microsoft.Windows.PowerShell.ScriptAnalyzer.Generic;
 
 namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
 {
+    /// <summary>
+    /// Find bare word "catch" or "finally" tokens that are not part of a TryStatementAst
+    /// </summary>
 #if !CORECLR
     [Export(typeof(IScriptRule))]
 #endif
@@ -20,15 +22,24 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
     /// <summary>
     /// Rule that warns when catch or finally blocks are used without a corresponding try block
     /// </summary>
-    public class MissingTryBlock : IScriptRule
+
+    public class MissingTryBlock : ConfigurableRule
     {
+
         /// <summary>
-        /// Analyzes the PowerShell AST for catch or finally blocks that miss the try block.
+        /// Construct an object of MissingTryBlock type.
         /// </summary>
-        /// <param name="ast">The PowerShell Abstract Syntax Tree to analyze.</param>
-        /// <param name="fileName">The name of the file being analyzed (for diagnostic reporting).</param>
-        /// <returns>A collection of diagnostic records for each violation.</returns>
-        public IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
+        public MissingTryBlock() {
+            Enable = false;
+        }
+
+        /// <summary>
+        /// Find bare word "catch" or "finally" tokens that are not part of a TryStatementAst
+        /// </summary>
+        /// <param name="ast">AST to be analyzed. This should be non-null</param>
+        /// <param name="fileName">Name of file that corresponds to the input AST.</param>
+        /// <returns>A an enumerable type containing the violations</returns>
+        public override IEnumerable<DiagnosticRecord> AnalyzeScript(Ast ast, string fileName)
         {
             if (ast == null) throw new ArgumentNullException(Strings.NullAstErrorMessage);
 
@@ -64,20 +75,66 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
             }
         }
 
-        public string GetCommonName() => Strings.MissingTryBlockCommonName;
+        /// <summary>
+        /// Retrieves the common name of this rule.
+        /// </summary>
+        public override string GetCommonName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.MissingTryBlockCommonName);
+        }
 
-        public string GetDescription() => Strings.MissingTryBlockDescription;
+        /// <summary>
+        /// Retrieves the description of this rule.
+        /// </summary>
+        public override string GetDescription()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.MissingTryBlockDescription);
+        }
 
-        public string GetName() => string.Format(
+        /// <summary>
+        /// Retrieves the name of this rule.
+        /// </summary>
+        public override string GetName()
+        {
+            return string.Format(
                 CultureInfo.CurrentCulture,
                 Strings.NameSpaceFormat,
                 GetSourceName(),
                 Strings.MissingTryBlockName);
+        }
 
-        public RuleSeverity GetSeverity() => RuleSeverity.Warning;
+        /// <summary>
+        /// Retrieves the severity of the rule: error, warning or information.
+        /// </summary>
+        public override RuleSeverity GetSeverity()
+        {
+            return RuleSeverity.Warning;
+        }
 
-        public string GetSourceName() => Strings.SourceName;
+        /// <summary>
+        /// Gets the severity of the returned diagnostic record: error, warning, or information.
+        /// </summary>
+        /// <returns></returns>
+        public DiagnosticSeverity GetDiagnosticSeverity()
+        {
+            return DiagnosticSeverity.Warning;
+        }
 
-        public SourceType GetSourceType() => SourceType.Builtin;
+        /// <summary>
+        /// Retrieves the name of the module/assembly the rule is from.
+        /// </summary>
+        public override string GetSourceName()
+        {
+            return string.Format(CultureInfo.CurrentCulture, Strings.SourceName);
+        }
+
+        /// <summary>
+        /// Retrieves the type of the rule, Builtin, Managed or Module.
+        /// </summary>
+        public override SourceType GetSourceType()
+        {
+            return SourceType.Builtin;
+        }
     }
 }
+

--- a/Rules/MissingTryBlock.cs
+++ b/Rules/MissingTryBlock.cs
@@ -109,15 +109,6 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
         }
 
         /// <summary>
-        /// Gets the severity of the returned diagnostic record: error, warning, or information.
-        /// </summary>
-        /// <returns></returns>
-        public DiagnosticSeverity GetDiagnosticSeverity()
-        {
-            return DiagnosticSeverity.Warning;
-        }
-
-        /// <summary>
         /// Retrieves the name of the module/assembly the rule is from.
         /// </summary>
         public override string GetSourceName()

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -276,6 +276,18 @@
   <data name="MissingModuleManifestFieldCommonName" xml:space="preserve">
     <value>Module Manifest Fields</value>
   </data>
+  <data name="MissingTryBlockName" xml:space="preserve">
+    <value>MissingTryBlock</value>
+  </data>
+  <data name="MissingTryBlockCommonName" xml:space="preserve">
+    <value>Missing try block</value>
+  </data>
+  <data name="MissingTryBlockDescription" xml:space="preserve">
+    <value>The catch and finally blocks should be preceded by a try block.</value>
+  </data>
+  <data name="MissingTryBlockError" xml:space="preserve">
+    <value>{0} is missing a try block</value>
+  </data>
   <data name="AvoidUnloadableModuleDescription" xml:space="preserve">
     <value>If a script file is in a PowerShell module folder, then that folder must be loadable.</value>
   </data>

--- a/Rules/Strings.resx
+++ b/Rules/Strings.resx
@@ -280,7 +280,7 @@
     <value>MissingTryBlock</value>
   </data>
   <data name="MissingTryBlockCommonName" xml:space="preserve">
-    <value>Missing try block</value>
+    <value>Missing Try Block</value>
   </data>
   <data name="MissingTryBlockDescription" xml:space="preserve">
     <value>The catch and finally blocks should be preceded by a try block.</value>

--- a/Tests/Rules/MissingTryBlock.tests.ps1
+++ b/Tests/Rules/MissingTryBlock.tests.ps1
@@ -14,7 +14,7 @@ Describe "MissingTryBlock" {
             $scriptDefinition = { catch { "An error occurred." } }.ToString()
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
             $violations.Count             | Should -Be 1
-            $violations.Severity          | Should -Be Error
+            $violations.Severity          | Should -Be Warning
             $violations.Extent.Text       | Should -Be catch
             $violations.Message           | Should -Be 'Catch is missing a try block'
             $violations.RuleSuppressionID | Should -Be catch
@@ -24,7 +24,7 @@ Describe "MissingTryBlock" {
             $scriptDefinition = { finally { "Finalizing..." } }.ToString()
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
             $violations.Count             | Should -Be 1
-            $violations.Severity          | Should -Be Error
+            $violations.Severity          | Should -Be Warning
             $violations.Extent.Text       | Should -Be finally
             $violations.Message           | Should -Be 'Finally is missing a try block'
             $violations.RuleSuppressionID | Should -Be finally
@@ -36,7 +36,7 @@ Describe "MissingTryBlock" {
             }.ToString()
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
             $violations.Count             | Should -Be 1
-            $violations.Severity          | Should -Be Error
+            $violations.Severity          | Should -Be Warning
             $violations.Extent.Text       | Should -Be catch
             $violations.Message           | Should -Be 'Catch is missing a try block'
             $violations.RuleSuppressionID | Should -Be catch
@@ -49,11 +49,11 @@ Describe "MissingTryBlock" {
             }.ToString()
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
             $violations.Count                | Should -Be 2
-            $violations[0].Severity          | Should -Be Error
+            $violations[0].Severity          | Should -Be Warning
             $violations[0].Extent.Text       | Should -Be catch
             $violations[0].Message           | Should -Be 'Catch is missing a try block'
             $violations[0].RuleSuppressionID | Should -Be catch
-            $violations[1].Severity          | Should -Be Error
+            $violations[1].Severity          | Should -Be Warning
             $violations[1].Extent.Text       | Should -Be finally
             $violations[1].Message           | Should -Be 'Finally is missing a try block'
             $violations[1].RuleSuppressionID | Should -Be finally

--- a/Tests/Rules/MissingTryBlock.tests.ps1
+++ b/Tests/Rules/MissingTryBlock.tests.ps1
@@ -1,0 +1,133 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+[Diagnostics.CodeAnalysis.SuppressMessage('PSUseDeclaredVarsMoreThanAssignments', '', Justification = 'False positive')]
+param()
+
+BeforeAll {
+    $ruleName = "PSMissingTryBlock"
+}
+
+Describe "MissingTryBlock" {
+    Context "Violates" {
+        It "Catch is missing a try block" {
+            $scriptDefinition = { catch { "An error occurred." } }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations.Count             | Should -Be 1
+            $violations.Severity          | Should -Be Error
+            $violations.Extent.Text       | Should -Be catch
+            $violations.Message           | Should -Be 'Catch is missing a try block'
+            $violations.RuleSuppressionID | Should -Be catch
+        }
+
+        It "Finally is missing a try block" {
+            $scriptDefinition = { finally { "Finalizing..." } }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations.Count             | Should -Be 1
+            $violations.Severity          | Should -Be Error
+            $violations.Extent.Text       | Should -Be finally
+            $violations.Message           | Should -Be 'Finally is missing a try block'
+            $violations.RuleSuppressionID | Should -Be finally
+        }
+
+        It "Single line catch and finally is missing a try block" {
+            $scriptDefinition = {
+                catch { "An error occurred." } finally { "Finalizing..." }
+            }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations.Count             | Should -Be 1
+            $violations.Severity          | Should -Be Error
+            $violations.Extent.Text       | Should -Be catch
+            $violations.Message           | Should -Be 'Catch is missing a try block'
+            $violations.RuleSuppressionID | Should -Be catch
+        }
+
+        It "Multi line catch and finally is missing a try block" {
+            $scriptDefinition = {
+                catch { "An error occurred." }
+                finally { "Finalizing..." }
+            }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations.Count                | Should -Be 2
+            $violations[0].Severity          | Should -Be Error
+            $violations[0].Extent.Text       | Should -Be catch
+            $violations[0].Message           | Should -Be 'Catch is missing a try block'
+            $violations[0].RuleSuppressionID | Should -Be catch
+            $violations[1].Severity          | Should -Be Error
+            $violations[1].Extent.Text       | Should -Be finally
+            $violations[1].Message           | Should -Be 'Finally is missing a try block'
+            $violations[1].RuleSuppressionID | Should -Be finally
+        }
+    }
+
+    Context "Compliant" {
+        It "try-catch block" {
+            $scriptDefinition = {
+                try { NonsenseString }
+                catch { "An error occurred." }
+            }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations | Should -BeNullOrEmpty
+        }
+
+        It "try-catch-final statement" {
+            $scriptDefinition = {
+                try { NonsenseString }
+                catch { "An error occurred." }
+                finally { "Finalizing..." }
+            }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations | Should -BeNullOrEmpty
+        }
+
+        It "Single line try statement" {
+            $scriptDefinition = {
+                try { NonsenseString } catch { "An error occurred." } finally { "Finalizing..." }
+            }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations | Should -BeNullOrEmpty
+        }
+
+        It "Catch as parameter" {
+            $scriptDefinition = { Write-Host Catch }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations | Should -BeNullOrEmpty
+        }
+
+        It "Catch as double quoted string" {
+            $scriptDefinition = { "Catch" }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations | Should -BeNullOrEmpty
+        }
+
+        It "Catch as single quoted string" {
+            $scriptDefinition = { 'Catch' }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Suppressed" {
+        It "Multi line catch and finally is missing a try block" {
+            $scriptDefinition = {
+                [Diagnostics.CodeAnalysis.SuppressMessage('PSMissingTryBlock', '', Justification = 'Test')]
+                param()
+                catch { "An error occurred." }
+                finally { "Finalizing..." }
+            }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations | Should -BeNullOrEmpty
+        }
+
+        It "Multi line catch and finally is missing a try block for catch only" {
+            $scriptDefinition = {
+                [Diagnostics.CodeAnalysis.SuppressMessage('PSMissingTryBlock', 'finally', Justification = 'Test')]
+                param()
+                catch { "An error occurred." }
+                finally { "Finalizing..." }
+            }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations.Count | Should -Be 1
+        }
+    }
+}

--- a/Tests/Rules/MissingTryBlock.tests.ps1
+++ b/Tests/Rules/MissingTryBlock.tests.ps1
@@ -148,7 +148,7 @@ Describe "MissingTryBlock" {
             }
         }
 
-        It "ConvertFrom-SecureString -AsPlainText" {
+        It "Doesn't emit a violation" {
             $scriptDefinition = { catch { "An error occurred." } }.ToString()
             $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations | Should -BeNullOrEmpty

--- a/Tests/Rules/MissingTryBlock.tests.ps1
+++ b/Tests/Rules/MissingTryBlock.tests.ps1
@@ -9,10 +9,18 @@ BeforeAll {
 }
 
 Describe "MissingTryBlock" {
+
+    BeforeAll {
+        $Settings = @{
+            IncludeRules = @($ruleName)
+            Rules        = @{ $ruleName = @{ Enable = $true } }
+        }
+    }
+
     Context "Violates" {
         It "Catch is missing a try block" {
             $scriptDefinition = { catch { "An error occurred." } }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations.Count             | Should -Be 1
             $violations.Severity          | Should -Be Warning
             $violations.Extent.Text       | Should -Be catch
@@ -22,7 +30,7 @@ Describe "MissingTryBlock" {
 
         It "Finally is missing a try block" {
             $scriptDefinition = { finally { "Finalizing..." } }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations.Count             | Should -Be 1
             $violations.Severity          | Should -Be Warning
             $violations.Extent.Text       | Should -Be finally
@@ -34,7 +42,7 @@ Describe "MissingTryBlock" {
             $scriptDefinition = {
                 catch { "An error occurred." } finally { "Finalizing..." }
             }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations.Count             | Should -Be 1
             $violations.Severity          | Should -Be Warning
             $violations.Extent.Text       | Should -Be catch
@@ -47,7 +55,7 @@ Describe "MissingTryBlock" {
                 catch { "An error occurred." }
                 finally { "Finalizing..." }
             }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations.Count                | Should -Be 2
             $violations[0].Severity          | Should -Be Warning
             $violations[0].Extent.Text       | Should -Be catch
@@ -66,7 +74,7 @@ Describe "MissingTryBlock" {
                 try { NonsenseString }
                 catch { "An error occurred." }
             }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations | Should -BeNullOrEmpty
         }
 
@@ -76,7 +84,7 @@ Describe "MissingTryBlock" {
                 catch { "An error occurred." }
                 finally { "Finalizing..." }
             }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations | Should -BeNullOrEmpty
         }
 
@@ -84,25 +92,25 @@ Describe "MissingTryBlock" {
             $scriptDefinition = {
                 try { NonsenseString } catch { "An error occurred." } finally { "Finalizing..." }
             }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations | Should -BeNullOrEmpty
         }
 
         It "Catch as parameter" {
             $scriptDefinition = { Write-Host Catch }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations | Should -BeNullOrEmpty
         }
 
         It "Catch as double quoted string" {
             $scriptDefinition = { "Catch" }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations | Should -BeNullOrEmpty
         }
 
         It "Catch as single quoted string" {
             $scriptDefinition = { 'Catch' }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations | Should -BeNullOrEmpty
         }
     }
@@ -115,7 +123,7 @@ Describe "MissingTryBlock" {
                 catch { "An error occurred." }
                 finally { "Finalizing..." }
             }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations | Should -BeNullOrEmpty
         }
 
@@ -126,8 +134,25 @@ Describe "MissingTryBlock" {
                 catch { "An error occurred." }
                 finally { "Finalizing..." }
             }.ToString()
-            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -IncludeRule @($ruleName)
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
             $violations.Count | Should -Be 1
         }
     }
+
+    Context "Disabled" {
+
+        BeforeAll {
+            $Settings = @{
+                IncludeRules = @($ruleName)
+                Rules        = @{ $ruleName = @{ Enable = $false } }
+            }
+        }
+
+        It "ConvertFrom-SecureString -AsPlainText" {
+            $scriptDefinition = { catch { "An error occurred." } }.ToString()
+            $violations = Invoke-ScriptAnalyzer -ScriptDefinition $scriptDefinition -Settings $Settings
+            $violations | Should -BeNullOrEmpty
+        }
+    }
+
 }

--- a/docs/Rules/MissingTryBlock.md
+++ b/docs/Rules/MissingTryBlock.md
@@ -11,8 +11,8 @@ title: MissingTryBlock
 ## Description
 
 The `catch` and `finally` blocks should be preceded by a `try` block.
-Otherwise, the `catch` and `finally` blocks will be interpreted as commands, which is likely a mistake and result
-in a "*The term 'catch' is not recognized as a name of a cmdlet*" error at runtime.
+Otherwise, the `catch` and `finally` blocks will be interpreted as commands, which is likely a mistake and
+will result in a "*The term 'catch' is not recognized as a name of a cmdlet*" error at runtime.
 
 ## How
 

--- a/docs/Rules/MissingTryBlock.md
+++ b/docs/Rules/MissingTryBlock.md
@@ -1,0 +1,34 @@
+---
+description: Missing Try Block
+ms.date: 04/22/2026
+ms.topic: reference
+title: MissingTryBlock
+---
+# MissingTryBlock
+
+**Severity Level: Error**
+
+## Description
+
+The `catch` and `finally` blocks should be preceded by a `try` block.
+Otherwise, the `catch` and `finally` blocks will be interpreted as commands, which is likely a mistake and result
+in a "*The term 'catch' is not recognized as a name of a cmdlet*" error at runtime.
+
+## How
+
+Add a `try` block before the `catch` and `finally` blocks.
+
+## Example
+
+### Wrong
+
+```powershell
+catch { "An error occurred." }
+```
+
+### Correct
+
+```powershell
+try { $a = 1 / $b }
+catch { "Attempted to divide by zero." }
+```

--- a/docs/Rules/MissingTryBlock.md
+++ b/docs/Rules/MissingTryBlock.md
@@ -6,7 +6,7 @@ title: MissingTryBlock
 ---
 # MissingTryBlock
 
-**Severity Level: Error**
+**Severity Level: Warning**
 
 ## Description
 

--- a/docs/Rules/MissingTryBlock.md
+++ b/docs/Rules/MissingTryBlock.md
@@ -50,7 +50,7 @@ catch { "Attempted to divide by zero." }
 
 ```powershell
 Rules = @{
-    PSAvoidExclaimOperator  = @{
+    PSMissingTryBlock = @{
         Enable = $true
     }
 }

--- a/docs/Rules/MissingTryBlock.md
+++ b/docs/Rules/MissingTryBlock.md
@@ -10,9 +10,13 @@ title: MissingTryBlock
 
 ## Description
 
-The `catch` and `finally` blocks should be preceded by a `try` block.
-Otherwise, the `catch` and `finally` blocks will be interpreted as commands, which is likely a mistake and
-will result in a "*The term 'catch' is not recognized as a name of a cmdlet*" error at runtime.
+The `catch` and `finally` blocks must be preceded by a `try` block. Without a `try` block, the
+`catch` and `finally` are interpreted as commands and result in a runtime error, such as:
+
+> "The term 'catch' is not recognized as a name of a cmdlet"
+
+This rule identifies instances where `catch` or `finally` blocks are present with out an associated
+`try` block.
 
 ## How
 

--- a/docs/Rules/MissingTryBlock.md
+++ b/docs/Rules/MissingTryBlock.md
@@ -18,9 +18,18 @@ The `catch` and `finally` blocks must be preceded by a `try` block. Without a `t
 This rule identifies instances where `catch` or `finally` blocks are present with out an associated
 `try` block.
 
+> [!NOTE]
+> This rule is not enabled by default. The user needs to enable it through settings.
+
 ## How
 
 Add a `try` block before the `catch` and `finally` blocks.
+
+> [!NOTE]
+> This rule could result in a false positive as it will fire on user code that violates the rule
+> [AvoidReservedWordsAsFunctionNames][1] for functions named `catch` or `finally`:
+> If you have functions named `catch` or `finally`, you can either rename the function or disable
+> this rule.
 
 ## Example
 
@@ -36,3 +45,21 @@ catch { "An error occurred." }
 try { $a = 1 / $b }
 catch { "Attempted to divide by zero." }
 ```
+
+## Configuration
+
+```powershell
+Rules = @{
+    PSAvoidExclaimOperator  = @{
+        Enable = $true
+    }
+}
+```
+
+### Parameters
+
+- `Enable`: **bool** (Default value is `$false`)
+
+  Enable or disable the rule during ScriptAnalyzer invocation.
+
+[1]: AvoidReservedWordsAsFunctionNames.md "Avoid using reserved words as function names."

--- a/docs/Rules/README.md
+++ b/docs/Rules/README.md
@@ -50,6 +50,7 @@ The PSScriptAnalyzer contains the following rule definitions.
 | [DSCUseVerboseMessageInDSCResource](./DSCUseVerboseMessageInDSCResource.md)                       | Error       |        Yes         |                 |
 | [MisleadingBacktick](./MisleadingBacktick.md)                                                     | Warning     |        Yes         |                 |
 | [MissingModuleManifestField](./MissingModuleManifestField.md)                                     | Warning     |        Yes         |                 |
+| [MissingTryBlock](./MissingTryBlock.md)                                                           | Error       |        Yes         |                 |
 | [PlaceCloseBrace](./PlaceCloseBrace.md)                                                           | Warning     |         No         |       Yes       |
 | [PlaceOpenBrace](./PlaceOpenBrace.md)                                                             | Warning     |         No         |       Yes       |
 | [PossibleIncorrectComparisonWithNull](./PossibleIncorrectComparisonWithNull.md)                   | Warning     |        Yes         |                 |

--- a/docs/Rules/README.md
+++ b/docs/Rules/README.md
@@ -50,7 +50,7 @@ The PSScriptAnalyzer contains the following rule definitions.
 | [DSCUseVerboseMessageInDSCResource](./DSCUseVerboseMessageInDSCResource.md)                       | Error       |        Yes         |                 |
 | [MisleadingBacktick](./MisleadingBacktick.md)                                                     | Warning     |        Yes         |                 |
 | [MissingModuleManifestField](./MissingModuleManifestField.md)                                     | Warning     |        Yes         |                 |
-| [MissingTryBlock](./MissingTryBlock.md)                                                           | Error       |        Yes         |                 |
+| [MissingTryBlock](./MissingTryBlock.md)                                                           | Warning     |        Yes         |                 |
 | [PlaceCloseBrace](./PlaceCloseBrace.md)                                                           | Warning     |         No         |       Yes       |
 | [PlaceOpenBrace](./PlaceOpenBrace.md)                                                             | Warning     |         No         |       Yes       |
 | [PossibleIncorrectComparisonWithNull](./PossibleIncorrectComparisonWithNull.md)                   | Warning     |        Yes         |                 |

--- a/docs/Rules/README.md
+++ b/docs/Rules/README.md
@@ -50,7 +50,7 @@ The PSScriptAnalyzer contains the following rule definitions.
 | [DSCUseVerboseMessageInDSCResource](./DSCUseVerboseMessageInDSCResource.md)                       | Error       |        Yes         |                 |
 | [MisleadingBacktick](./MisleadingBacktick.md)                                                     | Warning     |        Yes         |                 |
 | [MissingModuleManifestField](./MissingModuleManifestField.md)                                     | Warning     |        Yes         |                 |
-| [MissingTryBlock](./MissingTryBlock.md)                                                           | Warning     |        Yes         |                 |
+| [MissingTryBlock](./MissingTryBlock.md)                                                           | Warning     |         No         |       Yes       |
 | [PlaceCloseBrace](./PlaceCloseBrace.md)                                                           | Warning     |         No         |       Yes       |
 | [PlaceOpenBrace](./PlaceOpenBrace.md)                                                             | Warning     |         No         |       Yes       |
 | [PossibleIncorrectComparisonWithNull](./PossibleIncorrectComparisonWithNull.md)                   | Warning     |        Yes         |                 |


### PR DESCRIPTION
## PR Summary

<!-- summarize your PR between here and the checklist -->

Although #2098 didn't get an <kbd>up-for-graps</kbd> label, I did create the suggested **Add new MissingTryBlock rule** to warn when catch or finally blocks are not preceded by a try block because:
* I think that a `catch` block that misses a `try` block is less valid than a `try` block that misses a `catch` block which causes an parse error by the engine
  * and therefore even deserves the severity **Error** 
* A missing `try` block might easily get unnoticed during design time but will very likely fail during runtime
* It happened twice now that someone in our company tried to publish a script that was missing a `try` block

Closes https://github.com/PowerShell/PSScriptAnalyzer/issues/1700 and Fixes https://github.com/PowerShell/PSScriptAnalyzer/issues/2098

## PR Checklist

- [X] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [X] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [X] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [X] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [X] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.