### PR TITLE
Upgrade Pester to version 6

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test Windows PowerShell
         if: matrix.os == 'windows-latest'
         run: |
-           Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck
+           Install-Module Pester -RequiredVersion 6.0.1 -Scope CurrentUser -Force -SkipPublisherCheck
            ./build.ps1 -Test -Verbose
         shell: powershell
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To install **PSScriptAnalyzer** from source code:
 - If building for Windows PowerShell versions, then the .NET Framework 4.6.2 [targeting pack](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net462) (also referred to as developer/targeting pack) need to be installed. This is only possible on Windows.
 - Optional but recommended for development: [Visual Studio 2022](https://www.visualstudio.com/downloads)
 - Or [Visual Studio Code](https://code.visualstudio.com/download)
-- [Pester v5 PowerShell module, available on PowerShell Gallery](https://github.com/pester/Pester)
+- [Pester v6 PowerShell module, available on PowerShell Gallery](https://github.com/pester/Pester)
 - [PlatyPS PowerShell module, available on PowerShell Gallery](https://github.com/PowerShell/platyPS/releases)
 
 ### Steps
@@ -154,7 +154,7 @@ built-in rules.
 
 Pester-based ScriptAnalyzer Tests are located in `path/to/PSScriptAnalyzer/Tests` folder.
 
-- Ensure [Pester](https://www.powershellgallery.com/packages/Pester) of at least version 5.3 is installed
+- Ensure [Pester](https://www.powershellgallery.com/packages/Pester) of at least version 6.0 is installed
 - In the root folder of your local repository, run:
 
 ```powershell

--- a/Tests/Rules/UseIdenticalMandatoryParametersForDSC.tests.ps1
+++ b/Tests/Rules/UseIdenticalMandatoryParametersForDSC.tests.ps1
@@ -32,7 +32,7 @@ Describe "UseIdenticalMandatoryParametersForDSC" {
         }
 
         # todo add a test to check one violation per function
-        It "Should find a violations" -pending {
+        It "Should find a violations" -Skip {
             $violations.Count | Should -Be 0
         }
     }

--- a/Tests/Rules/UseToExportFieldsInManifest.tests.ps1
+++ b/Tests/Rules/UseToExportFieldsInManifest.tests.ps1
@@ -87,7 +87,7 @@ Describe "UseManifestExportFields" {
             $results[0].Extent.Text | Should -Be "'*'"
         }
 
-        It "suggests corrections for AliasesToExport with wildcard" -pending:($IsCoreClr) {
+        It "suggests corrections for AliasesToExport with wildcard" -Skip:($IsCoreClr) {
             $violations = Run-PSScriptAnalyzerRule $testManifestBadAliasesWildcardPath
             $violationFilepath = Join-path $testManifestPath $testManifestBadAliasesWildcardPath
             Test-CorrectionExtent $violationFilepath $violations[0] 1  "'*'" "@('gbar', 'gfoo')"

--- a/tools/installPSResources.ps1
+++ b/tools/installPSResources.ps1
@@ -18,7 +18,7 @@ Install-PSResource -Verbose -TrustRepository -RequiredResource  @{
         repository = $PSRepository
     }
     Pester = @{
-        version = "5.7.1"
+        version = "6.0.1"
         repository = $PSRepository
     }
 }


### PR DESCRIPTION
## PR Summary

Windows PowerShell CI tests [were not pinned to a Pester version](https://github.com/PowerShell/PSScriptAnalyzer/blob/4b0117ca7d2887711c9699f467ba7171f8859156/.github/workflows/ci-test.yml#L46-L51) and so used the latest stable. This changed recently to v6 (well done on the release @nohwnd 🎉).

Windows PowerShell CI was broken - complaining of a missing `-Pending` parameter, which has been removed in v6.

Instead of just pinning the Windows PowerShell version to 5.7.1, the changes required for v6 compatibility were minimal, so those changes were made instead.

Claude and I used [the v5-v6 migration guide and skill](https://pester.dev/docs/migrations/v5-to-v6) to update to v6.

I've now pinned the Windows PowerShell version in line with the `tools/installPSResources.ps1` version - settling on the current `6.0.1`. I Can't find a tidy way to specify the version once and have it used in both places. Open to suggestions if there's a good way.

> Note: This does not do the `Should -Be` to `Should-Be` migration that is optional for this version change and [documented here](https://pester.dev/docs/assertions/should-command).

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.