### PR TITLE
Include file path in AlignAssignmentStatement corrections

### DIFF
--- a/Rules/AlignAssignmentStatement.cs
+++ b/Rules/AlignAssignmentStatement.cs
@@ -650,6 +650,7 @@ namespace Microsoft.Windows.PowerShell.ScriptAnalyzer.BuiltinRules
                     lhsExtent.EndColumnNumber,
                     equalsExtent.StartColumnNumber,
                     new string(' ', targetColumn - lhsExtent.EndColumnNumber),
+                    lhsExtent.File,
                     string.Format(CultureInfo.CurrentCulture, Strings.AlignAssignmentStatementError)
                 )
             };

--- a/Tests/Rules/AlignAssignmentStatement.tests.ps1
+++ b/Tests/Rules/AlignAssignmentStatement.tests.ps1
@@ -126,6 +126,21 @@ Configuration C1 {
 
     Context 'When Hashtable checking is enabled' {
 
+        It 'Should set correction file and description when analyzing a file' {
+            $path = Join-Path -Path $TestDrive -ChildPath 'unaligned.ps1'
+            Set-Content -LiteralPath $path -Value '@{"Key"    = "Value"}'
+
+            $settings = New-AlignAssignmentSettings -CheckHashtable $true
+
+            $violations = Invoke-ScriptAnalyzer -Path $path -Settings $settings |
+                Get-NonParseDiagnostics
+
+            $violations | Should -HaveCount 1
+            $correction = $violations[0].SuggestedCorrections[0]
+            $correction.File | Should -Be ([IO.Path]::GetFullPath($path))
+            $correction.Description | Should -Be 'Assignment statements are not aligned'
+        }
+
         It 'Should not find violations in empty single-line hashtable' {
             $def = '@{}'
 


### PR DESCRIPTION
- Fixes #2201

## PR Summary

This PR adds a missing argument for the CorrectionExtent constructor in the AlignAssignmentStatement rule definition.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Change is not breaking](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)
- [x] [Make sure all `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] Make sure you've added a new test if existing tests do not effectively test the code changed and/or updated documentation
- [x] This PR is ready to merge and is not [Work in Progress](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---work-in-progress).
    - If the PR is work in progress, please add the prefix `WIP:` to the beginning of the title and remove the prefix when the PR is ready.