### PR TITLE
[DO NOT MERGE] Pester 6.0.0 release candidate update

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test Windows PowerShell
         if: matrix.os == 'windows-latest'
         run: |
-           Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck
+           Install-Module Pester -RequiredVersion 6.0.0-rc1 -AllowPrerelease -Scope CurrentUser -Force -SkipPublisherCheck
            ./build.ps1 -Test -Verbose
         shell: powershell
 

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test Windows PowerShell
         if: matrix.os == 'windows-latest'
         run: |
-           Install-Module Pester -RequiredVersion 6.0.0-rc1 -AllowPrerelease -Scope CurrentUser -Force -SkipPublisherCheck
+           Install-Module Pester -RequiredVersion 6.0.0-rc4 -AllowPrerelease -Scope CurrentUser -Force -SkipPublisherCheck
            ./build.ps1 -Test -Verbose
         shell: powershell
 

--- a/tools/installPSResources.ps1
+++ b/tools/installPSResources.ps1
@@ -18,7 +18,8 @@ Install-PSResource -Verbose -TrustRepository -RequiredResource  @{
         repository = $PSRepository
     }
     Pester = @{
-        version = "5.7.1"
+        version = "6.0.0-rc1"
+        prerelease = $true
         repository = $PSRepository
     }
 }

--- a/tools/installPSResources.ps1
+++ b/tools/installPSResources.ps1
@@ -18,7 +18,7 @@ Install-PSResource -Verbose -TrustRepository -RequiredResource  @{
         repository = $PSRepository
     }
     Pester = @{
-        version = "6.0.0-rc1"
+        version = "6.0.0-rc4"
         prerelease = $true
         repository = $PSRepository
     }


### PR DESCRIPTION
Hi — Pester 6.0.0 is almost ready, and before I release it I'm trying it out
against real-world Pester v5 test suites.

This PR updates Pester to the 6.0.0 release candidate and makes the changes
needed for your tests to run on it. I opened it to learn two things:

- whether migrating from v5 to v6 is straightforward, and
- where v6 breaks or behaves differently, so I can fix those things before the
  final release instead of after.

You don't need to merge this, and I'd suggest you don't — it's only meant to
show what a v6 update would involve and to give me feedback. Please leave it
open, though: if more release candidates come out I'll push those updates here
too, and I'll close it myself afterwards.

This PR was co-authored by GitHub Copilot. If you'd rather not receive
AI-assisted PRs, just close it and I won't open one for the next release.

Thanks for the CI time this run used, and for maintaining a suite I could test
against.

— Jakub & Copilot
