### PR TITLE
Add missing Severity entry for `Invoke-ScriptAnalyzer` docs

### DIFF
--- a/docs/Cmdlets/Invoke-ScriptAnalyzer.md
+++ b/docs/Cmdlets/Invoke-ScriptAnalyzer.md
@@ -536,7 +536,8 @@ Valid values are:
 
 - Error
 - Warning
-- Information.
+- Information
+- ParseError
 
 You can specify one ore more severity values.
 

--- a/docs/Cmdlets/Invoke-ScriptAnalyzer.md
+++ b/docs/Cmdlets/Invoke-ScriptAnalyzer.md
@@ -539,7 +539,7 @@ Valid values are:
 - Information
 - ParseError
 
-You can specify one ore more severity values.
+You can specify one or more severity values.
 
 The parameter filters the rules violations only after running all rules. To filter rules
 efficiently, use `Get-ScriptAnalyzerRule` to select the rules you want to run.


### PR DESCRIPTION
## PR Summary

The `-Severity` parameter of the `Invoke-ScriptAnalyzer` command has 4 allowed values.

https://github.com/PowerShell/PSScriptAnalyzer/blob/4b0117ca7d2887711c9699f467ba7171f8859156/Engine/Commands/InvokeScriptAnalyzerCommand.cs#L148-L159

The docs are missing `ParseError` as an allowed value.

Fixes #2192

Does not conflict with #2190

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.